### PR TITLE
feat: 完善一键开发 dry-run 与自举验证

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # clickvibe
 
-DSH web 插件:右侧面板输入 GitHub issue / PR 链接,通过本地 `gh` CLI 抓取并以 Markdown 渲染展示。
+DSH web 插件:右侧面板输入 GitHub issue / PR 链接,通过本地 `gh` CLI 抓取并以 Markdown 渲染展示；对 open issue 可创建独立 worktree 并启动 Codex/Claude 开发。
 
 ## 功能
 
@@ -13,12 +13,19 @@ DSH web 插件:右侧面板输入 GitHub issue / PR 链接,通过本地 `gh` CLI
   - PR 额外:分支 `base ← head`、变更统计、提交数、合并状态
   - 正文与评论:轻量 Markdown 渲染器(标题/粗斜体/代码块/列表/引用/链接),评论默认展开
   - 整块内容区一个滚动条(GitHub 风格)
+- Open issue 一键开发:
+  - `Codex 开发` / `Claude 开发`:在 issue worktree 中启动非交互 agent
+  - `安全演练`:走完整 worktree/任务/轮询链路,只执行 `pwd`、当前分支和 `git status`
+  - 日志按完整行、cursor 增量轮询；内存最多保留 2000 行,超出时明确提示截断
+  - 已有正确 worktree/分支会复用；缺分支、缺 worktree 或 detached 等半完成状态会安全恢复
+  - 冲突分支或未注册的非空目录不会被覆盖
 
 ## 架构
 
 | 半侧 | 文件 | 职责 |
 |---|---|---|
-| Host | `src/index.ts` | 注册 `/clickvibe/api` 前缀路由,POST `/fetch` 调 `gh`,返回 `{ ok, data }` 信封 |
+| Host | `src/index.ts` | 注册 `/clickvibe/api` 前缀路由,处理 GitHub 抓取、开发任务和 cursor 日志轮询 |
+| 开发内核 | `src/develop.ts` | agent/URL 校验、shell 参数转义、有界行日志和 worktree 恢复决策 |
 | Client | `src/client/index.tsx` | `shell.overlay` 右侧面板 + `sidebar.footer.action` 开关按钮,`fetch('/clickvibe/api/fetch')` 取数 |
 | 构建 | `tsdown.config.ts` | host → `lib/index.js`(ESM),client → `lib/client.js`(CJS 闭包,`window.__ModuleLoader__.load` 注册) |
 
@@ -29,8 +36,22 @@ Client→Host 走 **HTTP API 路由**(正式插件没有动态插件的 `harness
 ```sh
 pnpm install
 pnpm run build     # tsc 声明 + tsdown 双 bundle
+pnpm test          # Host 纯逻辑回归测试
 pnpm run watch     # client 热更新
 ```
+
+## 一键开发配置
+
+配置文件固定为 `~/.clickvibe/config.yaml`：
+
+```yaml
+repos:
+  ai-daming/clickvibe: /Users/me/work/clickvibe
+
+worktreeRoot: ~/.clickvibe/worktrees
+```
+
+仓库按 `owner/repo` 精确匹配。目标路径为 `<worktreeRoot>/<仓库目录名>/<仓库目录名>-issue-<N>`，分支名为 `<仓库目录名>-issue-<N>`。
 
 ## 安装到 profile
 
@@ -51,4 +72,16 @@ curl -X POST http://127.0.0.1:3080/clickvibe/api/fetch \
 
 # client bundle
 curl http://127.0.0.1:3080/plugins/clickvibe/client.js
+
+# 启动无代码副作用的 dry-run
+curl -X POST http://127.0.0.1:3080/clickvibe/api/develop \
+  -H 'content-type: application/json' \
+  -d '{"url":"https://github.com/ai-daming/clickvibe/issues/1","agent":"dryrun"}'
+
+# 用启动响应中的 taskId 和 poll 响应中的 cursor 增量轮询
+curl -X POST http://127.0.0.1:3080/clickvibe/api/develop/poll \
+  -H 'content-type: application/json' \
+  -d '{"taskId":"dev-...","cursor":0}'
 ```
+
+任务状态只保存在当前 Host 进程内,重启后旧 `taskId` 失效。真实 agent 会执行 Issue 内容并可能修改代码、commit、push 或创建 PR；只应对可信仓库和可信 Issue 主动点击运行。`dryrun` 不启动 agent,适合先验证配置与 worktree 恢复。

--- a/docs/plans/2026-08-21-dry-run-self-host-design.md
+++ b/docs/plans/2026-08-21-dry-run-self-host-design.md
@@ -1,0 +1,28 @@
+# Dry-run 与自举验证设计
+
+## 目标与边界
+
+ClickVibe 的正式插件目前只有 GitHub Issue/PR 查看能力；一键开发仅存在于主 checkout 的未提交原型中。本次把该能力正式落入仓库，并完成 Issue #1 要求的 dry-run、增量日志和 worktree 恢复。
+
+范围包括 `POST /clickvibe/api/develop`、`POST /clickvibe/api/develop/poll`、Issue 面板的一键开发区、`~/.clickvibe/config.yaml` 仓库映射，以及可重复验证的 Host 单元测试。不引入持久任务数据库、SSE、停止按钮、任务过期清理或自动合并；这些都不是 Issue #1 的验收项。
+
+## 架构与数据流
+
+Host 使用进程内任务表。`develop` 校验 GitHub Issue URL、agent 枚举和仓库映射后立即创建任务并返回 `taskId`；后台流程恢复或创建 issue worktree，再抓取 Issue 内容。`dryrun` 与真实 agent 共用同一 worktree 流程，但只执行 `pwd`、当前分支和 `git status --short --branch`，不启动 Codex/Claude，也不写代码。
+
+每个任务维护带单调序号的有界日志行。后台以短间隔读取 shell 增量输出，把任意 chunk 拼接成完整行；任务结束时刷新最后一个不带换行的残片。轮询方传入 `cursor`，Host 返回其后的行、新 cursor、状态和 `truncated`。若调用方 cursor 已落后于已淘汰日志，响应首行给出明确截断提示。这样刷新、重试和多个轮询方不会互相消费日志。
+
+## Worktree 恢复
+
+恢复前分别探测分支 ref、目标路径和 Git worktree 注册表：
+
+- 路径未注册：分支存在则从已有分支添加 worktree，分支不存在则从当前主仓库 HEAD 新建分支并添加。
+- 路径已注册且分支正确：直接复用。
+- 路径已注册但处于 detached HEAD，且目标分支不存在：在该 worktree 内创建目标分支。
+- 路径已注册到其他分支、同一分支已被其他 worktree 占用，或路径是非空的普通目录：失败关闭并输出可操作错误，不自动删除用户数据。
+
+所有 shell 参数使用 POSIX 单引号转义；worktree 创建需要修改主仓库 `.git`，沿用 DSH shell 的 `danger-full-access` 策略，并把 workspace root 限定为配置的仓库路径。
+
+## 错误处理与验证
+
+非法 agent 不得静默回退为 Codex。后台异常统一将任务置为 `failed` 并进入日志；UI 遇到轮询异常也停止定时器并展示错误。单元测试覆盖 URL/agent 解析、行缓冲 cursor 与截断、worktree 状态决策和 shell 转义。集成验收依次运行 typecheck/build/test、真实 HTTP dry-run、面板日志观察，并以当前 Issue #1 worktree 的最终 commit/push/PR 作为 Codex 自举证据。

--- a/docs/plans/2026-08-21-dry-run-self-host.md
+++ b/docs/plans/2026-08-21-dry-run-self-host.md
@@ -1,0 +1,67 @@
+# Dry-run and Self-host Development Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a safe dry-run development path, recoverable issue worktrees, cursor-based line logs, and live panel polling to ClickVibe.
+
+**Architecture:** Keep development tasks in Host memory and isolate pure validation, log-buffer, and worktree-decision logic for tests. The HTTP layer starts background shell processes while the Client polls immutable cursor ranges, so retries and multiple readers cannot consume each other's logs.
+
+**Tech Stack:** TypeScript, React 18, Cordis/DSH shell service, Node test runner through Vitest, GitHub CLI, Git worktrees.
+
+---
+
+### Task 1: Pure task and worktree primitives
+
+**Files:**
+- Create: `src/develop.ts`
+- Create: `tests/develop.test.ts`
+- Modify: `package.json`
+
+1. Add failing tests for strict `codex | claude | dryrun` parsing, POSIX shell quoting, chunk-to-line buffering, cursor polling, truncation, and worktree-state decisions.
+2. Run `pnpm test` and confirm the missing module/tests fail.
+3. Implement the smallest pure types and functions that satisfy those cases.
+4. Run `pnpm test` and confirm the primitive suite passes.
+
+### Task 2: Host develop and poll API
+
+**Files:**
+- Modify: `src/index.ts`
+- Modify: `tests/develop.test.ts`
+
+1. Add tests for task startup/dry-run command selection and recovery command plans through exported pure seams.
+2. Extend the Cordis shell declaration with background process support and bounded output.
+3. Add config loading, repository validation, idempotent worktree recovery, Issue prompt construction, task lifecycle, periodic output draining, and cursor-based polling.
+4. Register `develop` and `develop/poll` routes and reject unknown agents instead of falling back.
+5. Run `pnpm test` and `pnpm run typecheck`.
+
+### Task 3: Live panel logs
+
+**Files:**
+- Modify: `src/client/index.tsx`
+
+1. Add the one-click development panel for open Issues.
+2. Poll with the returned cursor, append only new lines, keep the log scrolled to the latest output, and stop cleanly on done/failed or API errors.
+3. Render worktree/branch, terminal state, failures, and truncation hints without claiming success for failed processes.
+4. Run `pnpm run typecheck` and `pnpm run build`.
+
+### Task 4: Documentation and acceptance
+
+**Files:**
+- Modify: `README.md`
+
+1. Document config, Host APIs, dry-run curl flow, polling cursor, recovery semantics, and safety limits.
+2. Install/link the built plugin in the local DSH profile if necessary and restart the Host.
+3. Trigger dry-run by curl, poll to `done`, and verify `git status` shows no dry-run code changes.
+4. Observe the panel receiving incremental agent lines.
+5. Verify the current `clickvibe-issue-1` worktree/branch and final commit as the self-host Codex run.
+
+### Task 5: Delivery
+
+**Files:**
+- Modify only files listed above.
+
+1. Review `git diff --check`, status, tests, typecheck, and build.
+2. Commit with an Issue-focused message.
+3. Push `clickvibe-issue-1` to `origin`.
+4. Create a PR against `main` with acceptance evidence and `Closes #1`.
+5. Read the PR back and report CI/review/deployment gates separately.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
+  "dependencies": {
+    "yaml": "^2.9.0"
+  },
   "devDependencies": {
     "@deepseek-ai/cordis": "^4.0.0-rc.8",
     "@deepseek-ai/dsh-client-runtime": "0.1.0-rc.8",
@@ -62,6 +65,7 @@
   "scripts": {
     "build": "rm -rf lib && tsc -p tsconfig.build.json && tsdown",
     "bundle": "tsdown",
+    "test": "node --test tests/*.test.ts",
     "watch": "tsdown --watch",
     "typecheck": "tsc --noEmit"
   }

--- a/package.json
+++ b/package.json
@@ -56,11 +56,11 @@
     "@types/node": "^24.0.0",
     "@types/react": "~18.3.1",
     "@types/react-dom": "~18.3.1",
+    "lightningcss": "^1.32.0",
     "react": "^18.2.0",
     "react-dom": "18.2.0",
     "tsdown": "^0.22.2",
-    "typescript": "^5.6.0",
-    "lightningcss": "^1.32.0"
+    "typescript": "^5.6.0"
   },
   "scripts": {
     "build": "rm -rf lib && tsc -p tsconfig.build.json && tsdown",
@@ -68,5 +68,8 @@
     "test": "node --test tests/*.test.ts",
     "watch": "tsdown --watch",
     "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "yaml": "^2.9.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@deepseek-ai/cordis':
         specifier: ^4.0.0-rc.8
@@ -1167,6 +1171,11 @@ packages:
       utf-8-validate:
         optional: true
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yuku-ast@0.8.7:
     resolution: {integrity: sha512-h6+4bDfyootiMB9vckk5uKo5r5j0GHrkr17FQTDNfEsFT3DWlN9uu1HJwQwc64pgmLCI945fWM3lbTIqxjT3GQ==}
 
@@ -2137,6 +2146,8 @@ snapshots:
   verkit@0.3.2: {}
 
   ws@8.21.3: {}
+
+  yaml@2.9.0: {}
 
   yuku-ast@0.8.7:
     dependencies:

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -89,7 +89,9 @@ export function parseCodexEvent(line: string): StatusLine[] {
       const item = event.item ?? {}
       switch (item.type) {
         case 'agent_message':
-          out.push({ kind: 'message', text: `💬 ${oneLine(item.text ?? '')}` })
+          // 结论类消息必须保留完整内容(截断会丢失 review 条目),
+          // 所以消息截断上限远大于工具行
+          out.push({ kind: 'message', text: `💬 ${oneLine(item.text ?? '', 4000)}` })
           break
         case 'function_call': {
           let args = ''

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -158,13 +158,28 @@ export function parseClaudeEvent(line: string): StatusLine[] {
   return out
 }
 
-/** Parse a chunk of agent stdout into status lines (both agents). */
-export function parseAgentChunk(agent: AgentKind, chunk: string): StatusLine[] {
-  const lines = chunk.split('\n').filter((l) => l.trim() !== '')
-  const out: StatusLine[] = []
-  for (const line of lines) {
-    if (agent === 'codex') out.push(...parseCodexEvent(line))
-    else out.push(...parseClaudeEvent(line))
+/** Parse a chunk of agent stdout into status lines + the session id (if seen). */
+export function parseAgentChunk(agent: AgentKind, chunk: string): { lines: StatusLine[]; sessionId: string | null } {
+  const rawLines = chunk.split('\n').filter((l) => l.trim() !== '')
+  const lines: StatusLine[] = []
+  let sessionId: string | null = null
+  for (const line of rawLines) {
+    try {
+      const parsed = JSON.parse(line) as {
+        type?: string
+        thread_id?: string
+        session_id?: string
+        item?: { type?: string; text?: string; name?: string; arguments?: unknown }
+        message?: { content?: { type?: string; text?: string; name?: string; input?: unknown }[] }
+      }
+      // codex: thread_id; claude: session_id
+      const sid = parsed.thread_id ?? parsed.session_id
+      if (sid) sessionId = sid
+    } catch {
+      // 非 JSON 行,跳过
+    }
+    if (agent === 'codex') lines.push(...parseCodexEvent(line))
+    else lines.push(...parseClaudeEvent(line))
   }
-  return out
+  return { lines, sessionId }
 }

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -1,0 +1,168 @@
+/**
+ * clickvibe agent event-stream parser.
+ *
+ * Turns the structured JSON event streams of codex (`exec --json`) and
+ * claude (`--print --verbose --output-format stream-json`) into human
+ * status lines the panel renders like a TUI: the current action, the agent's
+ * message, tool calls, and stage transitions.
+ */
+export type AgentKind = 'codex' | 'claude'
+
+export interface StatusLine {
+  kind: 'stage' | 'tool' | 'message' | 'text'
+  text: string
+}
+
+/** Trim a string to a bounded single line for display. */
+function oneLine(value: string, max = 140): string {
+  const collapsed = value.replace(/\s+/g, ' ').trim()
+  return collapsed.length > max ? `${collapsed.slice(0, max)}…` : collapsed
+}
+
+/** Classify a tool name into a friendly "current action" label. */
+function toolLabel(name: string, args: string): string {
+  const short = oneLine(args, 80)
+  switch (name) {
+    case 'bash':
+    case 'shell':
+    case 'execute_command':
+      return `🔧 执行命令: ${short}`
+    case 'read':
+    case 'read_file':
+    case 'fs.read':
+    case 'View':
+      return `📖 读取文件: ${short}`
+    case 'write':
+    case 'write_file':
+    case 'fs.write':
+    case 'Edit':
+      return `✍️ 修改文件: ${short}`
+    case 'apply_patch':
+    case 'MultiEdit':
+      return `🩹 应用补丁: ${short}`
+    case 'git':
+    case 'git_diff':
+      return `🌿 git: ${short}`
+    case 'gh':
+      return `🐙 gh: ${short}`
+    case 'web_search':
+    case 'WebSearch':
+      return `🔍 搜索: ${short}`
+    case 'web_fetch':
+    case 'WebFetch':
+      return `🌐 抓取网页: ${short}`
+    case 'subagent':
+    case 'task':
+      return `🤖 子代理: ${short}`
+    case 'ask_user_question':
+    case 'AskUserQuestion':
+      return `❓ 提问: ${short}`
+    default:
+      return `🛠️ ${name}: ${short}`
+  }
+}
+
+/** Parse one codex JSON event into optional status lines. */
+export function parseCodexEvent(line: string): StatusLine[] {
+  const out: StatusLine[] = []
+  let event: {
+    type?: string
+    item?: { type?: string; text?: string; name?: string; arguments?: unknown }
+    thread_id?: string
+  }
+  try {
+    event = JSON.parse(line)
+  } catch {
+    return out
+  }
+  switch (event.type) {
+    case 'thread.started':
+      out.push({ kind: 'stage', text: '🚀 会话开始' })
+      break
+    case 'turn.started':
+      out.push({ kind: 'stage', text: '💭 开始一轮思考…' })
+      break
+    case 'turn.completed':
+      out.push({ kind: 'stage', text: '✅ 本轮完成' })
+      break
+    case 'item.completed': {
+      const item = event.item ?? {}
+      switch (item.type) {
+        case 'agent_message':
+          out.push({ kind: 'message', text: `💬 ${oneLine(item.text ?? '')}` })
+          break
+        case 'function_call': {
+          let args = ''
+          if (typeof item.arguments === 'string') args = item.arguments
+          else if (item.arguments && typeof item.arguments === 'object') {
+            try { args = JSON.stringify(item.arguments) } catch { /* ignore */ }
+          }
+          out.push({ kind: 'tool', text: toolLabel(item.name ?? 'tool', args) })
+          break
+        }
+        case 'error':
+          out.push({ kind: 'text', text: `⚠️ ${oneLine(item.text ?? 'error')}` })
+          break
+        default:
+          break
+      }
+      break
+    }
+    default:
+      break
+  }
+  return out
+}
+
+/** Parse one claude stream-json event into optional status lines. */
+export function parseClaudeEvent(line: string): StatusLine[] {
+  const out: StatusLine[] = []
+  let event: {
+    type?: string
+    message?: { content?: { type?: string; text?: string; name?: string; input?: unknown }[] }
+    session_id?: string
+  }
+  try {
+    event = JSON.parse(line)
+  } catch {
+    return out
+  }
+  switch (event.type) {
+    case 'assistant': {
+      for (const block of event.message?.content ?? []) {
+        if (block.type === 'text' && block.text) {
+          out.push({ kind: 'message', text: `💬 ${oneLine(block.text)}` })
+        } else if (block.type === 'tool_use' && block.name) {
+          const args = block.input ? oneLine(JSON.stringify(block.input), 80) : ''
+          out.push({ kind: 'tool', text: toolLabel(block.name, args) })
+        }
+      }
+      break
+    }
+    case 'system': {
+      // system 事件可能含 tool_use 摘要
+      const sub = event.message?.content?.[0]
+      if (sub?.type === 'tool_use' && sub.name) {
+        out.push({ kind: 'tool', text: toolLabel(sub.name, '') })
+      }
+      break
+    }
+    case 'result':
+      out.push({ kind: 'stage', text: '✅ 会话结束' })
+      break
+    default:
+      break
+  }
+  return out
+}
+
+/** Parse a chunk of agent stdout into status lines (both agents). */
+export function parseAgentChunk(agent: AgentKind, chunk: string): StatusLine[] {
+  const lines = chunk.split('\n').filter((l) => l.trim() !== '')
+  const out: StatusLine[] = []
+  for (const line of lines) {
+    if (agent === 'codex') out.push(...parseCodexEvent(line))
+    else out.push(...parseClaudeEvent(line))
+  }
+  return out
+}

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -600,7 +600,11 @@ function DevSection({ url, workflow, onWorkflow }: {
   }
 
   const showDevButtons = stage === 'idle'
-  const showReviewButtons = stage === 'review-ready' && !interrupted && !workflow?.reviewResult
+  const canReview = stage === 'review-ready' && !interrupted && !workflow?.reviewResult
+  // review agent 锁定:上次用什么 review,这次就只显示那个按钮;
+  // 从未 review 过则两个都显示(首次自由选)。
+  const showCodexReview = canReview && (!workflow?.reviewAgent || workflow.reviewAgent === 'codex')
+  const showClaudeReview = canReview && (!workflow?.reviewAgent || workflow.reviewAgent === 'claude')
   const showReworkButtons = stage === 'review-ready' && workflow?.reviewResult?.passed === false
 
   return (
@@ -634,11 +638,11 @@ function DevSection({ url, workflow, onWorkflow }: {
             <button className="cv-dev-btn cv-dev-claude" onClick={() => startDev('claude')} disabled={busy !== null}>Claude 开发</button>
           </>
         ) : null}
-        {showReviewButtons ? (
-          <>
-            <button className="cv-dev-btn cv-dev-review" onClick={() => startReview('codex')} disabled={busy !== null}>Codex Review</button>
-            <button className="cv-dev-btn cv-dev-review" onClick={() => startReview('claude')} disabled={busy !== null}>Claude Review</button>
-          </>
+        {showCodexReview ? (
+          <button className="cv-dev-btn cv-dev-review" onClick={() => startReview('codex')} disabled={busy !== null}>Codex Review</button>
+        ) : null}
+        {showClaudeReview ? (
+          <button className="cv-dev-btn cv-dev-review" onClick={() => startReview('claude')} disabled={busy !== null}>Claude Review</button>
         ) : null}
         {workflow?.reviewResult && !workflow.reviewResult.passed ? (
           <button

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -100,16 +100,15 @@ const PANEL_CSS = `
 .cv-md-hr { border: none; border-top: 1px solid #d0d7de; margin: 10px 0; }
 .cv-dev { border: 1px solid #d0d7de; border-radius: 6px; padding: 8px 10px; display: flex; flex-direction: column; gap: 6px; }
 .cv-dev-head { font-weight: 600; font-size: 12.5px; color: #1f2328; }
-.cv-dev-actions { display: flex; flex-wrap: wrap; gap: 6px; }
-.cv-dev-btn { padding: 5px 10px; border: none; border-radius: 6px; cursor: pointer; font-size: 12px; font-weight: 600; color: #ffffff; }
-.cv-dev-btn:disabled { cursor: default; opacity: 0.6; }
+.cv-dev-actions { display: flex; gap: 6px; }
+.cv-dev-btn { padding: 5px 12px; border: none; border-radius: 6px; cursor: pointer; font-size: 12px; font-weight: 600; color: #ffffff; }
 .cv-dev-codex { background: #1f2328; }
 .cv-dev-claude { background: #d97706; }
-.cv-dev-dryrun { background: #57606a; }
+.cv-dev-btn:hover { opacity: 0.85; }
 .cv-dev-status { font-size: 12px; color: #57606a; }
 .cv-dev-path { font-size: 11px; color: #8c959f; word-break: break-all; margin-top: 2px; }
 .cv-dev-error { font-size: 12px; color: #cf222e; background: #ffebe9; border: 1px solid #ff8182; border-radius: 4px; padding: 6px 8px; }
-.cv-dev-log { background: #0d1117; color: #e6edf3; border-radius: 6px; padding: 8px 10px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; max-height: 240px; overflow-y: auto; margin: 0; }
+.cv-dev-log { background: #0d1117; color: #e6edf3; border-radius: 6px; padding: 8px 10px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; max-height: 200px; overflow-y: auto; margin: 0; }
 .cv-dev-done { font-size: 12px; color: #1a7f37; font-weight: 600; }
 `
 
@@ -356,24 +355,12 @@ function IssueView({ issue, kind }: { issue: GhIssue; kind: 'issue' | 'pr' }) {
   )
 }
 
-type DevelopAgent = 'codex' | 'claude' | 'dryrun'
-type DevelopStatus = 'idle' | 'starting' | 'creating' | 'running' | 'done' | 'failed'
-const MAX_UI_LOG_LINES = 2_000
-
 interface DevState {
-  status: DevelopStatus
+  taskId?: string
+  status: 'idle' | 'starting' | 'running' | 'done' | 'failed'
   worktree?: string
   branch?: string
   error?: string
-}
-
-interface PollSuccess {
-  ok: true
-  status: 'creating' | 'running' | 'done' | 'failed'
-  cursor: number
-  delta: string[]
-  truncated: boolean
-  done: boolean
 }
 
 async function apiCall<T>(method: string, body: Record<string, unknown>): Promise<T> {
@@ -388,92 +375,57 @@ async function apiCall<T>(method: string, body: Record<string, unknown>): Promis
 function DevSection({ url }: { url: string }) {
   const [state, setState] = React.useState<DevState>({ status: 'idle' })
   const [logs, setLogs] = React.useState<string[]>([])
-  const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
-  const logRef = React.useRef<HTMLPreElement | null>(null)
+  const timerRef = React.useRef<ReturnType<typeof setInterval> | null>(null)
 
-  const stopPolling = React.useCallback(() => {
-    if (timerRef.current !== null) clearTimeout(timerRef.current)
-    timerRef.current = null
+  React.useEffect(() => () => {
+    if (timerRef.current !== null) clearInterval(timerRef.current)
   }, [])
 
-  React.useEffect(() => stopPolling, [stopPolling])
-  React.useEffect(() => {
-    if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight
-  }, [logs])
-
-  const start = async (agent: DevelopAgent) => {
-    if (agent !== 'dryrun' && !window.confirm(
-      `将启动 ${agent} 执行该 Issue 及评论中的指令,并可能修改代码、提交、推送或创建 PR。确认继续?`,
-    )) return
-    stopPolling()
+  const start = async (agent: 'codex' | 'claude') => {
     setState({ status: 'starting' })
     setLogs([])
     try {
-      const started = await apiCall<
-        | { ok: true; taskId: string; worktree: string; branch: string }
-        | { ok: false; error: string }
-      >('develop', { url, agent })
-      if (!started.ok) {
-        setState({ status: 'failed', error: started.error })
+      const res = await apiCall<{ ok: true; taskId: string; worktree: string; branch: string } | { ok: false; error: string }>('develop', { url, agent })
+      if (!res.ok) {
+        setState({ status: 'failed', error: res.error })
         return
       }
-      setState({ status: 'creating', worktree: started.worktree, branch: started.branch })
-      let cursor = 0
-      const poll = async (): Promise<void> => {
-        try {
-          const result = await apiCall<PollSuccess | { ok: false; error: string }>(
-            'develop/poll',
-            { taskId: started.taskId, cursor },
-          )
-          if (!result.ok) throw new Error(result.error)
-          cursor = result.cursor
-          if (result.delta.length > 0) setLogs((previous) => {
-            const combined = [...previous, ...result.delta]
-            if (combined.length <= MAX_UI_LOG_LINES) return combined
-            return ['[clickvibe] 面板较早日志已截断', ...combined.slice(-(MAX_UI_LOG_LINES - 1))]
-          })
-          setState((previous) => ({ ...previous, status: result.status }))
-          if (result.done) {
-            stopPolling()
-            return
+      setState({ status: 'running', taskId: res.taskId, worktree: res.worktree, branch: res.branch })
+      // 轮询日志
+      timerRef.current = setInterval(async () => {
+        if (!res.taskId) return
+        const poll = await apiCall<{ ok: true; delta: string[]; status: string; done: boolean } | { ok: false; error: string }>('develop/poll', { taskId: res.taskId })
+        if (poll.ok) {
+          setLogs((prev) => [...prev, ...poll.delta])
+          if (poll.done) {
+            if (timerRef.current !== null) clearInterval(timerRef.current)
+            setState((prev) => ({ ...prev, status: poll.status as DevState['status'] }))
           }
-          timerRef.current = setTimeout(() => { void poll() }, 750)
-        } catch (error) {
-          stopPolling()
-          setState((previous) => ({
-            ...previous,
-            status: 'failed',
-            error: `日志轮询失败: ${String(error instanceof Error ? error.message : error)}`,
-          }))
         }
-      }
-      await poll()
-    } catch (error) {
-      setState({ status: 'failed', error: `启动失败: ${String(error instanceof Error ? error.message : error)}` })
+      }, 1500)
+    } catch (e) {
+      setState({ status: 'failed', error: String(e) })
     }
   }
 
-  const active = state.status === 'starting' || state.status === 'creating' || state.status === 'running'
   return (
     <div className="cv-dev">
       <div className="cv-dev-head">🚀 一键开发</div>
-      <div className="cv-dev-actions">
-        <button className="cv-dev-btn cv-dev-codex" disabled={active} onClick={() => { void start('codex') }}>Codex 开发</button>
-        <button className="cv-dev-btn cv-dev-claude" disabled={active} onClick={() => { void start('claude') }}>Claude 开发</button>
-        <button className="cv-dev-btn cv-dev-dryrun" disabled={active} onClick={() => { void start('dryrun') }}>安全演练</button>
-      </div>
-      {state.status !== 'idle' ? (
+      {state.status === 'idle' || state.status === 'failed' ? (
+        <div className="cv-dev-actions">
+          <button className="cv-dev-btn cv-dev-codex" onClick={() => start('codex')}>Codex 开发</button>
+          <button className="cv-dev-btn cv-dev-claude" onClick={() => start('claude')}>Claude 开发</button>
+        </div>
+      ) : (
         <div className="cv-dev-status">
-          {state.status === 'starting' ? '正在启动…'
-            : state.status === 'creating' ? '正在准备 worktree…'
-              : state.status === 'running' ? `开发中 (${state.branch ?? ''})`
-                : state.status === 'done' ? '任务已完成'
-                  : '任务失败'}
+          {state.status === 'starting' ? '正在创建 worktree…' : `开发中(${state.branch ?? ''})`}
           {state.worktree ? <div className="cv-dev-path">{state.worktree}</div> : null}
         </div>
-      ) : null}
+      )}
       {state.error ? <div className="cv-dev-error">{state.error}</div> : null}
-      {logs.length > 0 ? <pre ref={logRef} className="cv-dev-log">{logs.join('\n')}</pre> : null}
+      {logs.length > 0 ? (
+        <pre className="cv-dev-log">{logs.join('\n')}</pre>
+      ) : null}
       {state.status === 'done' ? <div className="cv-dev-done">✅ 开发完成</div> : null}
     </div>
   )

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -98,6 +98,19 @@ const PANEL_CSS = `
 .cv-md-ol { padding-left: 20px; list-style: decimal; margin: 0 0 8px; }
 .cv-md-blockquote { border-left: 4px solid #d0d7de; padding-left: 10px; margin: 0 0 8px; color: #57606a; }
 .cv-md-hr { border: none; border-top: 1px solid #d0d7de; margin: 10px 0; }
+.cv-dev { border: 1px solid #d0d7de; border-radius: 6px; padding: 8px 10px; display: flex; flex-direction: column; gap: 6px; }
+.cv-dev-head { font-weight: 600; font-size: 12.5px; color: #1f2328; }
+.cv-dev-actions { display: flex; flex-wrap: wrap; gap: 6px; }
+.cv-dev-btn { padding: 5px 10px; border: none; border-radius: 6px; cursor: pointer; font-size: 12px; font-weight: 600; color: #ffffff; }
+.cv-dev-btn:disabled { cursor: default; opacity: 0.6; }
+.cv-dev-codex { background: #1f2328; }
+.cv-dev-claude { background: #d97706; }
+.cv-dev-dryrun { background: #57606a; }
+.cv-dev-status { font-size: 12px; color: #57606a; }
+.cv-dev-path { font-size: 11px; color: #8c959f; word-break: break-all; margin-top: 2px; }
+.cv-dev-error { font-size: 12px; color: #cf222e; background: #ffebe9; border: 1px solid #ff8182; border-radius: 4px; padding: 6px 8px; }
+.cv-dev-log { background: #0d1117; color: #e6edf3; border-radius: 6px; padding: 8px 10px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; max-height: 240px; overflow-y: auto; margin: 0; }
+.cv-dev-done { font-size: 12px; color: #1a7f37; font-weight: 600; }
 `
 
 /** Inject the plugin stylesheet once; returns the disposer. */
@@ -335,7 +348,133 @@ function IssueView({ issue, kind }: { issue: GhIssue; kind: 'issue' | 'pr' }) {
       <div className="cv-issue-body">
         <div className="cv-md">{renderMarkdown(issue.body ?? '')}</div>
       </div>
+      {issue.url && kind === 'issue' && state === 'OPEN'
+        ? <DevSection url={issue.url} />
+        : null}
       <CommentsSection comments={issue.comments ?? []} />
+    </div>
+  )
+}
+
+type DevelopAgent = 'codex' | 'claude' | 'dryrun'
+type DevelopStatus = 'idle' | 'starting' | 'creating' | 'running' | 'done' | 'failed'
+const MAX_UI_LOG_LINES = 2_000
+
+interface DevState {
+  status: DevelopStatus
+  worktree?: string
+  branch?: string
+  error?: string
+}
+
+interface PollSuccess {
+  ok: true
+  status: 'creating' | 'running' | 'done' | 'failed'
+  cursor: number
+  delta: string[]
+  truncated: boolean
+  done: boolean
+}
+
+async function apiCall<T>(method: string, body: Record<string, unknown>): Promise<T> {
+  const response = await fetch(`/clickvibe/api/${method}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  return response.json() as Promise<T>
+}
+
+function DevSection({ url }: { url: string }) {
+  const [state, setState] = React.useState<DevState>({ status: 'idle' })
+  const [logs, setLogs] = React.useState<string[]>([])
+  const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const logRef = React.useRef<HTMLPreElement | null>(null)
+
+  const stopPolling = React.useCallback(() => {
+    if (timerRef.current !== null) clearTimeout(timerRef.current)
+    timerRef.current = null
+  }, [])
+
+  React.useEffect(() => stopPolling, [stopPolling])
+  React.useEffect(() => {
+    if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight
+  }, [logs])
+
+  const start = async (agent: DevelopAgent) => {
+    if (agent !== 'dryrun' && !window.confirm(
+      `将启动 ${agent} 执行该 Issue 及评论中的指令,并可能修改代码、提交、推送或创建 PR。确认继续?`,
+    )) return
+    stopPolling()
+    setState({ status: 'starting' })
+    setLogs([])
+    try {
+      const started = await apiCall<
+        | { ok: true; taskId: string; worktree: string; branch: string }
+        | { ok: false; error: string }
+      >('develop', { url, agent })
+      if (!started.ok) {
+        setState({ status: 'failed', error: started.error })
+        return
+      }
+      setState({ status: 'creating', worktree: started.worktree, branch: started.branch })
+      let cursor = 0
+      const poll = async (): Promise<void> => {
+        try {
+          const result = await apiCall<PollSuccess | { ok: false; error: string }>(
+            'develop/poll',
+            { taskId: started.taskId, cursor },
+          )
+          if (!result.ok) throw new Error(result.error)
+          cursor = result.cursor
+          if (result.delta.length > 0) setLogs((previous) => {
+            const combined = [...previous, ...result.delta]
+            if (combined.length <= MAX_UI_LOG_LINES) return combined
+            return ['[clickvibe] 面板较早日志已截断', ...combined.slice(-(MAX_UI_LOG_LINES - 1))]
+          })
+          setState((previous) => ({ ...previous, status: result.status }))
+          if (result.done) {
+            stopPolling()
+            return
+          }
+          timerRef.current = setTimeout(() => { void poll() }, 750)
+        } catch (error) {
+          stopPolling()
+          setState((previous) => ({
+            ...previous,
+            status: 'failed',
+            error: `日志轮询失败: ${String(error instanceof Error ? error.message : error)}`,
+          }))
+        }
+      }
+      await poll()
+    } catch (error) {
+      setState({ status: 'failed', error: `启动失败: ${String(error instanceof Error ? error.message : error)}` })
+    }
+  }
+
+  const active = state.status === 'starting' || state.status === 'creating' || state.status === 'running'
+  return (
+    <div className="cv-dev">
+      <div className="cv-dev-head">🚀 一键开发</div>
+      <div className="cv-dev-actions">
+        <button className="cv-dev-btn cv-dev-codex" disabled={active} onClick={() => { void start('codex') }}>Codex 开发</button>
+        <button className="cv-dev-btn cv-dev-claude" disabled={active} onClick={() => { void start('claude') }}>Claude 开发</button>
+        <button className="cv-dev-btn cv-dev-dryrun" disabled={active} onClick={() => { void start('dryrun') }}>安全演练</button>
+      </div>
+      {state.status !== 'idle' ? (
+        <div className="cv-dev-status">
+          {state.status === 'starting' ? '正在启动…'
+            : state.status === 'creating' ? '正在准备 worktree…'
+              : state.status === 'running' ? `开发中 (${state.branch ?? ''})`
+                : state.status === 'done' ? '任务已完成'
+                  : '任务失败'}
+          {state.worktree ? <div className="cv-dev-path">{state.worktree}</div> : null}
+        </div>
+      ) : null}
+      {state.error ? <div className="cv-dev-error">{state.error}</div> : null}
+      {logs.length > 0 ? <pre ref={logRef} className="cv-dev-log">{logs.join('\n')}</pre> : null}
+      {state.status === 'done' ? <div className="cv-dev-done">✅ 开发完成</div> : null}
     </div>
   )
 }

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -451,6 +451,7 @@ interface Workflow {
   devInterrupted: boolean
   reviewAgent: 'codex' | 'claude' | null
   reviewTaskId: string | null
+  reviewSessionId: string | null
   reviewResult: { passed: boolean; issues: string[]; commentUrl?: string } | null
   updatedAt: number
   events?: WorkflowEvent[]

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -626,14 +626,18 @@ function PanelContent() {
     return () => { cancelled = true }
   }, [])
 
-  const run = async () => {
-    if (!url.trim()) return
+  const run = async (targetUrl = url) => {
+    const trimmed = targetUrl.trim()
+    if (!trimmed) return
     setLoading(true)
     setError(null)
     setResult(null)
-    setWorkflow(null)
     try {
-      const res = await fetchIssue(url.trim())
+      // 按目标 url 匹配已存 workflow(恢复现场的关键:抓取不清 workflow)
+      const stateRes = await apiCall<{ ok: true; workflows: Workflow[] }>('state', {})
+      const matched = stateRes.ok ? stateRes.workflows.find((w) => w.url === trimmed) ?? null : null
+      setWorkflow(matched)
+      const res = await fetchIssue(trimmed)
       if (res.ok) setResult(res.data as { kind: 'issue' | 'pr'; item: GhIssue })
       else setError(res.error)
     } catch (e) {
@@ -663,7 +667,7 @@ function PanelContent() {
           onChange={(e) => setUrl(e.target.value)}
           onKeyDown={(e) => { if (e.key === 'Enter') run() }}
         />
-        <button className="cv-fetch" onClick={run} disabled={loading}>
+        <button className="cv-fetch" onClick={() => run()} disabled={loading}>
           {loading ? '抓取中…' : '抓取'}
         </button>
       </div>

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -121,6 +121,16 @@ const PANEL_CSS = `
 .cv-review-fail { display: flex; flex-direction: column; gap: 6px; }
 .cv-review-issues { margin: 0; padding-left: 18px; font-size: 12px; color: #1f2328; }
 .cv-review-issues li { margin: 2px 0; }
+.cv-refresh { padding: 6px 10px; border: 1px solid #d0d7de; border-radius: 6px; background: #ffffff; color: #57606a; cursor: pointer; font-size: 14px; line-height: 1; }
+.cv-refresh:hover { background: #f6f8fa; color: #1f2328; }
+.cv-links { display: flex; flex-direction: column; gap: 4px; }
+.cv-link-row { display: flex; align-items: center; gap: 6px; font-size: 12px; color: #57606a; flex-wrap: wrap; }
+.cv-link { color: #0969da; font-weight: 600; text-decoration: none; }
+.cv-link:hover { text-decoration: underline; }
+.cv-link-state { display: inline-block; padding: 0 6px; border-radius: 8px; font-size: 10.5px; font-weight: 600; }
+.cv-link-state-open { background: #dafbe1; color: #1a7f37; }
+.cv-link-state-closed { background: #ffebe9; color: #cf222e; }
+.cv-link-state-merged { background: #d8f5ff; color: #8250df; }
 `
 
 /** Inject the plugin stylesheet once; returns the disposer. */
@@ -309,11 +319,20 @@ interface GhIssue {
   headRefName?: string
 }
 
-function IssueView({ issue, kind, workflow, onWorkflow }: {
+interface TimelineEvent {
+  event: string
+  created_at?: string
+  actor?: string
+  commit_id?: string | null
+  source?: { number?: number; title?: string; html_url?: string; state?: string } | null
+}
+
+function IssueView({ issue, kind, workflow, onWorkflow, timeline }: {
   issue: GhIssue
   kind: 'issue' | 'pr'
   workflow: Workflow | null
   onWorkflow: (w: Workflow | null) => void
+  timeline?: TimelineEvent[]
 }) {
   const isPR = kind === 'pr'
   const state = String(issue.state || '').toUpperCase()
@@ -360,6 +379,29 @@ function IssueView({ issue, kind, workflow, onWorkflow }: {
           ))}
         </tbody>
       </table>
+      {timeline && timeline.length > 0 ? (
+        <div className="cv-links">
+          {timeline.map((ev, i) => {
+            if (ev.event === 'cross-referenced' && ev.source) {
+              return (
+                <div key={i} className="cv-link-row">
+                  🔗 关联
+                  <a className="cv-link" href={ev.source.html_url} target="_blank" rel="noreferrer">
+                    {ev.source.title ? `#${ev.source.number} ${ev.source.title}` : `#${ev.source.number}`}
+                  </a>
+                  <span className={`cv-link-state cv-link-state-${ev.source.state ?? 'open'}`}>
+                    {ev.source.state === 'closed' ? '已关闭' : ev.source.state === 'merged' ? '已合并' : '打开'}
+                  </span>
+                </div>
+              )
+            }
+            if (ev.event === 'referenced' && ev.commit_id) {
+              return <div key={i} className="cv-link-row">🔗 引用提交 <code className="cv-md-code">{ev.commit_id.slice(0, 7)}</code></div>
+            }
+            return null
+          })}
+        </div>
+      ) : null}
       <div className="cv-issue-body">
         <div className="cv-md">{renderMarkdown(issue.body ?? '')}</div>
       </div>
@@ -602,7 +644,7 @@ async function fetchIssue(url: string): Promise<{ ok: true; data: { kind: 'issue
 function PanelContent() {
   const [url, setUrl] = React.useState('')
   const [loading, setLoading] = React.useState(false)
-  const [result, setResult] = React.useState<{ kind: 'issue' | 'pr'; item: GhIssue } | null>(null)
+  const [result, setResult] = React.useState<{ kind: 'issue' | 'pr'; item: GhIssue; timeline?: TimelineEvent[] } | null>(null)
   const [error, setError] = React.useState<string | null>(null)
   const [workflow, setWorkflow] = React.useState<Workflow | null>(null)
   const [restored, setRestored] = React.useState(false)
@@ -620,7 +662,7 @@ function PanelContent() {
           // 自动重新抓取该 issue
           const fetchRes = await fetchIssue(active.url)
           if (!cancelled) {
-            if (fetchRes.ok) setResult(fetchRes.data as { kind: 'issue' | 'pr'; item: GhIssue })
+            if (fetchRes.ok) setResult(fetchRes.data as { kind: 'issue' | 'pr'; item: GhIssue; timeline?: TimelineEvent[] })
             else setError(fetchRes.error)
           }
         }
@@ -645,7 +687,7 @@ function PanelContent() {
       const matched = stateRes.ok ? stateRes.workflows.find((w) => w.url === trimmed) ?? null : null
       setWorkflow(matched)
       const res = await fetchIssue(trimmed)
-      if (res.ok) setResult(res.data as { kind: 'issue' | 'pr'; item: GhIssue })
+      if (res.ok) setResult(res.data as { kind: 'issue' | 'pr'; item: GhIssue; timeline?: TimelineEvent[] })
       else setError(res.error)
     } catch (e) {
       setError(`调用失败: ${String(e)}`)
@@ -677,10 +719,15 @@ function PanelContent() {
         <button className="cv-fetch" onClick={() => run()} disabled={loading}>
           {loading ? '抓取中…' : '抓取'}
         </button>
+        {result ? (
+          <button className="cv-refresh" onClick={() => run()} disabled={loading} title="重新抓取当前 issue">
+            ⟳
+          </button>
+        ) : null}
       </div>
       {error ? <div className="cv-error">{error}</div> : null}
       {result
-        ? <IssueView issue={result.item} kind={result.kind} workflow={workflow} onWorkflow={updateWorkflow} />
+        ? <IssueView issue={result.item} kind={result.kind} workflow={workflow} onWorkflow={updateWorkflow} timeline={result.timeline} />
         : loading
           ? <div className="cv-loading">正在通过 gh 抓取…</div>
           : restored

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -439,11 +439,15 @@ interface Workflow {
   updatedAt: number
 }
 
-function stageLabel(stage: Workflow['stage']): string {
+function stageLabel(stage: Workflow['stage'], workflow: Workflow | null): string {
   switch (stage) {
     case 'idle': return '未开发'
     case 'developing': return '开发中'
-    case 'review-ready': return '待 review'
+    case 'review-ready':
+      // 已有 review 结果:未通过 → "Review 未通过";否则 → "待 review"
+      return workflow?.reviewResult
+        ? (workflow.reviewResult.passed ? 'Review 通过' : 'Review 未通过')
+        : '待 review'
     case 'reviewing': return 'review 中'
     case 'passed': return '✅ 已通过'
   }
@@ -553,7 +557,7 @@ function DevSection({ url, workflow, onWorkflow }: {
   return (
     <div className="cv-dev">
       <div className="cv-dev-head">
-        🚀 开发流程 <span className={`cv-stage cv-stage-${stage}`}>{stageLabel(stage)}</span>
+        🚀 开发流程 <span className={`cv-stage cv-stage-${stage}`}>{stageLabel(stage, workflow)}</span>
       </div>
 
       {interrupted && stage === 'developing' ? (

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -460,11 +460,12 @@ function DevSection({ url, workflow, onWorkflow }: {
     }
   }
 
-  const startDev = async (agent: 'codex' | 'claude') => {
+  const startDev = async (agent: 'codex' | 'claude', context?: string) => {
     setBusy('developing')
     setError(null)
+    setStatusLines([])
     try {
-      const res = await apiCall<{ ok: true; taskId: string; worktree: string; branch: string } | { ok: false; error: string }>('develop', { url, agent })
+      const res = await apiCall<{ ok: true; taskId: string; worktree: string; branch: string } | { ok: false; error: string }>('develop', context ? { url, agent, context } : { url, agent })
       if (!res.ok) { setError(res.error); setBusy(null); return }
       await refresh()
       openStream(res.taskId)
@@ -503,7 +504,9 @@ function DevSection({ url, workflow, onWorkflow }: {
     }
   }
 
-  const showButtons = stage === 'idle' || (stage === 'review-ready' && !interrupted)
+  const showDevButtons = stage === 'idle'
+  const showReviewButtons = stage === 'review-ready' && !interrupted && !workflow?.reviewResult
+  const showReworkButtons = stage === 'review-ready' && workflow?.reviewResult?.passed === false
 
   return (
     <div className="cv-dev">
@@ -519,14 +522,14 @@ function DevSection({ url, workflow, onWorkflow }: {
         </div>
       ) : null}
 
-      {showButtons ? (
+      {showDevButtons ? (
         <div className="cv-dev-actions">
           <button className="cv-dev-btn cv-dev-codex" onClick={() => startDev('codex')} disabled={busy !== null}>Codex 开发</button>
           <button className="cv-dev-btn cv-dev-claude" onClick={() => startDev('claude')} disabled={busy !== null}>Claude 开发</button>
         </div>
       ) : null}
 
-      {stage === 'review-ready' && !interrupted ? (
+      {showReviewButtons ? (
         <div className="cv-dev-actions">
           <button className="cv-dev-btn cv-dev-review" onClick={() => startReview('codex')} disabled={busy !== null}>Codex Review</button>
           <button className="cv-dev-btn cv-dev-review" onClick={() => startReview('claude')} disabled={busy !== null}>Claude Review</button>
@@ -550,7 +553,11 @@ function DevSection({ url, workflow, onWorkflow }: {
                 {workflow.reviewResult.issues.map((issue, i) => <li key={i}>{issue}</li>)}
               </ul>
               <div className="cv-dev-actions">
-                <button className="cv-dev-btn cv-dev-codex" onClick={() => startDev('codex')} disabled={busy !== null}>↩ 按 review 意见继续开发</button>
+                <button
+                  className="cv-dev-btn cv-dev-codex"
+                  onClick={() => startDev('codex', workflow?.reviewResult?.issues.join('\n'))}
+                  disabled={busy !== null}
+                >↩ 按 review 意见继续开发</button>
               </div>
             </div>
           )

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -131,6 +131,22 @@ const PANEL_CSS = `
 .cv-link-state-open { background: #dafbe1; color: #1a7f37; }
 .cv-link-state-closed { background: #ffebe9; color: #cf222e; }
 .cv-link-state-merged { background: #d8f5ff; color: #8250df; }
+.cv-stage-new { background: #fff8c5; color: #9a6700; }
+.cv-timeline { border-top: 1px solid #d0d7de; padding-top: 6px; display: flex; flex-direction: column; gap: 4px; }
+.cv-timeline-head { font-size: 12px; font-weight: 600; color: #57606a; }
+.cv-tl-row { display: flex; align-items: center; gap: 6px; font-size: 11.5px; flex-wrap: wrap; }
+.cv-tl-kind { display: inline-block; padding: 0 6px; border-radius: 8px; font-size: 10.5px; font-weight: 600; }
+.cv-tl-kind-dev { background: #ddf4ff; color: #0969da; }
+.cv-tl-kind-rework { background: #fff8c5; color: #9a6700; }
+.cv-tl-kind-review { background: #fbefff; color: #8250df; }
+.cv-tl-kind-resume { background: #f6f8fa; color: #57606a; }
+.cv-tl-kind-note { background: #f6f8fa; color: #57606a; }
+.cv-tl-time { color: #8c959f; }
+.cv-tl-hash { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 10.5px; background: #eff1f3; padding: 0 4px; border-radius: 4px; }
+.cv-tl-verdict { font-weight: 600; }
+.cv-tl-pass { color: #1a7f37; }
+.cv-tl-fail { color: #cf222e; }
+.cv-tl-note { color: #57606a; }
 `
 
 /** Inject the plugin stylesheet once; returns the disposer. */
@@ -437,6 +453,20 @@ interface Workflow {
   reviewTaskId: string | null
   reviewResult: { passed: boolean; issues: string[]; commentUrl?: string } | null
   updatedAt: number
+  events?: WorkflowEvent[]
+  derived?: { head: string | null; hasNewCommits: boolean; lastDevHash: string | null; lastReviewHash: string | null }
+}
+
+interface WorkflowEvent {
+  kind: 'dev' | 'review' | 'rework' | 'resume' | 'note'
+  at: string
+  hash?: string
+  verdict?: { passed: boolean; issues: string[] }
+  note?: string
+}
+
+function fmtTime(iso: string): string {
+  try { return new Date(iso).toLocaleString() } catch { return iso }
 }
 
 function stageLabel(stage: Workflow['stage'], workflow: Workflow | null): string {
@@ -556,57 +586,79 @@ function DevSection({ url, workflow, onWorkflow }: {
 
   return (
     <div className="cv-dev">
+      {/* 状态卡:当前状态 + 关键事实 */}
       <div className="cv-dev-head">
         🚀 开发流程 <span className={`cv-stage cv-stage-${stage}`}>{stageLabel(stage, workflow)}</span>
+        {workflow?.derived?.hasNewCommits ? <span className="cv-stage cv-stage-new">有未 review 的新提交</span> : null}
+      </div>
+      {workflow?.worktree ? <div className="cv-dev-path">{workflow.worktree}</div> : null}
+      {workflow?.derived?.head ? <div className="cv-dev-path">HEAD {workflow.derived.head}</div> : null}
+
+      {/* 操作区(悬浮感):与信息分离 */}
+      <div className="cv-dev-actions">
+        {interrupted && stage === 'developing' ? (
+          <button className="cv-dev-btn cv-dev-warn" onClick={resume} disabled={busy !== null}>
+            {busy === 'resuming' ? '恢复中…' : '↩ 恢复开发'}
+          </button>
+        ) : null}
+        {showDevButtons ? (
+          <>
+            <button className="cv-dev-btn cv-dev-codex" onClick={() => startDev('codex')} disabled={busy !== null}>Codex 开发</button>
+            <button className="cv-dev-btn cv-dev-claude" onClick={() => startDev('claude')} disabled={busy !== null}>Claude 开发</button>
+          </>
+        ) : null}
+        {showReviewButtons ? (
+          <>
+            <button className="cv-dev-btn cv-dev-review" onClick={() => startReview('codex')} disabled={busy !== null}>Codex Review</button>
+            <button className="cv-dev-btn cv-dev-review" onClick={() => startReview('claude')} disabled={busy !== null}>Claude Review</button>
+          </>
+        ) : null}
+        {workflow?.reviewResult && !workflow.reviewResult.passed ? (
+          <button
+            className="cv-dev-btn cv-dev-codex"
+            onClick={() => startDev('codex', workflow?.reviewResult?.issues.join('\n'))}
+            disabled={busy !== null}
+          >↩ 按 review 意见继续开发</button>
+        ) : null}
       </div>
 
-      {interrupted && stage === 'developing' ? (
-        <div className="cv-dev-actions">
-          <button className="cv-dev-btn cv-dev-warn" onClick={resume} disabled={busy !== null}>
-            {busy === 'resuming' ? '恢复中…' : '↩ 恢复开发(上次中断)'}
-          </button>
-        </div>
-      ) : null}
-
-      {showDevButtons ? (
-        <div className="cv-dev-actions">
-          <button className="cv-dev-btn cv-dev-codex" onClick={() => startDev('codex')} disabled={busy !== null}>Codex 开发</button>
-          <button className="cv-dev-btn cv-dev-claude" onClick={() => startDev('claude')} disabled={busy !== null}>Claude 开发</button>
-        </div>
-      ) : null}
-
-      {showReviewButtons ? (
-        <div className="cv-dev-actions">
-          <button className="cv-dev-btn cv-dev-review" onClick={() => startReview('codex')} disabled={busy !== null}>Codex Review</button>
-          <button className="cv-dev-btn cv-dev-review" onClick={() => startReview('claude')} disabled={busy !== null}>Claude Review</button>
-        </div>
-      ) : null}
-
-      {workflow?.worktree ? <div className="cv-dev-path">{workflow.worktree}</div> : null}
       {error ? <div className="cv-dev-error">{error}</div> : null}
 
       {statusLines.length > 0 ? (
         <pre className="cv-dev-log">{statusLines.join('\n')}</pre>
       ) : null}
 
-      {workflow?.reviewResult ? (
-        workflow.reviewResult.passed
-          ? <div className="cv-dev-done">✅ Review 通过,流程完成</div>
-          : (
-            <div className="cv-review-fail">
-              <div className="cv-dev-error">❌ Review 发现 {workflow.reviewResult.issues.length} 个问题</div>
-              <ul className="cv-review-issues">
-                {workflow.reviewResult.issues.map((issue, i) => <li key={i}>{issue}</li>)}
-              </ul>
-              <div className="cv-dev-actions">
-                <button
-                  className="cv-dev-btn cv-dev-codex"
-                  onClick={() => startDev('codex', workflow?.reviewResult?.issues.join('\n'))}
-                  disabled={busy !== null}
-                >↩ 按 review 意见继续开发</button>
-              </div>
+      {/* 最新 review 结论(当前状态的一部分) */}
+      {workflow?.reviewResult && !workflow.reviewResult.passed ? (
+        <div className="cv-review-fail">
+          <div className="cv-dev-error">❌ 最近一次 Review 发现 {workflow.reviewResult.issues.length} 个问题</div>
+          <ul className="cv-review-issues">
+            {workflow.reviewResult.issues.map((issue, i) => <li key={i}>{issue}</li>)}
+          </ul>
+        </div>
+      ) : null}
+      {workflow?.reviewResult?.passed ? <div className="cv-dev-done">✅ Review 通过</div> : null}
+
+      {/* 历史时间线:全部事件,按时间顺序 */}
+      {(workflow?.events ?? []).length > 0 ? (
+        <div className="cv-timeline">
+          <div className="cv-timeline-head">📜 历史</div>
+          {[...(workflow?.events ?? [])].reverse().map((ev, i) => (
+            <div key={i} className="cv-tl-row">
+              <span className={`cv-tl-kind cv-tl-kind-${ev.kind}`}>
+                {ev.kind === 'dev' ? '开发' : ev.kind === 'rework' ? '返工' : ev.kind === 'review' ? 'Review' : ev.kind === 'resume' ? '恢复' : '备注'}
+              </span>
+              <span className="cv-tl-time">{fmtTime(ev.at)}</span>
+              {ev.hash ? <code className="cv-tl-hash">{ev.hash}</code> : null}
+              {ev.kind === 'review' && ev.verdict
+                ? <span className={ev.verdict.passed ? 'cv-tl-verdict cv-tl-pass' : 'cv-tl-verdict cv-tl-fail'}>
+                    {ev.verdict.passed ? '✅ 通过' : `❌ ${ev.verdict.issues.length} 个问题`}
+                  </span>
+                : null}
+              {ev.note ? <span className="cv-tl-note">{ev.note}</span> : null}
             </div>
-          )
+          ))}
+        </div>
       ) : null}
     </div>
   )

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -110,6 +110,17 @@ const PANEL_CSS = `
 .cv-dev-error { font-size: 12px; color: #cf222e; background: #ffebe9; border: 1px solid #ff8182; border-radius: 4px; padding: 6px 8px; }
 .cv-dev-log { background: #0d1117; color: #e6edf3; border-radius: 6px; padding: 8px 10px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; max-height: 200px; overflow-y: auto; margin: 0; }
 .cv-dev-done { font-size: 12px; color: #1a7f37; font-weight: 600; }
+.cv-stage { display: inline-block; padding: 1px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; margin-left: 6px; }
+.cv-stage-idle { background: #f6f8fa; color: #57606a; }
+.cv-stage-developing { background: #ddf4ff; color: #0969da; }
+.cv-stage-review-ready { background: #fff8c5; color: #9a6700; }
+.cv-stage-reviewing { background: #fbefff; color: #8250df; }
+.cv-stage-passed { background: #dafbe1; color: #1a7f37; }
+.cv-dev-btn.cv-dev-warn { background: #d4a72c; color: #ffffff; }
+.cv-dev-btn.cv-dev-review { background: #8250df; color: #ffffff; }
+.cv-review-fail { display: flex; flex-direction: column; gap: 6px; }
+.cv-review-issues { margin: 0; padding-left: 18px; font-size: 12px; color: #1f2328; }
+.cv-review-issues li { margin: 2px 0; }
 `
 
 /** Inject the plugin stylesheet once; returns the disposer. */
@@ -298,7 +309,12 @@ interface GhIssue {
   headRefName?: string
 }
 
-function IssueView({ issue, kind }: { issue: GhIssue; kind: 'issue' | 'pr' }) {
+function IssueView({ issue, kind, workflow, onWorkflow }: {
+  issue: GhIssue
+  kind: 'issue' | 'pr'
+  workflow: Workflow | null
+  onWorkflow: (w: Workflow | null) => void
+}) {
   const isPR = kind === 'pr'
   const state = String(issue.state || '').toUpperCase()
   const stateBadge = isPR && state === 'MERGED'
@@ -348,19 +364,11 @@ function IssueView({ issue, kind }: { issue: GhIssue; kind: 'issue' | 'pr' }) {
         <div className="cv-md">{renderMarkdown(issue.body ?? '')}</div>
       </div>
       {issue.url && kind === 'issue' && state === 'OPEN'
-        ? <DevSection url={issue.url} />
+        ? <DevSection url={issue.url} workflow={workflow} onWorkflow={onWorkflow} />
         : null}
       <CommentsSection comments={issue.comments ?? []} />
     </div>
   )
-}
-
-interface DevState {
-  taskId?: string
-  status: 'idle' | 'starting' | 'running' | 'done' | 'failed'
-  worktree?: string
-  branch?: string
-  error?: string
 }
 
 async function apiCall<T>(method: string, body: Record<string, unknown>): Promise<T> {
@@ -372,61 +380,181 @@ async function apiCall<T>(method: string, body: Record<string, unknown>): Promis
   return response.json() as Promise<T>
 }
 
-function DevSection({ url }: { url: string }) {
-  const [state, setState] = React.useState<DevState>({ status: 'idle' })
-  const [logs, setLogs] = React.useState<string[]>([])
-  const timerRef = React.useRef<ReturnType<typeof setInterval> | null>(null)
+interface Workflow {
+  key: string
+  url: string
+  repoKey: string
+  worktree: string
+  branch: string
+  stage: 'idle' | 'developing' | 'review-ready' | 'reviewing' | 'passed'
+  devAgent: 'codex' | 'claude' | null
+  devTaskId: string | null
+  devSessionId: string | null
+  devInterrupted: boolean
+  reviewAgent: 'codex' | 'claude' | null
+  reviewTaskId: string | null
+  reviewResult: { passed: boolean; issues: string[]; commentUrl?: string } | null
+  updatedAt: number
+}
+
+function stageLabel(stage: Workflow['stage']): string {
+  switch (stage) {
+    case 'idle': return '未开发'
+    case 'developing': return '开发中'
+    case 'review-ready': return '待 review'
+    case 'reviewing': return 'review 中'
+    case 'passed': return '✅ 已通过'
+  }
+}
+
+function DevSection({ url, workflow, onWorkflow }: {
+  url: string
+  workflow: Workflow | null
+  onWorkflow: (w: Workflow | null) => void
+}) {
+  const [busy, setBusy] = React.useState<string | null>(null)
+  const [error, setError] = React.useState<string | null>(null)
+  const [statusLines, setStatusLines] = React.useState<string[]>([])
+  const esRef = React.useRef<EventSource | null>(null)
+  const stage = workflow?.stage ?? 'idle'
+  const interrupted = workflow?.devInterrupted ?? false
+
+  // 打开 SSE 实时流
+  const openStream = (taskId: string) => {
+    esRef.current?.close()
+    const es = new EventSource(`/clickvibe/api/stream?taskId=${encodeURIComponent(taskId)}`)
+    esRef.current = es
+    es.onmessage = (e) => {
+      try {
+        const data = JSON.parse(e.data) as string | { __done?: boolean }
+        if (typeof data === 'object' && data.__done) {
+          es.close()
+          return
+        }
+        setStatusLines((prev) => [...prev, String(data)])
+      } catch {
+        setStatusLines((prev) => [...prev, e.data])
+      }
+    }
+    es.onerror = () => { es.close() }
+  }
 
   React.useEffect(() => () => {
-    if (timerRef.current !== null) clearInterval(timerRef.current)
+    esRef.current?.close()
   }, [])
 
-  const start = async (agent: 'codex' | 'claude') => {
-    setState({ status: 'starting' })
-    setLogs([])
-    try {
-      const res = await apiCall<{ ok: true; taskId: string; worktree: string; branch: string } | { ok: false; error: string }>('develop', { url, agent })
-      if (!res.ok) {
-        setState({ status: 'failed', error: res.error })
-        return
-      }
-      setState({ status: 'running', taskId: res.taskId, worktree: res.worktree, branch: res.branch })
-      // 轮询日志
-      timerRef.current = setInterval(async () => {
-        if (!res.taskId) return
-        const poll = await apiCall<{ ok: true; delta: string[]; status: string; done: boolean } | { ok: false; error: string }>('develop/poll', { taskId: res.taskId })
-        if (poll.ok) {
-          setLogs((prev) => [...prev, ...poll.delta])
-          if (poll.done) {
-            if (timerRef.current !== null) clearInterval(timerRef.current)
-            setState((prev) => ({ ...prev, status: poll.status as DevState['status'] }))
-          }
-        }
-      }, 1500)
-    } catch (e) {
-      setState({ status: 'failed', error: String(e) })
+  // 恢复现场:若已有进行中的任务,重连其 SSE
+  React.useEffect(() => {
+    if (!workflow) return
+    const taskId = workflow.stage === 'reviewing' ? workflow.reviewTaskId : workflow.devTaskId
+    if (taskId && (workflow.stage === 'developing' || workflow.stage === 'reviewing')) {
+      openStream(taskId)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workflow?.devTaskId, workflow?.reviewTaskId, workflow?.stage])
+
+  const refresh = async () => {
+    const res = await apiCall<{ ok: true; workflows: Workflow[] }>('state', {})
+    if (res.ok) {
+      onWorkflow(res.workflows.find((w) => w.url === url) ?? null)
     }
   }
 
+  const startDev = async (agent: 'codex' | 'claude') => {
+    setBusy('developing')
+    setError(null)
+    try {
+      const res = await apiCall<{ ok: true; taskId: string; worktree: string; branch: string } | { ok: false; error: string }>('develop', { url, agent })
+      if (!res.ok) { setError(res.error); setBusy(null); return }
+      await refresh()
+      openStream(res.taskId)
+      setBusy(null)
+    } catch (e) {
+      setError(String(e)); setBusy(null)
+    }
+  }
+
+  const resume = async () => {
+    setBusy('resuming')
+    setError(null)
+    try {
+      const res = await apiCall<{ ok: true; taskId: string } | { ok: false; error: string }>('resume', { url })
+      if (!res.ok) { setError(res.error); setBusy(null); return }
+      await refresh()
+      openStream(res.taskId)
+      setBusy(null)
+    } catch (e) {
+      setError(String(e)); setBusy(null)
+    }
+  }
+
+  const startReview = async (agent: 'codex' | 'claude') => {
+    setBusy('reviewing')
+    setError(null)
+    setStatusLines([])
+    try {
+      const res = await apiCall<{ ok: true; taskId: string } | { ok: false; error: string }>('review', { url, agent })
+      if (!res.ok) { setError(res.error); setBusy(null); return }
+      await refresh()
+      openStream(res.taskId)
+      setBusy(null)
+    } catch (e) {
+      setError(String(e)); setBusy(null)
+    }
+  }
+
+  const showButtons = stage === 'idle' || (stage === 'review-ready' && !interrupted)
+
   return (
     <div className="cv-dev">
-      <div className="cv-dev-head">🚀 一键开发</div>
-      {state.status === 'idle' || state.status === 'failed' ? (
+      <div className="cv-dev-head">
+        🚀 开发流程 <span className={`cv-stage cv-stage-${stage}`}>{stageLabel(stage)}</span>
+      </div>
+
+      {interrupted && stage === 'developing' ? (
         <div className="cv-dev-actions">
-          <button className="cv-dev-btn cv-dev-codex" onClick={() => start('codex')}>Codex 开发</button>
-          <button className="cv-dev-btn cv-dev-claude" onClick={() => start('claude')}>Claude 开发</button>
+          <button className="cv-dev-btn cv-dev-warn" onClick={resume} disabled={busy !== null}>
+            {busy === 'resuming' ? '恢复中…' : '↩ 恢复开发(上次中断)'}
+          </button>
         </div>
-      ) : (
-        <div className="cv-dev-status">
-          {state.status === 'starting' ? '正在创建 worktree…' : `开发中(${state.branch ?? ''})`}
-          {state.worktree ? <div className="cv-dev-path">{state.worktree}</div> : null}
-        </div>
-      )}
-      {state.error ? <div className="cv-dev-error">{state.error}</div> : null}
-      {logs.length > 0 ? (
-        <pre className="cv-dev-log">{logs.join('\n')}</pre>
       ) : null}
-      {state.status === 'done' ? <div className="cv-dev-done">✅ 开发完成</div> : null}
+
+      {showButtons ? (
+        <div className="cv-dev-actions">
+          <button className="cv-dev-btn cv-dev-codex" onClick={() => startDev('codex')} disabled={busy !== null}>Codex 开发</button>
+          <button className="cv-dev-btn cv-dev-claude" onClick={() => startDev('claude')} disabled={busy !== null}>Claude 开发</button>
+        </div>
+      ) : null}
+
+      {stage === 'review-ready' && !interrupted ? (
+        <div className="cv-dev-actions">
+          <button className="cv-dev-btn cv-dev-review" onClick={() => startReview('codex')} disabled={busy !== null}>Codex Review</button>
+          <button className="cv-dev-btn cv-dev-review" onClick={() => startReview('claude')} disabled={busy !== null}>Claude Review</button>
+        </div>
+      ) : null}
+
+      {workflow?.worktree ? <div className="cv-dev-path">{workflow.worktree}</div> : null}
+      {error ? <div className="cv-dev-error">{error}</div> : null}
+
+      {statusLines.length > 0 ? (
+        <pre className="cv-dev-log">{statusLines.join('\n')}</pre>
+      ) : null}
+
+      {workflow?.reviewResult ? (
+        workflow.reviewResult.passed
+          ? <div className="cv-dev-done">✅ Review 通过,流程完成</div>
+          : (
+            <div className="cv-review-fail">
+              <div className="cv-dev-error">❌ Review 发现 {workflow.reviewResult.issues.length} 个问题</div>
+              <ul className="cv-review-issues">
+                {workflow.reviewResult.issues.map((issue, i) => <li key={i}>{issue}</li>)}
+              </ul>
+              <div className="cv-dev-actions">
+                <button className="cv-dev-btn cv-dev-codex" onClick={() => startDev('codex')} disabled={busy !== null}>↩ 按 review 意见继续开发</button>
+              </div>
+            </div>
+          )
+      ) : null}
     </div>
   )
 }
@@ -469,12 +597,41 @@ function PanelContent() {
   const [loading, setLoading] = React.useState(false)
   const [result, setResult] = React.useState<{ kind: 'issue' | 'pr'; item: GhIssue } | null>(null)
   const [error, setError] = React.useState<string | null>(null)
+  const [workflow, setWorkflow] = React.useState<Workflow | null>(null)
+  const [restored, setRestored] = React.useState(false)
+
+  // 恢复现场:打开面板时读回所有工作流,若存在进行中的任务自动重连展示
+  React.useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await apiCall<{ ok: true; workflows: Workflow[] }>('state', {})
+        if (!cancelled && res.ok && res.workflows.length > 0) {
+          const active = res.workflows[0]
+          setWorkflow(active)
+          setUrl(active.url)
+          // 自动重新抓取该 issue
+          const fetchRes = await fetchIssue(active.url)
+          if (!cancelled) {
+            if (fetchRes.ok) setResult(fetchRes.data as { kind: 'issue' | 'pr'; item: GhIssue })
+            else setError(fetchRes.error)
+          }
+        }
+      } catch {
+        // 恢复失败不阻塞面板
+      } finally {
+        if (!cancelled) setRestored(true)
+      }
+    })()
+    return () => { cancelled = true }
+  }, [])
 
   const run = async () => {
     if (!url.trim()) return
     setLoading(true)
     setError(null)
     setResult(null)
+    setWorkflow(null)
     try {
       const res = await fetchIssue(url.trim())
       if (res.ok) setResult(res.data as { kind: 'issue' | 'pr'; item: GhIssue })
@@ -484,6 +641,11 @@ function PanelContent() {
     } finally {
       setLoading(false)
     }
+  }
+
+  const updateWorkflow = (w: Workflow | null) => {
+    setWorkflow(w)
+    // workflow 变化时同步刷新状态(不打断当前展示)
   }
 
   return (
@@ -507,10 +669,12 @@ function PanelContent() {
       </div>
       {error ? <div className="cv-error">{error}</div> : null}
       {result
-        ? <IssueView issue={result.item} kind={result.kind} />
+        ? <IssueView issue={result.item} kind={result.kind} workflow={workflow} onWorkflow={updateWorkflow} />
         : loading
           ? <div className="cv-loading">正在通过 gh 抓取…</div>
-          : <div className="cv-hint">粘贴一个 GitHub issue / PR 链接,回车抓取</div>}
+          : restored
+            ? <div className="cv-hint">粘贴一个 GitHub issue / PR 链接,回车抓取</div>
+            : <div className="cv-loading">正在恢复现场…</div>}
     </div>
   )
 }

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -551,11 +551,12 @@ function DevSection({ url, workflow, onWorkflow }: {
     }
   }
 
-  const resume = async () => {
+  const resume = async (context?: string) => {
     setBusy('resuming')
     setError(null)
+    setStatusLines([])
     try {
-      const res = await apiCall<{ ok: true; taskId: string } | { ok: false; error: string }>('resume', { url })
+      const res = await apiCall<{ ok: true; taskId: string } | { ok: false; error: string }>('resume', context ? { url, context } : { url })
       if (!res.ok) { setError(res.error); setBusy(null); return }
       await refresh()
       openStream(res.taskId)
@@ -597,7 +598,7 @@ function DevSection({ url, workflow, onWorkflow }: {
       {/* 操作区(悬浮感):与信息分离 */}
       <div className="cv-dev-actions">
         {interrupted && stage === 'developing' ? (
-          <button className="cv-dev-btn cv-dev-warn" onClick={resume} disabled={busy !== null}>
+          <button className="cv-dev-btn cv-dev-warn" onClick={() => resume()} disabled={busy !== null}>
             {busy === 'resuming' ? '恢复中…' : '↩ 恢复开发'}
           </button>
         ) : null}
@@ -616,8 +617,9 @@ function DevSection({ url, workflow, onWorkflow }: {
         {workflow?.reviewResult && !workflow.reviewResult.passed ? (
           <button
             className="cv-dev-btn cv-dev-codex"
-            onClick={() => startDev('codex', workflow?.reviewResult?.issues.join('\n'))}
+            onClick={() => resume(workflow?.reviewResult?.issues.join('\n'))}
             disabled={busy !== null}
+            title="续上次开发会话,并把 review 意见带进去"
           >↩ 按 review 意见继续开发</button>
         ) : null}
       </div>

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -395,14 +395,25 @@ function IssueView({ issue, kind, workflow, onWorkflow, timeline }: {
           ))}
         </tbody>
       </table>
+      {/* 开发上下文:worktree + 基线 —— 只要进入开发流程就显示,不依赖 PR */}
+      {workflow ? (
+        <div className="cv-links">
+          <div className="cv-link-row">
+            📁 worktree
+            <code className="cv-tl-hash">{workflow.worktree}</code>
+          </div>
+          {workflow.baseRef ? (
+            <div className="cv-link-row">
+              📍 基线
+              <code className="cv-tl-hash">{workflow.baseRef}</code>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
       {timeline && timeline.length > 0 ? (
         <div className="cv-links">
           {timeline.map((ev, i) => {
             if (ev.event === 'cross-referenced' && ev.source) {
-              // 若 workflow 记录了该 PR 的 worktree,一并显示
-              const linkedWorktree = workflow && workflow.prNumber === String(ev.source.number)
-                ? workflow.worktree
-                : undefined
               return (
                 <div key={i} className="cv-link-row">
                   🔗 关联
@@ -412,7 +423,6 @@ function IssueView({ issue, kind, workflow, onWorkflow, timeline }: {
                   <span className={`cv-link-state cv-link-state-${ev.source.state ?? 'open'}`}>
                     {ev.source.state === 'closed' ? '已关闭' : ev.source.state === 'merged' ? '已合并' : '打开'}
                   </span>
-                  {linkedWorktree ? <code className="cv-tl-hash">{linkedWorktree}</code> : null}
                 </div>
               )
             }
@@ -459,6 +469,7 @@ interface Workflow {
   reviewSessionId: string | null
   reviewResult: { passed: boolean; issues: string[]; commentUrl?: string } | null
   prNumber: string | null
+  baseRef: string | null
   updatedAt: number
   events?: WorkflowEvent[]
   derived?: { head: string | null; hasNewCommits: boolean; lastDevHash: string | null; lastReviewHash: string | null }

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -453,6 +453,7 @@ interface Workflow {
   reviewTaskId: string | null
   reviewSessionId: string | null
   reviewResult: { passed: boolean; issues: string[]; commentUrl?: string } | null
+  prNumber: string | null
   updatedAt: number
   events?: WorkflowEvent[]
   derived?: { head: string | null; hasNewCommits: boolean; lastDevHash: string | null; lastReviewHash: string | null }
@@ -595,6 +596,14 @@ function DevSection({ url, workflow, onWorkflow }: {
       </div>
       {workflow?.worktree ? <div className="cv-dev-path">{workflow.worktree}</div> : null}
       {workflow?.derived?.head ? <div className="cv-dev-path">HEAD {workflow.derived.head}</div> : null}
+      {workflow?.prNumber ? (
+        <div className="cv-dev-path">
+          🔗 PR{' '}
+          <a className="cv-link" href={`https://github.com/${workflow.repoKey}/pull/${workflow.prNumber}`} target="_blank" rel="noreferrer">
+            #{workflow.prNumber}
+          </a>
+        </div>
+      ) : null}
 
       {/* 操作区(悬浮感):与信息分离 */}
       <div className="cv-dev-actions">

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -399,6 +399,10 @@ function IssueView({ issue, kind, workflow, onWorkflow, timeline }: {
         <div className="cv-links">
           {timeline.map((ev, i) => {
             if (ev.event === 'cross-referenced' && ev.source) {
+              // 若 workflow 记录了该 PR 的 worktree,一并显示
+              const linkedWorktree = workflow && workflow.prNumber === String(ev.source.number)
+                ? workflow.worktree
+                : undefined
               return (
                 <div key={i} className="cv-link-row">
                   🔗 关联
@@ -408,6 +412,7 @@ function IssueView({ issue, kind, workflow, onWorkflow, timeline }: {
                   <span className={`cv-link-state cv-link-state-${ev.source.state ?? 'open'}`}>
                     {ev.source.state === 'closed' ? '已关闭' : ev.source.state === 'merged' ? '已合并' : '打开'}
                   </span>
+                  {linkedWorktree ? <code className="cv-tl-hash">{linkedWorktree}</code> : null}
                 </div>
               )
             }

--- a/src/develop.ts
+++ b/src/develop.ts
@@ -102,6 +102,7 @@ export type WorktreeRecovery =
   | { kind: 'reuse' }
   | { kind: 'attach-detached' }
   | { kind: 'attach-existing' }
+  | { kind: 'repair'; reason: string }
   | { kind: 'conflict'; reason: string }
 
 /** Decide a safe recovery action without deleting or overwriting directories. */
@@ -119,9 +120,16 @@ export function decideWorktreeRecovery(snapshot: WorktreeSnapshot): WorktreeReco
       return branchExists ? { kind: 'attach-existing' } : { kind: 'attach-detached' }
     }
     if (registeredBranch !== '') {
-      return registeredBranch === targetBranch
-        ? { kind: 'reuse' }
-        : { kind: 'conflict', reason: `目标路径已检出其他分支: ${registeredBranch}` }
+      if (registeredBranch !== targetBranch) {
+        return { kind: 'conflict', reason: `目标路径已检出其他分支: ${registeredBranch}` }
+      }
+      // 注册匹配目标分支:仅当路径真实存在且非空才能复用;
+      // 路径消失或为空(stale 注册)→ repair:先清理注册再重建。
+      if (pathExists && !pathEmpty) return { kind: 'reuse' }
+      return {
+        kind: 'repair',
+        reason: `注册记录指向 ${targetBranch} 但路径${pathExists ? '为空' : '不存在'},需要清理注册后重建`,
+      }
     }
   }
 

--- a/src/develop.ts
+++ b/src/develop.ts
@@ -1,0 +1,132 @@
+export type DevelopAgent = 'codex' | 'claude' | 'dryrun'
+
+export interface GithubTarget {
+  kind: 'issue' | 'pr'
+  owner: string
+  repo: string
+  number: string
+}
+
+export function parseAgent(value: unknown): DevelopAgent {
+  const agent = String(value ?? 'codex').trim().toLowerCase()
+  if (agent === 'codex' || agent === 'claude' || agent === 'dryrun') return agent
+  throw new Error(`不支持的 agent "${agent}"`)
+}
+
+export function parseGithubUrl(value: string): GithubTarget | null {
+  const match = value.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/(issues|pull)\/(\d+)\/?(?:\?[^#]*)?(?:#.*)?$/)
+  if (!match) return null
+  return {
+    kind: match[3] === 'pull' ? 'pr' : 'issue',
+    owner: match[1],
+    repo: match[2],
+    number: match[4],
+  }
+}
+
+/** Quote one argument for a POSIX shell command without allowing expansion. */
+export function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`
+}
+
+interface LogEntry {
+  sequence: number
+  line: string
+}
+
+export interface LogRead {
+  cursor: number
+  lines: string[]
+  truncated: boolean
+}
+
+/** Bounded, non-destructive line log with independent cursor readers. */
+export class LineLog {
+  readonly #limit: number
+  #entries: LogEntry[] = []
+  #partial = ''
+  #sequence = 0
+
+  constructor(limit: number) {
+    if (!Number.isSafeInteger(limit) || limit < 1) throw new Error('log limit must be positive')
+    this.#limit = limit
+  }
+
+  appendLine(line: string): void {
+    this.#sequence += 1
+    this.#entries.push({ sequence: this.#sequence, line })
+    if (this.#entries.length > this.#limit) {
+      this.#entries.splice(0, this.#entries.length - this.#limit)
+    }
+  }
+
+  appendChunk(chunk: string): void {
+    const normalized = (this.#partial + chunk).replaceAll('\r\n', '\n').replaceAll('\r', '\n')
+    const parts = normalized.split('\n')
+    this.#partial = parts.pop() ?? ''
+    for (const line of parts) this.appendLine(line)
+  }
+
+  flush(): void {
+    if (this.#partial === '') return
+    this.appendLine(this.#partial)
+    this.#partial = ''
+  }
+
+  read(cursor: number): LogRead {
+    const safeCursor = Number.isSafeInteger(cursor) && cursor >= 0 ? cursor : 0
+    const oldest = this.#entries[0]?.sequence ?? this.#sequence + 1
+    const truncated = safeCursor < oldest - 1
+    const lines = this.#entries
+      .filter((entry) => entry.sequence > safeCursor)
+      .map((entry) => entry.line)
+    if (truncated) lines.unshift('[clickvibe] 较早日志已截断')
+    return { cursor: this.#sequence, lines, truncated }
+  }
+}
+
+export interface WorktreeSnapshot {
+  targetBranch: string
+  pathExists: boolean
+  pathEmpty: boolean
+  /** Short branch name, or HEAD for a detached registered worktree. */
+  registeredBranch: string | null
+  branchExists: boolean
+  /** Registered location of the intended branch, if any. */
+  branchWorktree: string | null
+}
+
+export type WorktreeRecovery =
+  | { kind: 'add-new-branch' }
+  | { kind: 'add-existing-branch' }
+  | { kind: 'reuse' }
+  | { kind: 'attach-detached' }
+  | { kind: 'attach-existing' }
+  | { kind: 'conflict'; reason: string }
+
+/** Decide a safe recovery action without deleting or overwriting directories. */
+export function decideWorktreeRecovery(snapshot: WorktreeSnapshot): WorktreeRecovery {
+  const {
+    targetBranch, pathExists, pathEmpty, registeredBranch, branchExists, branchWorktree,
+  } = snapshot
+
+  if (branchWorktree !== null && registeredBranch !== targetBranch) {
+    return { kind: 'conflict', reason: `目标分支已被其他 worktree 使用: ${branchWorktree}` }
+  }
+
+  if (registeredBranch !== null) {
+    if (registeredBranch === 'HEAD') {
+      return branchExists ? { kind: 'attach-existing' } : { kind: 'attach-detached' }
+    }
+    if (registeredBranch !== '') {
+      return registeredBranch === targetBranch
+        ? { kind: 'reuse' }
+        : { kind: 'conflict', reason: `目标路径已检出其他分支: ${registeredBranch}` }
+    }
+  }
+
+  if (pathExists && !pathEmpty) {
+    return { kind: 'conflict', reason: '目标路径是未注册的非空目录,拒绝覆盖' }
+  }
+  return branchExists ? { kind: 'add-existing-branch' } : { kind: 'add-new-branch' }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -746,9 +746,11 @@ async function postReviewComment(ctx: Context, issueUrl: string, passed: boolean
   const body = passed
     ? '## ✅ ClickVibe Review 通过\n\n自动 review 未发现问题。'
     : `## ❌ ClickVibe Review 发现问题(${issues.length} 条)\n\n${issues.map((i) => `- ${i}`).join('\n')}`
-  const command = `gh issue comment ${JSON.stringify(issueUrl)} --body ${JSON.stringify(body)}`
+  // body 走 stdin(--body-file -),避免 shell 转义破坏反引号/换行;
+  // URL 用单引号安全引用(与 develop.ts 的 shellQuote 一致)。
+  const command = `gh issue comment '${issueUrl.replaceAll("'", "'\\''")}' --body-file -`
   try {
-    await runCommand(ctx, command, { timeoutMs: 30000 })
+    await runCommand(ctx, command, { stdin: body, timeoutMs: 30000 })
   } catch {
     // posting is best-effort
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -286,7 +286,7 @@ export function apply(ctx: Context): void {
 async function fetchIssue(
   ctx: Context,
   payload: unknown,
-): Promise<{ ok: true; data: { kind: 'issue' | 'pr'; item: unknown } } | { ok: false; error: string }> {
+): Promise<{ ok: true; data: { kind: 'issue' | 'pr'; item: unknown; timeline?: unknown } } | { ok: false; error: string }> {
   const url = String((payload as { url?: unknown } | undefined)?.url ?? '').trim()
   const parsed = parseUrl(url)
   if (!parsed) {
@@ -302,9 +302,28 @@ async function fetchIssue(
       return { ok: false, error: stderr || `gh 执行失败(exit ${result.exitCode})` }
     }
     const parsedJson = JSON.parse(result.stdout.text) as unknown
-    return { ok: true, data: { kind: parsed.kind, item: parsedJson } }
+    const data: { kind: 'issue' | 'pr'; item: unknown; timeline?: unknown } = { kind: parsed.kind, item: parsedJson }
+    // issue 额外拉 timeline,提取关联事件(linked PR/commit)——GitHub UI 的
+    // "linked a pull request" 就来自 cross-referenced 事件
+    if (!isPR) {
+      data.timeline = await fetchTimeline(ctx, parsed.owner, parsed.repo, parsed.number)
+    }
+    return { ok: true, data }
   } catch (error) {
     return { ok: false, error: `抓取异常: ${String(error instanceof Error ? error.message : error)}` }
+  }
+}
+
+/** Fetch the issue timeline and keep only the events worth showing. */
+async function fetchTimeline(ctx: Context, owner: string, repo: string, number: string): Promise<unknown[]> {
+  const command = `gh api repos/${owner}/${repo}/issues/${number}/timeline -H "Accept: application/vnd.github+json" --jq '[.[] | select(.event == "cross-referenced" or .event == "referenced" or .event == "connected" or .event == "closed" or .event == "reopened") | {event, created_at, actor: .actor.login, commit_id, source: (if .source then {number: .source.issue.number, title: .source.issue.title, html_url: .source.issue.html_url, state: .source.issue.state} else null end)}]'`
+  try {
+    const spec = ctx.shell.resolve({ command, timeoutMs: 15000 })
+    const result = await ctx.shell.run(spec)
+    if (result.exitCode !== 0) return []
+    return JSON.parse(result.stdout.text) as unknown[]
+  } catch {
+    return []
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -948,12 +948,9 @@ async function startReview(
   workflow.stage = 'reviewing'
   await saveWorkflow(workflow)
 
-  // review 与 dev 同规则:同 agent 且上次有会话 id 才续会话(精确 id,不用 --last);
-  // 跨 agent 不续(换 codex/claude 就该重新审,且 session id 是 agent 私有的);
-  // 没有可续的会话则新开会话。
-  const sessionId = workflow.reviewSessionId && workflow.reviewAgent === agent
-    ? workflow.reviewSessionId
-    : null
+  // review 与 dev 同规则:有上次会话 id 就续会话(精确 id,不用 --last)。
+  // UI 已保证按钮只显示上次 review 的 agent,所以这里不需要再判断 agent 一致。
+  const sessionId = workflow.reviewSessionId
   let agentCommand: string
   if (agent === 'claude') {
     agentCommand = sessionId

--- a/src/index.ts
+++ b/src/index.ts
@@ -782,6 +782,9 @@ async function startDevelop(
           if (exitCode === 0) {
             reloaded.stage = 'review-ready'
             reloaded.devInterrupted = false
+            // 开发完成(含 rework):旧的 review 结论已归档到 events 历史,
+            // 当前回到"待 review"——不能继续显示"Review 未通过"
+            reloaded.reviewResult = null
             // 记录 agent 会话 id(供续会话精确恢复,不用 --last)
             if (sessionId) reloaded.devSessionId = sessionId
             // 检测关联 PR:开发可能创建了 PR,记录到 workflow(issue 为 key,PR 是产物)

--- a/src/index.ts
+++ b/src/index.ts
@@ -530,14 +530,16 @@ async function ensureWorktree(ctx: Context, parsed: { owner: string; repo: strin
       reviewSessionId: null,
       reviewResult: null,
       prNumber: null,
+      baseRef: null,
       updatedAt: Date.now(),
       events: [],
     }
   }
-  // 旧状态文件兜底:补 events / reviewSessionId / prNumber 字段
+  // 旧状态文件兜底:补 events / reviewSessionId / prNumber / baseRef 字段
   if (!Array.isArray(workflow.events)) workflow.events = []
   if (workflow.reviewSessionId === undefined) workflow.reviewSessionId = null
   if (workflow.prNumber === undefined) workflow.prNumber = null
+  if (workflow.baseRef === undefined) workflow.baseRef = null
   // 校正路径字段(配置可能变化)
   workflow.worktree = worktree
   workflow.branch = branch
@@ -608,6 +610,18 @@ async function ensureWorktree(ctx: Context, parsed: { owner: string; repo: strin
     await appendLog(workflow.key, 'dev', recovery.kind === 'add-new-branch'
       ? `[clickvibe] worktree 与分支创建完成`
       : `[clickvibe] 已从现有分支恢复 worktree`)
+  }
+
+  // 记录开发基线:首次开发时记下主仓库的分支 + HEAD(开 worktree 的来源)
+  if (!workflow.baseRef) {
+    const baseBranch = await runCommand(
+      ctx,
+      'git rev-parse --abbrev-ref HEAD; git rev-parse --short HEAD',
+      { workdir: expandedRepo, timeoutMs: 10000, sandboxPolicy: policy },
+    ).catch(() => '')
+    const [branchName = '', headHash = ''] = baseBranch.split('\n')
+    workflow.baseRef = `${branchName} @ ${headHash}`.trim()
+    await appendLog(workflow.key, 'dev', `[clickvibe] 开发基线: ${workflow.baseRef}`)
   }
 
   await saveWorkflow(workflow)

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,7 @@ interface LiveTask {
   process?: ReturnType<Context['shell']['start']>
   lines: string[]          // 已解析的状态行(供 SSE 增量读取)
   closed: boolean
+  sessionId: string | null // 从事件流捕获的 agent 会话 id(续会话用)
 }
 
 const liveTasks = new Map<string, LiveTask>()
@@ -505,7 +506,7 @@ function attachAgentProcess(
   command: string,
   workdir: string,
   prompt: string,
-  onExit: (exitCode: number | null) => void,
+  onExit: (exitCode: number | null, sessionId: string | null) => void,
 ): void {
   const spec = ctx.shell.resolve({
     command,
@@ -521,11 +522,12 @@ function attachAgentProcess(
   const pump = setInterval(() => {
     const read = process.readOutput()
     if (read.delta !== '') {
-      const lines = parseAgentChunk(task.agent, read.delta)
-      for (const line of lines) {
+      const parsed = parseAgentChunk(task.agent, read.delta)
+      for (const line of parsed.lines) {
         task.lines.push(line.text)
         void appendLog(task.workflowKey, task.kind, line.text)
       }
+      if (parsed.sessionId) task.sessionId = parsed.sessionId
       if (read.lossy) {
         task.lines.push('[clickvibe] 输出被截断(日志过长)')
       }
@@ -537,7 +539,7 @@ function attachAgentProcess(
     clearInterval(pump)
     task.closed = true
     notifyTask(task.taskId)
-    onExit(process.exitCode)
+    onExit(process.exitCode, task.sessionId)
   })
 }
 
@@ -579,6 +581,7 @@ async function startDevelop(
     agent,
     lines: [],
     closed: false,
+    sessionId: null,
   }
   liveTasks.set(taskId, live)
   workflow.devAgent = agent
@@ -602,13 +605,15 @@ async function startDevelop(
         ? 'claude -p --verbose --output-format stream-json'
         : 'codex exec --json -'
 
-      attachAgentProcess(ctx, live, agentCommand, workflow.worktree, prompt, async (exitCode) => {
+      attachAgentProcess(ctx, live, agentCommand, workflow.worktree, prompt, async (exitCode, sessionId) => {
         await appendLog(workflow.key, 'dev', `[clickvibe] ${agent} 结束,退出码 ${exitCode}`)
         const reloaded = await loadWorkflow(workflow.key)
         if (reloaded) {
           if (exitCode === 0) {
             reloaded.stage = 'review-ready'
             reloaded.devInterrupted = false
+            // 记录 agent 会话 id(供续会话精确恢复,不用 --last)
+            if (sessionId) reloaded.devSessionId = sessionId
             // 记录开发提交事件:读 worktree HEAD 作为锚定哈希
             const head = await readWorktreeHead(ctx, workflow.worktree)
             await appendEvent(reloaded, {
@@ -739,6 +744,7 @@ async function startReview(
     agent,
     lines: [],
     closed: false,
+    sessionId: null,
   }
   liveTasks.set(taskId, live)
   workflow.reviewAgent = agent
@@ -841,21 +847,28 @@ async function postReviewComment(ctx: Context, issueUrl: string, passed: boolean
   }
 }
 
-/** Resume an interrupted dev session (codex exec resume / claude --continue). */
+/** Resume (or continue) a dev session with an exact session id; `context`
+ *  carries extra instructions (e.g. review issues for a rework). */
 async function resumeDevelop(
   ctx: Context,
   payload: unknown,
 ): Promise<{ ok: true; taskId: string } | { ok: false; error: string }> {
-  const body = (payload ?? {}) as { url?: unknown }
+  const body = (payload ?? {}) as { url?: unknown; context?: unknown }
   const url = String(body.url ?? '').trim()
+  const extraContext = typeof body.context === 'string' ? body.context.trim() : ''
   const parsed = parseUrl(url)
   if (!parsed || parsed.kind !== 'issue') {
     return { ok: false, error: '请输入形如 https://github.com/owner/repo/issues/123 的链接' }
   }
   const key = issueKey(`${parsed.owner}/${parsed.repo}`, parsed.number)
   const workflow = await loadWorkflow(key)
-  if (!workflow || !workflow.devInterrupted || !workflow.devTaskId) {
-    return { ok: false, error: '没有可恢复的中断任务' }
+  if (!workflow || !workflow.devTaskId) {
+    return { ok: false, error: '该 issue 尚无开发记录,无法续会话' }
+  }
+
+  // 没有记录会话 id(旧版本开发或会话已丢):回退到新开会话,但保留 context
+  if (!workflow.devSessionId) {
+    return await startDevelop(ctx, { url, agent: workflow.devAgent ?? 'codex', context: extraContext })
   }
 
   const oldLive = liveTasks.get(workflow.devTaskId)
@@ -871,6 +884,7 @@ async function resumeDevelop(
     agent: workflow.devAgent ?? 'codex',
     lines: [],
     closed: false,
+    sessionId: workflow.devSessionId,
   }
   liveTasks.set(taskId, live)
   workflow.devTaskId = taskId
@@ -878,22 +892,41 @@ async function resumeDevelop(
   workflow.stage = 'developing'
   await saveWorkflow(workflow)
 
-  // resume 需要会话 id(codex)或 --continue(claude);这里先尝试从日志找 session
-  const command = workflow.devAgent === 'claude'
-    ? 'claude -p --continue --verbose --output-format stream-json'
-    : 'codex exec --json --last -'
-  const prompt = '请继续完成刚才的开发任务。'
+  // 用精确会话 id 续会话(不能用 --last/--continue:worktree 里可能有多个
+  // agent 会话,--last 续的是"最近那个",不一定是我们这个)。
+  // sessionId 缺失时回退 --last/--continue(尽力而为)。
+  const agent = workflow.devAgent ?? 'codex'
+  const sessionId = workflow.devSessionId
+  let command: string
+  if (agent === 'claude') {
+    command = sessionId
+      ? `claude -p --resume ${shellQuoteId(sessionId)} --verbose --output-format stream-json`
+      : 'claude -p --continue --verbose --output-format stream-json'
+  } else {
+    command = sessionId
+      ? `codex exec resume ${shellQuoteId(sessionId)} --json -`
+      : 'codex exec --json --last -'
+  }
+  const prompt = extraContext !== ''
+    ? `请继续完成开发任务,并处理以下 review 意见:\n${extraContext}`
+    : '请继续完成刚才的开发任务。'
 
-  await appendLog(workflow.key, 'dev', `[clickvibe] 恢复 ${workflow.devAgent} 会话…`)
-  attachAgentProcess(ctx, live, command, workflow.worktree, prompt, async (exitCode) => {
-    await appendLog(workflow.key, 'dev', `[clickvibe] ${workflow.devAgent} 恢复结束,退出码 ${exitCode}`)
+  await appendLog(workflow.key, 'dev', `[clickvibe] 恢复 ${agent} 会话${sessionId ? `(${sessionId})` : ''}…`)
+  attachAgentProcess(ctx, live, command, workflow.worktree, prompt, async (exitCode, newSessionId) => {
+    await appendLog(workflow.key, 'dev', `[clickvibe] ${agent} 恢复结束,退出码 ${exitCode}`)
     const reloaded = await loadWorkflow(workflow.key)
     if (reloaded) {
       reloaded.stage = exitCode === 0 ? 'review-ready' : 'developing'
       reloaded.devInterrupted = exitCode !== 0
+      if (newSessionId) reloaded.devSessionId = newSessionId
       await saveWorkflow(reloaded)
     }
   })
 
   return { ok: true, taskId }
+}
+
+/** Quote an opaque id for a shell command (single-quote safe). */
+function shellQuoteId(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,6 +228,24 @@ async function readWorktreeHead(ctx: Context, worktree: string): Promise<string 
 }
 
 /**
+ * Detect the PR opened from a branch (via gh). Returns the PR number or null.
+ */
+async function detectLinkedPr(ctx: Context, repoKey: string, branch: string): Promise<string | null> {
+  try {
+    const spec = ctx.shell.resolve({
+      command: `gh pr list --repo ${repoKey} --head ${shellQuote(branch)} --state open --json number --jq '.[0].number // ""'`,
+      timeoutMs: 15000,
+    })
+    const result = await ctx.shell.run(spec)
+    if (result.exitCode !== 0) return null
+    const num = result.stdout.text.trim()
+    return num === '' ? null : num
+  } catch {
+    return null
+  }
+}
+
+/**
  * Derive the live state of a workflow from git facts + its event history.
  * The stored `stage`/`reviewResult` stay as-is; this adds `derived` with
  * the current worktree HEAD and whether commits exist beyond the last
@@ -398,20 +416,59 @@ function buildPrompt(item: Record<string, unknown>): string {
   ].join('\n')
 }
 
-/** Build the review prompt: review the dev branch diff against the issue. */
-function buildReviewPrompt(workflow: IssueWorkflow): string {
+/** Build the review prompt: review `git diff base...HEAD` against the issue.
+ *  base 取远端主干(origin/main 或 PR base),让 agent 用真实 diff 审查。 */
+async function buildReviewPrompt(ctx: Context, workflow: IssueWorkflow): Promise<string> {
+  // 解析 base:PR 有 baseRefName(若记录过),否则尝试 origin/HEAD 主干
+  let base = 'origin/main'
+  if (workflow.prNumber) {
+    const baseRef = await fetchPrBase(ctx, workflow.repoKey, workflow.prNumber)
+    if (baseRef) base = `origin/${baseRef}`
+  }
   return [
-    `请 review 分支 ${workflow.branch} 相对其 base 的代码改动,对照 issue:`,
+    `请 review 分支 ${workflow.branch} 的代码改动(相对 base ${base}),对照 issue:`,
     workflow.url,
     '',
     '要求:',
-    '1. 用 git diff 查看改动(相对主干)',
+    `1. 先执行 git diff ${base}...HEAD 查看完整改动(在 worktree 内)`,
     '2. 检查:需求是否完整实现、是否有 bug/安全隐患、测试是否覆盖',
     '3. 不要修改任何文件,只做只读 review',
     '4. 最后一行必须输出一个 JSON 对象(单独一行,不要包裹在代码块里),格式:',
     '{"passed": true|false, "issues": ["问题1(含文件/位置/原因)", "问题2", ...]}',
     '   passed=true 表示无问题;有任意问题则 passed=false 并列出全部。',
   ].join('\n')
+}
+
+/** Fetch a PR's base ref name via gh. */
+async function fetchPrBase(ctx: Context, repoKey: string, prNumber: string): Promise<string | null> {
+  try {
+    const spec = ctx.shell.resolve({
+      command: `gh pr view ${prNumber} --repo ${repoKey} --json baseRefName --jq '.baseRefName // ""'`,
+      timeoutMs: 15000,
+    })
+    const result = await ctx.shell.run(spec)
+    if (result.exitCode !== 0) return null
+    const name = result.stdout.text.trim()
+    return name === '' ? null : name
+  } catch {
+    return null
+  }
+}
+
+/** Fetch a PR's head branch name via gh (to locate its worktree). */
+async function fetchPrHeadBranch(ctx: Context, owner: string, repo: string, prNumber: string): Promise<string | null> {
+  try {
+    const spec = ctx.shell.resolve({
+      command: `gh pr view ${prNumber} --repo ${owner}/${repo} --json headRefName --jq '.headRefName // ""'`,
+      timeoutMs: 15000,
+    })
+    const result = await ctx.shell.run(spec)
+    if (result.exitCode !== 0) return null
+    const name = result.stdout.text.trim()
+    return name === '' ? null : name
+  } catch {
+    return null
+  }
 }
 
 /** Extract the final JSON verdict object from review log lines. */
@@ -472,13 +529,15 @@ async function ensureWorktree(ctx: Context, parsed: { owner: string; repo: strin
       reviewTaskId: null,
       reviewSessionId: null,
       reviewResult: null,
+      prNumber: null,
       updatedAt: Date.now(),
       events: [],
     }
   }
-  // 旧状态文件兜底:补 events / reviewSessionId 字段
+  // 旧状态文件兜底:补 events / reviewSessionId / prNumber 字段
   if (!Array.isArray(workflow.events)) workflow.events = []
   if (workflow.reviewSessionId === undefined) workflow.reviewSessionId = null
+  if (workflow.prNumber === undefined) workflow.prNumber = null
   // 校正路径字段(配置可能变化)
   workflow.worktree = worktree
   workflow.branch = branch
@@ -692,6 +751,11 @@ async function startDevelop(
             reloaded.devInterrupted = false
             // 记录 agent 会话 id(供续会话精确恢复,不用 --last)
             if (sessionId) reloaded.devSessionId = sessionId
+            // 检测关联 PR:开发可能创建了 PR,记录到 workflow(issue 为 key,PR 是产物)
+            if (!reloaded.prNumber) {
+              const pr = await detectLinkedPr(ctx, workflow.repoKey, workflow.branch)
+              if (pr) reloaded.prNumber = pr
+            }
             // 记录开发提交事件:读 worktree HEAD 作为锚定哈希
             const head = await readWorktreeHead(ctx, workflow.worktree)
             await appendEvent(reloaded, {
@@ -799,19 +863,37 @@ async function startReview(
   const agent: AgentKind = agentRaw === 'claude' ? 'claude' : 'codex'
   const parsed = parseUrl(url)
   if (!parsed) {
-    return { ok: false, error: '请输入形如 https://github.com/owner/repo/issues/123 的链接' }
-  }
-  if (parsed.kind !== 'issue') {
-    return { ok: false, error: 'review 仅支持 issue 链接' }
+    return { ok: false, error: '请输入形如 https://github.com/owner/repo/issues/123 或 /pull/123 的链接' }
   }
 
-  const key = issueKey(`${parsed.owner}/${parsed.repo}`, parsed.number)
-  const workflow = await loadWorkflow(key)
+  // 定位 workflow:issue URL → 直接按 key;PR URL → 按 prNumber 或 head 分支反查
+  let workflow: IssueWorkflow | null = null
+  if (parsed.kind === 'issue') {
+    const key = issueKey(`${parsed.owner}/${parsed.repo}`, parsed.number)
+    workflow = await loadWorkflow(key)
+  } else {
+    // PR:先按已记录的 prNumber 找,再按 head 分支找(可能尚未记录)
+    const all = await loadAllWorkflows()
+    const repoKey = `${parsed.owner}/${parsed.repo}`
+    workflow = all.find((w) => w.repoKey === repoKey && w.prNumber === parsed.number) ?? null
+    if (!workflow) {
+      const prInfo = await fetchPrHeadBranch(ctx, parsed.owner, parsed.repo, parsed.number)
+      if (prInfo) {
+        workflow = all.find((w) => w.repoKey === repoKey && w.branch === prInfo) ?? null
+      }
+    }
+  }
+
   if (!workflow || workflow.stage === 'idle' || workflow.stage === 'developing') {
     return { ok: false, error: '该 issue 尚未完成开发,无法 review' }
   }
   if (!existsSync(workflow.worktree)) {
     return { ok: false, error: `worktree 不存在: ${workflow.worktree}` }
+  }
+  // 记录关联 PR(若 review 的是 PR 且未记录)
+  if (parsed.kind === 'pr' && !workflow.prNumber) {
+    workflow.prNumber = parsed.number
+    await saveWorkflow(workflow)
   }
 
   const taskId = `review-${Date.now()}`
@@ -846,7 +928,7 @@ async function startReview(
   }
   const prompt = sessionId
     ? '请继续 review。代码已更新,请先确认之前发现的问题是否已解决,再审查新改动,最后输出同样的 JSON 结论。'
-    : buildReviewPrompt(workflow)
+    : await buildReviewPrompt(ctx, workflow)
 
   await appendLog(workflow.key, 'review', `[clickvibe] 启动 ${agent} review${sessionId ? `(续会话 ${sessionId})` : ''}…`)
   attachAgentProcess(ctx, live, agentCommand, workflow.worktree, prompt, async (exitCode, newSessionId) => {
@@ -873,8 +955,12 @@ async function startReview(
         note: `${agent} review${passed ? ' 通过' : ` 发现 ${issues.length} 个问题`}`,
       })
       await saveWorkflow(reloaded)
-      // 发到 GitHub issue 评论
-      void postReviewComment(ctx, workflow.url, passed, issues)
+      // 发评论:有 PR 则发到 PR 评论(review 对象是代码/PR),否则发 issue
+      if (reloaded.prNumber) {
+        void postReviewComment(ctx, `https://github.com/${workflow.repoKey}/pull/${reloaded.prNumber}`, passed, issues)
+      } else {
+        void postReviewComment(ctx, workflow.url, passed, issues)
+      }
     }
   })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -469,13 +469,15 @@ async function ensureWorktree(ctx: Context, parsed: { owner: string; repo: strin
       devInterrupted: false,
       reviewAgent: null,
       reviewTaskId: null,
+      reviewSessionId: null,
       reviewResult: null,
       updatedAt: Date.now(),
       events: [],
     }
   }
-  // 旧状态文件兜底:补 events 字段
+  // 旧状态文件兜底:补 events / reviewSessionId 字段
   if (!Array.isArray(workflow.events)) workflow.events = []
+  if (workflow.reviewSessionId === undefined) workflow.reviewSessionId = null
   // 校正路径字段(配置可能变化)
   workflow.worktree = worktree
   workflow.branch = branch
@@ -744,7 +746,7 @@ async function startReview(
     agent,
     lines: [],
     closed: false,
-    sessionId: null,
+    sessionId: workflow.reviewSessionId,
   }
   liveTasks.set(taskId, live)
   workflow.reviewAgent = agent
@@ -752,13 +754,26 @@ async function startReview(
   workflow.stage = 'reviewing'
   await saveWorkflow(workflow)
 
-  const prompt = buildReviewPrompt(workflow)
-  const agentCommand = agent === 'claude'
-    ? 'claude -p --verbose --output-format stream-json'
-    : 'codex exec --json -'
+  // review 与 dev 同规则:有上次会话 id 就续会话(精确 id,不用 --last),
+  // 续会话时提示"代码已更新,检查之前的问题是否已解决并审查新改动";
+  // 没有会话 id 则新开会话。
+  const sessionId = workflow.reviewSessionId
+  let agentCommand: string
+  if (agent === 'claude') {
+    agentCommand = sessionId
+      ? `claude -p --resume ${shellQuoteId(sessionId)} --verbose --output-format stream-json`
+      : 'claude -p --verbose --output-format stream-json'
+  } else {
+    agentCommand = sessionId
+      ? `codex exec resume ${shellQuoteId(sessionId)} --json -`
+      : 'codex exec --json -'
+  }
+  const prompt = sessionId
+    ? '请继续 review。代码已更新,请先确认之前发现的问题是否已解决,再审查新改动,最后输出同样的 JSON 结论。'
+    : buildReviewPrompt(workflow)
 
-  await appendLog(workflow.key, 'review', `[clickvibe] 启动 ${agent} review…`)
-  attachAgentProcess(ctx, live, agentCommand, workflow.worktree, prompt, async (exitCode) => {
+  await appendLog(workflow.key, 'review', `[clickvibe] 启动 ${agent} review${sessionId ? `(续会话 ${sessionId})` : ''}…`)
+  attachAgentProcess(ctx, live, agentCommand, workflow.worktree, prompt, async (exitCode, newSessionId) => {
     await appendLog(workflow.key, 'review', `[clickvibe] review 结束,退出码 ${exitCode}`)
     // 优先用 agent 输出的 JSON 结论(完整、不受截断/分块影响);
     // JSON 缺失时回退到 ❌/✅ 文本判定。
@@ -770,6 +785,8 @@ async function startReview(
     if (reloaded) {
       reloaded.reviewResult = { passed, issues }
       reloaded.stage = passed ? 'passed' : 'review-ready' // 有问题 → 可回开发(rework)
+      // 记录 review 会话 id(供下次 review 续会话)
+      if (newSessionId) reloaded.reviewSessionId = newSessionId
       // 记录 review 历史事件:锚定被 review 的 HEAD
       const reviewedHead = await readWorktreeHead(ctx, workflow.worktree)
       await appendEvent(reloaded, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,9 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import { readFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { join, basename } from 'node:path'
+import { join, basename, dirname, resolve } from 'node:path'
 import { parse as parseYaml } from 'yaml'
+import { decideWorktreeRecovery, shellQuote } from './develop.ts'
 import {
   appendEvent,
   appendLog,
@@ -482,23 +483,98 @@ async function ensureWorktree(ctx: Context, parsed: { owner: string; repo: strin
   workflow.worktree = worktree
   workflow.branch = branch
 
-  // 幂等建 worktree(无沙箱:git 需要写主仓库 .git/refs)
-  if (!existsSync(worktree)) {
-    await appendLog(workflow.key, 'dev', `[clickvibe] 创建 worktree: ${worktree}`)
-    await runCommand(
-      ctx,
-      `git worktree add ${JSON.stringify(worktree)} -b ${JSON.stringify(branch)}`,
-      {
-        workdir: expandedRepo,
-        timeoutMs: 60000,
-        sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: expandedRepo },
-      },
-    )
-    await appendLog(workflow.key, 'dev', `[clickvibe] worktree 创建完成`)
+  // 幂等建 worktree:用完整恢复决策(处理 reuse/attach/conflict/重建),
+  // 而不是简单判断目录是否存在。git 操作需要无沙箱(写主仓库 .git/refs)。
+  const policy = { mode: 'danger-full-access' as const, workspaceRoot: expandedRepo }
+  const listOut = await runCommand(ctx, 'git worktree list --porcelain', { workdir: expandedRepo, sandboxPolicy: policy, timeoutMs: 15000 })
+  const records = parseWorktreeList(listOut)
+  const normalizedTarget = resolve(worktree)
+  const atPath = records.find((r) => r.path === normalizedTarget)
+  const atBranch = records.find((r) => r.branch === branch)
+  const pathExists = existsSync(normalizedTarget)
+  let pathEmpty = false
+  if (pathExists) {
+    const { readdir } = await import('node:fs/promises')
+    pathEmpty = (await readdir(normalizedTarget)).length === 0
+  }
+  const branchOut = await runCommand(
+    ctx,
+    `git show-ref --verify --quiet ${shellQuote(`refs/heads/${branch}`)}; echo $?`,
+    { workdir: expandedRepo, sandboxPolicy: policy, timeoutMs: 15000 },
+  )
+  const branchExists = branchOut.trim() === '0'
+  const recovery = decideWorktreeRecovery({
+    targetBranch: branch,
+    pathExists,
+    pathEmpty,
+    registeredBranch: atPath?.branch ?? null,
+    branchExists,
+    branchWorktree: atBranch?.path ?? null,
+  })
+
+  if (recovery.kind === 'conflict') {
+    await appendLog(workflow.key, 'dev', `[clickvibe] worktree 冲突: ${recovery.reason}`)
+    return { ok: false, error: `worktree 冲突: ${recovery.reason}` }
+  }
+
+  if (recovery.kind === 'reuse') {
+    await appendLog(workflow.key, 'dev', `[clickvibe] worktree 已存在,复用`)
+  } else if (recovery.kind === 'attach-detached') {
+    await runCommand(ctx, `git switch -c ${shellQuote(branch)}`, { workdir: normalizedTarget, timeoutMs: 60000, sandboxPolicy: policy })
+    await appendLog(workflow.key, 'dev', `[clickvibe] 已为 detached worktree 创建目标分支`)
+  } else if (recovery.kind === 'attach-existing') {
+    await runCommand(ctx, `git switch ${shellQuote(branch)}`, { workdir: normalizedTarget, timeoutMs: 60000, sandboxPolicy: policy })
+    await appendLog(workflow.key, 'dev', `[clickvibe] 已将 detached worktree 切换到现有目标分支`)
+  } else if (recovery.kind === 'repair') {
+    // stale 注册:先清理 git 注册记录(路径为空时可顺带删空目录),再重建
+    await appendLog(workflow.key, 'dev', `[clickvibe] 修复 stale 注册: ${recovery.reason}`)
+    if (pathExists && pathEmpty) {
+      const { rmdir } = await import('node:fs/promises')
+      await rmdir(normalizedTarget).catch(() => { /* 非空时忽略,交给 git */ })
+    }
+    await runCommand(ctx, `git worktree remove --force ${shellQuote(normalizedTarget)}`, { workdir: expandedRepo, timeoutMs: 60000, sandboxPolicy: policy }).catch(() => { /* 记录已不在也忽略 */ })
+    const { mkdir } = await import('node:fs/promises')
+    await mkdir(dirname(normalizedTarget), { recursive: true })
+    const branchArg = branchExists ? shellQuote(branch) : `-b ${shellQuote(branch)}`
+    await runCommand(ctx, `git worktree add ${shellQuote(normalizedTarget)} ${branchArg}`, { workdir: expandedRepo, timeoutMs: 60000, sandboxPolicy: policy })
+    await appendLog(workflow.key, 'dev', `[clickvibe] stale worktree 已重建`)
+  } else {
+    // add-new-branch / add-existing-branch:确保父目录存在后创建/复用
+    const { mkdir } = await import('node:fs/promises')
+    await mkdir(dirname(normalizedTarget), { recursive: true })
+    const branchArg = recovery.kind === 'add-new-branch'
+      ? `-b ${shellQuote(branch)}`
+      : shellQuote(branch)
+    await runCommand(ctx, `git worktree add ${shellQuote(normalizedTarget)} ${branchArg}`, { workdir: expandedRepo, timeoutMs: 60000, sandboxPolicy: policy })
+    await appendLog(workflow.key, 'dev', recovery.kind === 'add-new-branch'
+      ? `[clickvibe] worktree 与分支创建完成`
+      : `[clickvibe] 已从现有分支恢复 worktree`)
   }
 
   await saveWorkflow(workflow)
   return { ok: true, workflow, worktree, branch }
+}
+
+/** Parse `git worktree list --porcelain` output into { path, branch } records. */
+function parseWorktreeList(output: string): { path: string; branch: string | null }[] {
+  const records: { path: string; branch: string | null }[] = []
+  let current: { path: string; branch: string | null } | null = null
+  for (const line of output.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed === '') {
+      if (current) { records.push(current); current = null }
+      continue
+    }
+    if (trimmed.startsWith('worktree ')) {
+      current = { path: trimmed.slice('worktree '.length), branch: null }
+    } else if (trimmed.startsWith('branch ') && current) {
+      current.branch = trimmed.slice('branch refs/heads/'.length)
+    } else if (trimmed.startsWith('detached') && current) {
+      current.branch = 'HEAD'
+    }
+  }
+  if (current) records.push(current)
+  return records
 }
 
 /** Start (or restart) a dev task in the live map with status parsing. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1145,6 +1145,19 @@ async function resumeDevelop(
       reloaded.stage = exitCode === 0 ? 'review-ready' : 'developing'
       reloaded.devInterrupted = exitCode !== 0
       if (newSessionId) reloaded.devSessionId = newSessionId
+      if (exitCode === 0) {
+        // rework 完成:旧的 review 结论已归档到 events,回到"待 review",
+        // 不能继续显示"Review 未通过"让用户无限重复点
+        reloaded.reviewResult = null
+        // 记录 rework 事件(带新 HEAD)
+        const head = await readWorktreeHead(ctx, workflow.worktree)
+        await appendEvent(reloaded, {
+          kind: 'rework',
+          at: new Date().toISOString(),
+          hash: head ?? undefined,
+          note: `${agent} 完成 rework(按 review 意见)`,
+        })
+      }
       await saveWorkflow(reloaded)
     }
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -948,10 +948,12 @@ async function startReview(
   workflow.stage = 'reviewing'
   await saveWorkflow(workflow)
 
-  // review 与 dev 同规则:有上次会话 id 就续会话(精确 id,不用 --last),
-  // 续会话时提示"代码已更新,检查之前的问题是否已解决并审查新改动";
-  // 没有会话 id 则新开会话。
-  const sessionId = workflow.reviewSessionId
+  // review 与 dev 同规则:同 agent 且上次有会话 id 才续会话(精确 id,不用 --last);
+  // 跨 agent 不续(换 codex/claude 就该重新审,且 session id 是 agent 私有的);
+  // 没有可续的会话则新开会话。
+  const sessionId = workflow.reviewSessionId && workflow.reviewAgent === agent
+    ? workflow.reviewSessionId
+    : null
   let agentCommand: string
   if (agent === 'claude') {
     agentCommand = sessionId

--- a/src/index.ts
+++ b/src/index.ts
@@ -393,8 +393,8 @@ async function fetchTimeline(ctx: Context, owner: string, repo: string, number: 
   }
 }
 
-/** Build the development prompt from issue/PR data. */
-function buildPrompt(item: Record<string, unknown>): string {
+/** Build the development prompt from issue/PR data + the worktree path. */
+function buildPrompt(item: Record<string, unknown>, worktreePath: string): string {
   const comments = Array.isArray(item.comments)
     ? (item.comments as { author?: { login?: string } | null; body?: string }[])
         .map((c) => `@${c.author?.login ?? 'unknown'}: ${c.body ?? ''}`)
@@ -404,10 +404,14 @@ function buildPrompt(item: Record<string, unknown>): string {
     `请开发这个 GitHub ${item.url?.toString().includes('/pull/') ? 'PR' : 'issue'}: ${item.title ?? ''}`,
     String(item.url ?? ''),
     '',
+    `工作区(worktree): ${worktreePath}`,
+    '',
     '--- issue 正文 ---',
     String(item.body ?? ''),
     comments ? '--- 评论 ---\n' + comments : '',
     '--- 要求 ---',
+    '0. 先执行 git fetch origin 同步远端,并检查 base(默认 origin/main)是否有更新;',
+    '   并行开发时 base 会变化,若已有更新先合并/变基到最新再开始开发',
     '1. 先理解需求,如有歧义可自行判断或提问',
     '2. 实现代码改动',
     '3. 运行相关测试',
@@ -429,8 +433,11 @@ async function buildReviewPrompt(ctx: Context, workflow: IssueWorkflow): Promise
     `请 review 分支 ${workflow.branch} 的代码改动(相对 base ${base}),对照 issue:`,
     workflow.url,
     '',
+    `工作区(worktree): ${workflow.worktree}`,
+    '',
     '要求:',
-    `1. 先执行 git diff ${base}...HEAD 查看完整改动(在 worktree 内)`,
+    `0. 先执行 git fetch origin 同步远端最新状态(并行开发时 base 可能已变化)`,
+    `1. 再执行 git diff ${base}...HEAD 查看完整改动(在 worktree 内)`,
     '2. 检查:需求是否完整实现、是否有 bug/安全隐患、测试是否覆盖',
     '3. 不要修改任何文件,只做只读 review',
     '4. 最后一行必须输出一个 JSON 对象(单独一行,不要包裹在代码块里),格式:',
@@ -746,7 +753,19 @@ async function startDevelop(
       await appendLog(workflow.key, 'dev', `[clickvibe] 抓取 issue 数据…`)
       const fetchResult = await fetchIssue(ctx, { url })
       if (!fetchResult.ok) throw new Error(fetchResult.error)
-      let prompt = buildPrompt(fetchResult.data.item as Record<string, unknown>)
+      // Host 侧先同步远端(并行开发时 base 会变化,确保 agent 从最新基线开发)
+      try {
+        await runCommand(ctx, 'git fetch origin', {
+          workdir: workflow.worktree,
+          timeoutMs: 30000,
+          sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: workflow.worktree },
+        })
+        await appendLog(workflow.key, 'dev', `[clickvibe] 已同步远端(origin)`)
+      } catch (e) {
+        await appendLog(workflow.key, 'dev', `[clickvibe] git fetch 失败(继续): ${String(e instanceof Error ? e.message : e)}`)
+      }
+
+      let prompt = buildPrompt(fetchResult.data.item as Record<string, unknown>, workflow.worktree)
       if (extraContext !== '') {
         prompt += '\n\n--- 附加上下文(来自 review 或其他) ---\n' + extraContext
       }
@@ -1100,6 +1119,18 @@ async function resumeDevelop(
       ? `codex exec resume ${shellQuoteId(sessionId)} --json -`
       : 'codex exec --json --last -'
   }
+  // 续会话前也同步远端(并行开发时 base 会变化)
+  try {
+    await runCommand(ctx, 'git fetch origin', {
+      workdir: workflow.worktree,
+      timeoutMs: 30000,
+      sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: workflow.worktree },
+    })
+    await appendLog(workflow.key, 'dev', `[clickvibe] 已同步远端(origin)`)
+  } catch (e) {
+    await appendLog(workflow.key, 'dev', `[clickvibe] git fetch 失败(继续): ${String(e instanceof Error ? e.message : e)}`)
+  }
+
   const prompt = extraContext !== ''
     ? `请继续完成开发任务,并处理以下 review 意见:\n${extraContext}`
     : '请继续完成刚才的开发任务。'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,20 @@
-/** ClickVibe Host routes: GitHub fetch plus issue development tasks. */
+/**
+ * clickvibe host half:
+ * - `/clickvibe/api/fetch` — fetch GitHub issue/PR data via gh,
+ * - `/clickvibe/api/develop` — start a development task: create a git
+ *   worktree + branch for the issue's repo, then run codex/claude
+ *   non-interactively inside it,
+ * - `/clickvibe/api/develop/poll` — consume incremental task log/status.
+ *
+ * Config lives at ~/.clickvibe/config.yaml (see project README).
+ */
 import type { Context } from '@deepseek-ai/cordis'
-import { existsSync } from 'node:fs'
-import { mkdir, readFile, readdir } from 'node:fs/promises'
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import { readFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { basename, dirname, join, resolve } from 'node:path'
+import { join, basename } from 'node:path'
 import { parse as parseYaml } from 'yaml'
-import {
-  LineLog,
-  decideWorktreeRecovery,
-  parseAgent,
-  parseGithubUrl,
-  shellQuote,
-  type DevelopAgent,
-} from './develop.js'
 
 declare module '@deepseek-ai/cordis' {
   interface Context {
@@ -28,13 +29,9 @@ declare module '@deepseek-ai/cordis' {
       resolve(request: {
         command: string
         timeoutMs?: number
-        stdoutMaxBytes?: number
         workdir?: string
         stdin?: string
-        sandboxPolicy?: {
-          mode: 'read-only' | 'workspace-write' | 'danger-full-access'
-          workspaceRoot: string
-        }
+        sandboxPolicy?: { mode: 'read-only' | 'workspace-write' | 'danger-full-access'; workspaceRoot: string }
       }): unknown
       run(spec: unknown): Promise<{
         exitCode: number | null
@@ -52,17 +49,20 @@ declare module '@deepseek-ai/cordis' {
   }
 }
 
+/** Prefix route owning every /clickvibe/api/<method> request. */
 const ROUTE = '/clickvibe/api'
-const MAX_BODY_BYTES = 64 * 1024
-const MAX_LOG_LINES = 2_000
-const OUTPUT_PUMP_MS = 200
 
+/** Body size bound of one JSON request (defense against unbounded reads). */
+const MAX_BODY_BYTES = 64 * 1024
+
+/** Fields the issue fetch requests from gh (all verified against rc.8). */
 const ISSUE_FIELDS = [
   'number', 'title', 'state', 'stateReason', 'author', 'createdAt',
   'updatedAt', 'closedAt', 'body', 'url', 'labels', 'assignees',
   'milestone', 'comments', 'reactionGroups', 'isPinned',
 ].join(',')
 
+/** Fields the PR fetch requests from gh (all verified against rc.8). */
 const PR_FIELDS = [
   'number', 'title', 'state', 'author', 'createdAt', 'updatedAt',
   'closedAt', 'mergedAt', 'body', 'url', 'labels', 'assignees',
@@ -76,57 +76,57 @@ interface ClickVibeConfig {
   worktreeRoot: string
 }
 
-interface DevTask {
-  id: string
-  repo: string
-  number: string
-  worktree: string
-  branch: string
-  agent: DevelopAgent
-  status: 'creating' | 'running' | 'done' | 'failed'
-  exitCode: number | null
-  log: LineLog
-  process?: ReturnType<Context['shell']['start']>
-}
-
-interface WorktreeRecord {
-  path: string
-  branch: string
-}
-
-const tasks = new Map<string, DevTask>()
-
+/** Expand a leading `~` in a path to the user's home directory. */
 function expandHome(path: string): string {
   if (path === '~') return homedir()
   if (path.startsWith('~/')) return join(homedir(), path.slice(2))
   return path
 }
 
+/** Read and parse ~/.clickvibe/config.yaml; missing/invalid yields a default. */
 async function loadConfig(): Promise<ClickVibeConfig> {
-  const configPath = join(homedir(), '.clickvibe', 'config.yaml')
+  const path = join(homedir(), '.clickvibe', 'config.yaml')
   try {
-    const parsed = parseYaml(await readFile(configPath, 'utf8')) as Partial<ClickVibeConfig> | null
-    if (parsed?.repos !== undefined && (typeof parsed.repos !== 'object' || parsed.repos === null
-      || Object.values(parsed.repos).some((value) => typeof value !== 'string'))) {
-      throw new Error('repos 必须是 owner/repo 到本地路径的字符串映射')
-    }
-    if (parsed?.worktreeRoot !== undefined && typeof parsed.worktreeRoot !== 'string') {
-      throw new Error('worktreeRoot 必须是字符串路径')
-    }
+    const raw = await readFile(path, 'utf8')
+    const parsed = parseYaml(raw) as Partial<ClickVibeConfig> | null
     return {
       repos: parsed?.repos ?? {},
-      worktreeRoot: resolve(expandHome(parsed?.worktreeRoot ?? join(homedir(), '.clickvibe', 'worktrees'))),
+      worktreeRoot: parsed?.worktreeRoot ? expandHome(parsed.worktreeRoot) : join(homedir(), '.clickvibe', 'worktrees'),
     }
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return { repos: {}, worktreeRoot: join(homedir(), '.clickvibe', 'worktrees') }
+  } catch {
+    return {
+      repos: {},
+      worktreeRoot: join(homedir(), '.clickvibe', 'worktrees'),
     }
-    throw new Error(`读取 ${configPath} 失败: ${String(error instanceof Error ? error.message : error)}`)
   }
 }
 
+/** One in-flight development task. */
+interface DevTask {
+  id: string
+  repo: string
+  number: string
+  worktree: string
+  branch: string
+  agent: 'codex' | 'claude'
+  status: 'creating' | 'running' | 'done' | 'failed'
+  exitCode: number | null
+  log: string[]
+  process?: ReturnType<Context['shell']['start']>
+}
+
+const tasks = new Map<string, DevTask>()
+
+/** Extract owner/repo and issue number from a GitHub issue/PR URL. */
+function parseUrl(url: string): { kind: 'issue' | 'pr'; owner: string; repo: string; number: string } | null {
+  const m = url.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/(issues|pull)\/(\d+)/)
+  if (!m) return null
+  return { kind: m[3] === 'pull' ? 'pr' : 'issue', owner: m[1], repo: m[2], number: m[4] }
+}
+
+/** Read the (bounded) JSON request body. */
 function readJsonBody(req: IncomingMessage): Promise<unknown> {
-  return new Promise((resolveBody, reject) => {
+  return new Promise((resolve, reject) => {
     const chunks: Buffer[] = []
     let total = 0
     req.on('data', (chunk: Buffer) => {
@@ -139,9 +139,9 @@ function readJsonBody(req: IncomingMessage): Promise<unknown> {
       chunks.push(chunk)
     })
     req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8')
       try {
-        const raw = Buffer.concat(chunks).toString('utf8')
-        resolveBody(raw === '' ? {} : JSON.parse(raw))
+        resolve(raw === '' ? {} : JSON.parse(raw))
       } catch {
         reject(new Error('malformed JSON body'))
       }
@@ -150,6 +150,7 @@ function readJsonBody(req: IncomingMessage): Promise<unknown> {
   })
 }
 
+/** Write a JSON response with the given status. */
 function writeJson(res: ServerResponse, status: number, value: unknown): void {
   const body = JSON.stringify(value)
   res.writeHead(status, {
@@ -159,318 +160,38 @@ function writeJson(res: ServerResponse, status: number, value: unknown): void {
   res.end(body)
 }
 
-async function runShell(
+/** Run one foreground command; returns trimmed stdout or throws on non-zero. */
+async function runCommand(
   ctx: Context,
   command: string,
   options: {
     workdir?: string
+    stdin?: string
     timeoutMs?: number
-    sandboxPolicy?: {
-      mode: 'read-only' | 'workspace-write' | 'danger-full-access'
-      workspaceRoot: string
-    }
+    sandboxPolicy?: { mode: 'read-only' | 'workspace-write' | 'danger-full-access'; workspaceRoot: string }
   } = {},
-): Promise<{ exitCode: number | null; stdout: string; stderr: string }> {
-  const result = await ctx.shell.run(ctx.shell.resolve({
+): Promise<string> {
+  const spec = ctx.shell.resolve({
     command,
     workdir: options.workdir,
-    timeoutMs: options.timeoutMs ?? 30_000,
+    stdin: options.stdin,
+    timeoutMs: options.timeoutMs ?? 30000,
     sandboxPolicy: options.sandboxPolicy,
-  }))
-  return {
-    exitCode: result.exitCode,
-    stdout: result.stdout.text.trim(),
-    stderr: result.stderr?.text?.trim() ?? '',
-  }
-}
-
-async function runChecked(
-  ctx: Context,
-  command: string,
-  options: Parameters<typeof runShell>[2] = {},
-): Promise<string> {
-  const result = await runShell(ctx, command, options)
+  })
+  const result = await ctx.shell.run(spec)
   if (result.exitCode !== 0) {
-    throw new Error(`命令退出码 ${result.exitCode}${result.stderr ? `: ${result.stderr}` : ''}`)
+    const stderr = result.stderr?.text?.trim() ?? ''
+    throw new Error(`命令退出码 ${result.exitCode}${stderr ? `: ${stderr}` : ''}`)
   }
-  return result.stdout
+  return result.stdout.text.trim()
 }
 
-function parseWorktreeList(output: string): WorktreeRecord[] {
-  const records: WorktreeRecord[] = []
-  let path: string | null = null
-  let branch = 'HEAD'
-  for (const line of `${output}\n`.split('\n')) {
-    if (line.startsWith('worktree ')) path = resolve(line.slice('worktree '.length))
-    else if (line.startsWith('branch refs/heads/')) branch = line.slice('branch refs/heads/'.length)
-    else if (line === 'detached') branch = 'HEAD'
-    else if (line === '' && path !== null) {
-      records.push({ path, branch })
-      path = null
-      branch = 'HEAD'
-    }
-  }
-  return records
-}
-
-async function ensureWorktree(
-  ctx: Context,
-  repoPath: string,
-  worktree: string,
-  branch: string,
-  log: LineLog,
-): Promise<void> {
-  const policy = { mode: 'danger-full-access' as const, workspaceRoot: repoPath }
-  const list = await runChecked(ctx, 'git worktree list --porcelain', { workdir: repoPath, sandboxPolicy: policy })
-  const records = parseWorktreeList(list)
-  const normalizedTarget = resolve(worktree)
-  const atPath = records.find((record) => record.path === normalizedTarget)
-  const atBranch = records.find((record) => record.branch === branch)
-  const pathExists = existsSync(normalizedTarget)
-  const pathEmpty = pathExists ? (await readdir(normalizedTarget)).length === 0 : false
-  const branchCheck = await runShell(
-    ctx,
-    `git show-ref --verify --quiet ${shellQuote(`refs/heads/${branch}`)}`,
-    { workdir: repoPath, sandboxPolicy: policy },
-  )
-  const recovery = decideWorktreeRecovery({
-    targetBranch: branch,
-    pathExists,
-    pathEmpty,
-    registeredBranch: atPath?.branch ?? null,
-    branchExists: branchCheck.exitCode === 0,
-    branchWorktree: atBranch?.path ?? null,
-  })
-
-  if (recovery.kind === 'conflict') throw new Error(recovery.reason)
-  if (recovery.kind === 'reuse') {
-    log.appendLine('[clickvibe] worktree 与分支已存在,复用')
-    return
-  }
-  if (recovery.kind === 'attach-detached') {
-    await runChecked(ctx, `git switch -c ${shellQuote(branch)}`, {
-      workdir: normalizedTarget,
-      timeoutMs: 60_000,
-      sandboxPolicy: policy,
-    })
-    log.appendLine('[clickvibe] 已为 detached worktree 创建目标分支')
-    return
-  }
-  if (recovery.kind === 'attach-existing') {
-    await runChecked(ctx, `git switch ${shellQuote(branch)}`, {
-      workdir: normalizedTarget,
-      timeoutMs: 60_000,
-      sandboxPolicy: policy,
-    })
-    log.appendLine('[clickvibe] 已将 detached worktree 切换到现有目标分支')
-    return
-  }
-
-  await mkdir(dirname(normalizedTarget), { recursive: true })
-  const branchArg = recovery.kind === 'add-new-branch'
-    ? `-b ${shellQuote(branch)}`
-    : shellQuote(branch)
-  await runChecked(ctx, `git worktree add ${shellQuote(normalizedTarget)} ${branchArg}`, {
-    workdir: repoPath,
-    timeoutMs: 60_000,
-    sandboxPolicy: policy,
-  })
-  log.appendLine(recovery.kind === 'add-new-branch'
-    ? '[clickvibe] worktree 与分支创建完成'
-    : '[clickvibe] 已从现有分支恢复 worktree')
-}
-
-function buildPrompt(item: Record<string, unknown>): string {
-  const comments = Array.isArray(item.comments)
-    ? (item.comments as { author?: { login?: string } | null; body?: string }[])
-        .map((comment) => `@${comment.author?.login ?? 'unknown'}: ${comment.body ?? ''}`)
-        .join('\n\n---\n\n')
-    : ''
-  return [
-    `请开发这个 GitHub issue: ${item.title ?? ''}`,
-    String(item.url ?? ''),
-    '',
-    '--- issue 正文 ---',
-    String(item.body ?? ''),
-    comments ? `--- 评论 ---\n${comments}` : '',
-    '--- 要求 ---',
-    '1. 先理解需求,如有歧义可自行判断或提问',
-    '2. 实现代码改动',
-    '3. 运行相关测试',
-    '4. 完成后 git commit 并推送分支',
-    '5. 用 gh 创建 PR(若适用)',
-  ].join('\n')
-}
-
-async function fetchIssue(
-  ctx: Context,
-  payload: unknown,
-): Promise<{ ok: true; data: { kind: 'issue' | 'pr'; item: unknown } } | { ok: false; error: string }> {
-  const url = String((payload as { url?: unknown } | undefined)?.url ?? '').trim()
-  const parsed = parseGithubUrl(url)
-  if (!parsed) {
-    return { ok: false, error: '请输入形如 https://github.com/owner/repo/issues/123 或 /pull/123 的链接' }
-  }
-  const isPR = parsed.kind === 'pr'
-  const command = `${isPR ? 'gh pr view' : 'gh issue view'} ${shellQuote(url)} --json ${isPR ? PR_FIELDS : ISSUE_FIELDS}`
-  try {
-    const result = await runShell(ctx, command, { timeoutMs: 20_000 })
-    if (result.exitCode !== 0) {
-      return { ok: false, error: result.stderr || `gh 执行失败(exit ${result.exitCode})` }
-    }
-    return { ok: true, data: { kind: parsed.kind, item: JSON.parse(result.stdout) as unknown } }
-  } catch (error) {
-    return { ok: false, error: `抓取异常: ${String(error instanceof Error ? error.message : error)}` }
-  }
-}
-
-function agentCommand(agent: DevelopAgent): string {
-  if (agent === 'dryrun') return 'pwd && git branch --show-current && git status --short --branch'
-  if (agent === 'claude') return 'claude -p - --output-format stream-json --verbose'
-  return 'codex exec --json -s danger-full-access -'
-}
-
-function drainProcess(task: DevTask): void {
-  if (!task.process) return
-  const read = task.process.readOutput()
-  if (read.delta !== '') task.log.appendChunk(read.delta)
-  if (read.lossy) task.log.appendLine('[clickvibe] agent 原始输出超长,部分内容已截断')
-}
-
-function runTaskProcess(ctx: Context, task: DevTask, prompt: string | undefined): void {
-  const spec = ctx.shell.resolve({
-    command: agentCommand(task.agent),
-    workdir: task.worktree,
-    stdin: prompt,
-    stdoutMaxBytes: 4 * 1024 * 1024,
-    sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: task.worktree },
-  })
-  task.process = ctx.shell.start(spec)
-  task.status = 'running'
-  task.log.appendLine(`[clickvibe] 启动 ${task.agent}…`)
-  const timer = setInterval(() => drainProcess(task), OUTPUT_PUMP_MS)
-  void task.process.done.then(() => {
-    clearInterval(timer)
-    drainProcess(task)
-    task.log.flush()
-    task.exitCode = task.process?.exitCode ?? null
-    task.status = task.exitCode === 0 ? 'done' : 'failed'
-    task.log.appendLine(`[clickvibe] ${task.agent} 结束,退出码 ${task.exitCode}`)
-  })
-}
-
-async function startDevelop(
-  ctx: Context,
-  payload: unknown,
-): Promise<
-  | { ok: true; taskId: string; worktree: string; branch: string }
-  | { ok: false; error: string }
-> {
-  const body = (payload ?? {}) as { url?: unknown; agent?: unknown }
-  const url = String(body.url ?? '').trim()
-  const parsed = parseGithubUrl(url)
-  if (!parsed || parsed.kind !== 'issue') return { ok: false, error: '一键开发仅支持 GitHub issue 链接' }
-
-  let agent: DevelopAgent
-  try {
-    agent = parseAgent(body.agent)
-  } catch (error) {
-    return { ok: false, error: String(error instanceof Error ? error.message : error) }
-  }
-
-  let config: ClickVibeConfig
-  try {
-    config = await loadConfig()
-  } catch (error) {
-    return { ok: false, error: String(error instanceof Error ? error.message : error) }
-  }
-  const repoKey = `${parsed.owner}/${parsed.repo}`
-  const configuredRepo = config.repos[repoKey]
-  if (!configuredRepo) {
-    return { ok: false, error: `本地未配置仓库 ${repoKey},请在 ~/.clickvibe/config.yaml 的 repos 中添加映射` }
-  }
-  const repoPath = resolve(expandHome(configuredRepo))
-  if (!existsSync(repoPath)) return { ok: false, error: `仓库路径不存在: ${repoPath}` }
-
-  const project = basename(repoPath)
-  const branch = `${project}-issue-${parsed.number}`
-  const worktree = join(config.worktreeRoot, project, branch)
-  for (const existing of tasks.values()) {
-    if (existing.repo === repoKey && existing.number === parsed.number
-      && (existing.status === 'creating' || existing.status === 'running')) {
-      if (existing.agent === agent) {
-        return { ok: true, taskId: existing.id, worktree: existing.worktree, branch: existing.branch }
-      }
-      return { ok: false, error: `该 issue 已有 ${existing.agent} 任务运行中` }
-    }
-  }
-
-  const task: DevTask = {
-    id: `dev-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-    repo: repoKey,
-    number: parsed.number,
-    worktree,
-    branch,
-    agent,
-    status: 'creating',
-    exitCode: null,
-    log: new LineLog(MAX_LOG_LINES),
-  }
-  tasks.set(task.id, task)
-
-  void (async () => {
-    try {
-      task.log.appendLine(`[clickvibe] worktree: ${worktree}`)
-      await ensureWorktree(ctx, repoPath, worktree, branch, task.log)
-      if (agent === 'dryrun') {
-        runTaskProcess(ctx, task, undefined)
-        return
-      }
-      task.log.appendLine('[clickvibe] 抓取 issue 数据…')
-      const fetched = await fetchIssue(ctx, { url })
-      if (!fetched.ok) throw new Error(fetched.error)
-      runTaskProcess(ctx, task, buildPrompt(fetched.data.item as Record<string, unknown>))
-    } catch (error) {
-      task.status = 'failed'
-      task.log.flush()
-      task.log.appendLine(`[clickvibe] 失败: ${String(error instanceof Error ? error.message : error)}`)
-    }
-  })()
-
-  return { ok: true, taskId: task.id, worktree, branch }
-}
-
-function pollDevelop(payload: unknown):
-  | {
-      ok: true
-      taskId: string
-      status: DevTask['status']
-      exitCode: number | null
-      cursor: number
-      delta: string[]
-      truncated: boolean
-      done: boolean
-    }
-  | { ok: false; error: string } {
-  const body = (payload ?? {}) as { taskId?: unknown; cursor?: unknown }
-  const taskId = String(body.taskId ?? '')
-  const task = tasks.get(taskId)
-  if (!task) return { ok: false, error: `未知任务 ${taskId}` }
-  const cursor = Number(body.cursor ?? 0)
-  const read = task.log.read(cursor)
-  return {
-    ok: true,
-    taskId,
-    status: task.status,
-    exitCode: task.exitCode,
-    cursor: read.cursor,
-    delta: read.lines,
-    truncated: read.truncated,
-    done: task.status === 'done' || task.status === 'failed',
-  }
-}
-
+/**
+ * The clickvibe plugin: exports the profile-patch plugin contract
+ * (inject / apply) the cordis loader expects.
+ */
 export const name = 'clickvibe'
+
 export const inject = ['webServer', 'shell']
 
 export function apply(ctx: Context): void {
@@ -483,9 +204,10 @@ export function apply(ctx: Context): void {
         return
       }
       const pathname = new URL(req.url ?? '/', 'http://clickvibe.internal').pathname
-      const method = pathname.startsWith(`${ROUTE}/`) ? pathname.slice(`${ROUTE}/`.length) : ''
-      if (!new Set(['fetch', 'develop', 'develop/poll']).has(method)) {
-        writeJson(res, 404, { ok: false, error: `unknown method "${method}"` })
+      const method = pathname.startsWith(`${ROUTE}/`) ? pathname.slice(`${ROUTE}/`.length) : undefined
+      const knownMethods = new Set(['fetch', 'develop', 'develop/poll'])
+      if (method === undefined || !knownMethods.has(method)) {
+        writeJson(res, 404, { ok: false, error: 'unknown method' })
         return
       }
 
@@ -500,13 +222,217 @@ export function apply(ctx: Context): void {
       if (method === 'fetch') {
         const result = await fetchIssue(ctx, payload)
         writeJson(res, result.ok ? 200 : 400, result)
-      } else if (method === 'develop') {
+        return
+      }
+      if (method === 'develop') {
         const result = await startDevelop(ctx, payload)
         writeJson(res, result.ok ? 200 : 400, result)
-      } else {
+        return
+      }
+      if (method === 'develop/poll') {
         const result = pollDevelop(payload)
         writeJson(res, result.ok ? 200 : 400, result)
+        return
       }
+
+      writeJson(res, 404, { ok: false, error: `unknown method "${method}"` })
     },
   })
+}
+
+/** Validate the URL and run gh, returning the { ok, ... } envelope. */
+async function fetchIssue(
+  ctx: Context,
+  payload: unknown,
+): Promise<{ ok: true; data: { kind: 'issue' | 'pr'; item: unknown } } | { ok: false; error: string }> {
+  const url = String((payload as { url?: unknown } | undefined)?.url ?? '').trim()
+  const parsed = parseUrl(url)
+  if (!parsed) {
+    return { ok: false, error: '请输入形如 https://github.com/owner/repo/issues/123 或 /pull/123 的链接' }
+  }
+  const isPR = parsed.kind === 'pr'
+  const command = `${isPR ? 'gh pr view' : 'gh issue view'} ${url} --json ${isPR ? PR_FIELDS : ISSUE_FIELDS}`
+  try {
+    const spec = ctx.shell.resolve({ command, timeoutMs: 20000 })
+    const result = await ctx.shell.run(spec)
+    if (result.exitCode !== 0) {
+      const stderr = result.stderr?.text ?? ''
+      return { ok: false, error: stderr || `gh 执行失败(exit ${result.exitCode})` }
+    }
+    const parsedJson = JSON.parse(result.stdout.text) as unknown
+    return { ok: true, data: { kind: parsed.kind, item: parsedJson } }
+  } catch (error) {
+    return { ok: false, error: `抓取异常: ${String(error instanceof Error ? error.message : error)}` }
+  }
+}
+
+/** Build the development prompt from issue/PR data. */
+function buildPrompt(item: Record<string, unknown>): string {
+  const comments = Array.isArray(item.comments)
+    ? (item.comments as { author?: { login?: string } | null; body?: string }[])
+        .map((c) => `@${c.author?.login ?? 'unknown'}: ${c.body ?? ''}`)
+        .join('\n\n---\n\n')
+    : ''
+  return [
+    `请开发这个 GitHub ${item.url?.toString().includes('/pull/') ? 'PR' : 'issue'}: ${item.title ?? ''}`,
+    String(item.url ?? ''),
+    '',
+    '--- issue 正文 ---',
+    String(item.body ?? ''),
+    comments ? '--- 评论 ---\n' + comments : '',
+    '--- 要求 ---',
+    '1. 先理解需求,如有歧义可自行判断或提问',
+    '2. 实现代码改动',
+    '3. 运行相关测试',
+    '4. 完成后 git commit 并推送分支',
+    '5. 用 gh 创建 PR(若适用)',
+  ].join('\n')
+}
+
+/** Start a development task: worktree + branch + background agent run. */
+async function startDevelop(
+  ctx: Context,
+  payload: unknown,
+): Promise<
+  | { ok: true; taskId: string; worktree: string; branch: string }
+  | { ok: false; error: string }
+> {
+  const body = (payload ?? {}) as { url?: unknown; agent?: unknown }
+  const url = String(body.url ?? '').trim()
+  const agentRaw = String(body.agent ?? 'codex').trim().toLowerCase()
+  const agent = agentRaw === 'claude' ? 'claude' : 'codex'
+  const parsed = parseUrl(url)
+  if (!parsed) {
+    return { ok: false, error: '请输入形如 https://github.com/owner/repo/issues/123 的链接' }
+  }
+  if (parsed.kind !== 'issue') {
+    return { ok: false, error: '一键开发仅支持 issue 链接' }
+  }
+
+  const config = await loadConfig()
+  const repoKey = `${parsed.owner}/${parsed.repo}`
+  const repoPath = config.repos[repoKey]
+  if (!repoPath) {
+    return {
+      ok: false,
+      error: `本地未配置仓库 ${repoKey},请在 ~/.clickvibe/config.yaml 的 repos 中添加映射`,
+    }
+  }
+  const expandedRepo = expandHome(repoPath)
+  if (!existsSync(expandedRepo)) {
+    return { ok: false, error: `仓库路径不存在: ${expandedRepo}` }
+  }
+
+  const project = basename(expandedRepo)
+  const branch = `${project}-issue-${parsed.number}`
+  const worktree = join(config.worktreeRoot, project, branch)
+
+  // 同一 issue 已有任务在跑:直接返回现有任务
+  for (const task of tasks.values()) {
+    if (task.repo === repoKey && task.number === parsed.number && task.status !== 'failed') {
+      return { ok: true, taskId: task.id, worktree: task.worktree, branch: task.branch }
+    }
+  }
+
+  const taskId = `dev-${Date.now()}`
+  const task: DevTask = {
+    id: taskId,
+    repo: repoKey,
+    number: parsed.number,
+    worktree,
+    branch,
+    agent,
+    status: 'creating',
+    exitCode: null,
+    log: [],
+  }
+  tasks.set(taskId, task)
+
+  void (async () => {
+    try {
+      // 幂等建 worktree:已存在则跳过
+      task.log.push(`[clickvibe] worktree: ${worktree}`)
+      if (!existsSync(worktree)) {
+        const worktreeOut = await runCommand(
+          ctx,
+          `git worktree add ${JSON.stringify(worktree)} -b ${JSON.stringify(branch)}`,
+          {
+            workdir: expandedRepo,
+            timeoutMs: 60000,
+            // git 需要写主仓库的 .git/refs(sandbox 默认 read-only 会以
+            // EPERM 拒绝创建 ref 锁),worktree 创建必须在无沙箱下进行
+            sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: expandedRepo },
+          },
+        )
+        task.log.push(`[clickvibe] worktree 创建完成: ${worktreeOut}`)
+      } else {
+        task.log.push('[clickvibe] worktree 已存在,复用')
+      }
+
+      // 抓 issue 数据拼 prompt
+      task.log.push('[clickvibe] 抓取 issue 数据…')
+      const fetchResult = await fetchIssue(ctx, { url })
+      if (!fetchResult.ok) {
+        throw new Error(fetchResult.error)
+      }
+      const prompt = buildPrompt(fetchResult.data.item as Record<string, unknown>)
+
+      // 后台启动 agent
+      task.log.push(`[clickvibe] 启动 ${agent} 开发…`)
+      task.status = 'running'
+      const agentCommand = agent === 'claude'
+        ? 'claude -p - --output-format text'
+        : 'codex exec --json -'
+      const spec = ctx.shell.resolve({
+        command: agentCommand,
+        workdir: worktree,
+        stdin: prompt,
+        timeoutMs: 600000,
+        // codex/claude 需要完整的 IPC/进程能力,sandbox 会以 EPERM 拒绝其
+        // app-server 初始化 —— 开发任务必须在无沙箱(danger-full-access)下运行
+        sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: worktree },
+      })
+      const process = ctx.shell.start(spec)
+      task.process = process
+      void process.done.then(() => {
+        task.exitCode = process.exitCode
+        task.status = process.exitCode === 0 ? 'done' : 'failed'
+        task.log.push(`[clickvibe] ${agent} 结束,退出码 ${process.exitCode}`)
+      })
+    } catch (error) {
+      task.status = 'failed'
+      task.exitCode = null
+      task.log.push(`[clickvibe] 失败: ${String(error instanceof Error ? error.message : error)}`)
+    }
+  })()
+
+  return { ok: true, taskId, worktree, branch }
+}
+
+/** Consume incremental log/status for one task. */
+function pollDevelop(
+  payload: unknown,
+): { ok: true; taskId: string; status: string; exitCode: number | null; delta: string[]; done: boolean } | { ok: false; error: string } {
+  const taskId = String((payload as { taskId?: unknown } | undefined)?.taskId ?? '')
+  const task = tasks.get(taskId)
+  if (!task) {
+    return { ok: false, error: `未知任务 ${taskId}` }
+  }
+  const delta: string[] = []
+  if (task.process) {
+    const read = task.process.readOutput()
+    if (read.delta !== '') delta.push(read.delta)
+    if (read.lossy) delta.push('[clickvibe] 输出被截断(日志过长)')
+  }
+  // 内部日志(worktree 创建等)增量补发
+  const newLogs = task.log.splice(0, task.log.length)
+  delta.push(...newLogs)
+  return {
+    ok: true,
+    taskId,
+    status: task.status,
+    exitCode: task.exitCode,
+    delta,
+    done: task.status === 'done' || task.status === 'failed',
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -654,11 +654,12 @@ async function startReview(
   await appendLog(workflow.key, 'review', `[clickvibe] 启动 ${agent} review…`)
   attachAgentProcess(ctx, live, agentCommand, workflow.worktree, prompt, async (exitCode) => {
     await appendLog(workflow.key, 'review', `[clickvibe] review 结束,退出码 ${exitCode}`)
-    // 读取 review 全文,判断通过/有问题
+    // 读取 review 全文,判断通过/有问题。只认 agent 的 ❌/✅ 结论行,
+    // 忽略 "✅ 本轮完成" 这类 turn 状态行(codex 事件流会混入)。
     const lines = await readLogTail(workflow.key, 'review', 200)
-    const full = lines.join('\n')
-    const passed = exitCode === 0 && /^✅|通过/.test(full)
-    const issues = passed ? [] : extractIssues(full)
+    const verdict = reviewVerdict(lines)
+    const passed = verdict.passed
+    const issues = passed ? [] : extractIssues(lines)
     const reloaded = await loadWorkflow(workflow.key)
     if (reloaded) {
       reloaded.reviewResult = { passed, issues }
@@ -672,20 +673,43 @@ async function startReview(
   return { ok: true, taskId }
 }
 
+/** Decide the review verdict from the log: ❌ wins over ✅; neither → fail closed. */
+function reviewVerdict(lines: string[]): { passed: boolean } {
+  let sawFail = false
+  let sawPass = false
+  for (const line of lines) {
+    const t = line.trim()
+    // 结论可能带 emoji/状态前缀(💬/🔧/⚠️…),用 includes 判断更稳
+    if (t.includes('❌') && /发现|存在|问题|Review/.test(t)) sawFail = true
+    if (t.includes('✅') && !/本轮完成|会话结束/.test(t)) sawPass = true
+    if (/Review\s*通过|未发现问题|无问题/.test(t)) sawPass = true
+  }
+  return { passed: !sawFail && sawPass }
+}
+
 /** Extract issue lines from a review result (lines after a ❌ header). */
-function extractIssues(text: string): string[] {
-  const lines = text.split('\n')
+/** Extract issue lines from review log lines (lines after a ❌ verdict). */
+function extractIssues(lines: string[]): string[] {
   const out: string[] = []
   let capturing = false
   for (const line of lines) {
-    const trimmed = line.trim()
-    if (/^❌/.test(trimmed)) { capturing = true; continue }
-    if (capturing && trimmed !== '' && !/^✅/.test(trimmed)) {
-      out.push(trimmed)
+    const t = line.trim()
+    if (t.includes('❌')) {
+      capturing = true
+      // ❌ 结论可能与问题条目同行(agent 一次性输出),直接拆分
+      const rest = t.slice(t.indexOf('❌') + 1)
+      const numbered = rest.match(/\d+\.\s*[^0-9][^]*/g)
+      if (numbered) {
+        for (const n of numbered) out.push(n.replace(/^\d+\.\s*/, '').trim())
+      }
+      continue
+    }
+    if (capturing && t !== '' && !/^✅|^⚠️|^🚀|^💭|^🔧|^\[clickvibe\]|本轮完成|会话结束/.test(t)) {
+      out.push(t)
       if (out.length >= 20) break
     }
   }
-  return out
+  return out.slice(0, 20)
 }
 
 /** Post the review result to the issue's GitHub comments. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -481,10 +481,11 @@ async function startDevelop(
   | { ok: true; taskId: string; worktree: string; branch: string }
   | { ok: false; error: string }
 > {
-  const body = (payload ?? {}) as { url?: unknown; agent?: unknown }
+  const body = (payload ?? {}) as { url?: unknown; agent?: unknown; context?: unknown }
   const url = String(body.url ?? '').trim()
   const agentRaw = String(body.agent ?? 'codex').trim().toLowerCase()
   const agent: AgentKind = agentRaw === 'claude' ? 'claude' : 'codex'
+  const extraContext = typeof body.context === 'string' ? body.context.trim() : ''
   const parsed = parseUrl(url)
   if (!parsed) {
     return { ok: false, error: '请输入形如 https://github.com/owner/repo/issues/123 的链接' }
@@ -523,7 +524,10 @@ async function startDevelop(
       await appendLog(workflow.key, 'dev', `[clickvibe] 抓取 issue 数据…`)
       const fetchResult = await fetchIssue(ctx, { url })
       if (!fetchResult.ok) throw new Error(fetchResult.error)
-      const prompt = buildPrompt(fetchResult.data.item as Record<string, unknown>)
+      let prompt = buildPrompt(fetchResult.data.item as Record<string, unknown>)
+      if (extraContext !== '') {
+        prompt += '\n\n--- 附加上下文(来自 review 或其他) ---\n' + extraContext
+      }
 
       await appendLog(workflow.key, 'dev', `[clickvibe] 启动 ${agent} 开发…`)
       const agentCommand = agent === 'claude'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,19 @@
-/**
- * clickvibe host half: a /clickvibe/api JSON route that fetches GitHub
- * issue / PR data through the local gh CLI.
- *
- * The client bundle posts to `/clickvibe/api/fetch` with `{ url }`; this
- * route validates the URL shape, runs `gh issue view` / `gh pr view`, and
- * returns the parsed JSON envelope `{ ok, data }` / `{ ok: false, error }`.
- */
+/** ClickVibe Host routes: GitHub fetch plus issue development tasks. */
 import type { Context } from '@deepseek-ai/cordis'
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, readdir } from 'node:fs/promises'
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import { homedir } from 'node:os'
+import { basename, dirname, join, resolve } from 'node:path'
+import { parse as parseYaml } from 'yaml'
+import {
+  LineLog,
+  decideWorktreeRecovery,
+  parseAgent,
+  parseGithubUrl,
+  shellQuote,
+  type DevelopAgent,
+} from './develop.js'
 
 declare module '@deepseek-ai/cordis' {
   interface Context {
@@ -19,30 +25,44 @@ declare module '@deepseek-ai/cordis' {
       }): () => void
     }
     shell: {
-      resolve(request: { command: string; timeoutMs?: number }): unknown
+      resolve(request: {
+        command: string
+        timeoutMs?: number
+        stdoutMaxBytes?: number
+        workdir?: string
+        stdin?: string
+        sandboxPolicy?: {
+          mode: 'read-only' | 'workspace-write' | 'danger-full-access'
+          workspaceRoot: string
+        }
+      }): unknown
       run(spec: unknown): Promise<{
         exitCode: number | null
         stdout: { text: string }
         stderr?: { text?: string }
       }>
+      start(spec: unknown): {
+        status: string
+        exitCode: number | null
+        readonly done: Promise<void>
+        readOutput(): { delta: string; lossy: boolean }
+        kill(): boolean
+      }
     }
   }
 }
 
-/** Prefix route owning every /clickvibe/api/<method> request. */
 const ROUTE = '/clickvibe/api'
-
-/** Body size bound of one JSON request (defense against unbounded reads). */
 const MAX_BODY_BYTES = 64 * 1024
+const MAX_LOG_LINES = 2_000
+const OUTPUT_PUMP_MS = 200
 
-/** Fields the issue fetch requests from gh (all verified against rc.8). */
 const ISSUE_FIELDS = [
   'number', 'title', 'state', 'stateReason', 'author', 'createdAt',
   'updatedAt', 'closedAt', 'body', 'url', 'labels', 'assignees',
   'milestone', 'comments', 'reactionGroups', 'isPinned',
 ].join(',')
 
-/** Fields the PR fetch requests from gh (all verified against rc.8). */
 const PR_FIELDS = [
   'number', 'title', 'state', 'author', 'createdAt', 'updatedAt',
   'closedAt', 'mergedAt', 'body', 'url', 'labels', 'assignees',
@@ -51,9 +71,62 @@ const PR_FIELDS = [
   'headRefName', 'reviews', 'reviewRequests', 'comments',
 ].join(',')
 
-/** Read the (bounded) JSON request body. */
+interface ClickVibeConfig {
+  repos: Record<string, string>
+  worktreeRoot: string
+}
+
+interface DevTask {
+  id: string
+  repo: string
+  number: string
+  worktree: string
+  branch: string
+  agent: DevelopAgent
+  status: 'creating' | 'running' | 'done' | 'failed'
+  exitCode: number | null
+  log: LineLog
+  process?: ReturnType<Context['shell']['start']>
+}
+
+interface WorktreeRecord {
+  path: string
+  branch: string
+}
+
+const tasks = new Map<string, DevTask>()
+
+function expandHome(path: string): string {
+  if (path === '~') return homedir()
+  if (path.startsWith('~/')) return join(homedir(), path.slice(2))
+  return path
+}
+
+async function loadConfig(): Promise<ClickVibeConfig> {
+  const configPath = join(homedir(), '.clickvibe', 'config.yaml')
+  try {
+    const parsed = parseYaml(await readFile(configPath, 'utf8')) as Partial<ClickVibeConfig> | null
+    if (parsed?.repos !== undefined && (typeof parsed.repos !== 'object' || parsed.repos === null
+      || Object.values(parsed.repos).some((value) => typeof value !== 'string'))) {
+      throw new Error('repos 必须是 owner/repo 到本地路径的字符串映射')
+    }
+    if (parsed?.worktreeRoot !== undefined && typeof parsed.worktreeRoot !== 'string') {
+      throw new Error('worktreeRoot 必须是字符串路径')
+    }
+    return {
+      repos: parsed?.repos ?? {},
+      worktreeRoot: resolve(expandHome(parsed?.worktreeRoot ?? join(homedir(), '.clickvibe', 'worktrees'))),
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { repos: {}, worktreeRoot: join(homedir(), '.clickvibe', 'worktrees') }
+    }
+    throw new Error(`读取 ${configPath} 失败: ${String(error instanceof Error ? error.message : error)}`)
+  }
+}
+
 function readJsonBody(req: IncomingMessage): Promise<unknown> {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolveBody, reject) => {
     const chunks: Buffer[] = []
     let total = 0
     req.on('data', (chunk: Buffer) => {
@@ -66,9 +139,9 @@ function readJsonBody(req: IncomingMessage): Promise<unknown> {
       chunks.push(chunk)
     })
     req.on('end', () => {
-      const raw = Buffer.concat(chunks).toString('utf8')
       try {
-        resolve(raw === '' ? {} : JSON.parse(raw))
+        const raw = Buffer.concat(chunks).toString('utf8')
+        resolveBody(raw === '' ? {} : JSON.parse(raw))
       } catch {
         reject(new Error('malformed JSON body'))
       }
@@ -77,7 +150,6 @@ function readJsonBody(req: IncomingMessage): Promise<unknown> {
   })
 }
 
-/** Write a JSON response with the given status. */
 function writeJson(res: ServerResponse, status: number, value: unknown): void {
   const body = JSON.stringify(value)
   res.writeHead(status, {
@@ -87,12 +159,318 @@ function writeJson(res: ServerResponse, status: number, value: unknown): void {
   res.end(body)
 }
 
-/**
- * The clickvibe plugin: exports the profile-patch plugin contract
- * (inject / apply) the cordis loader expects.
- */
-export const name = 'clickvibe'
+async function runShell(
+  ctx: Context,
+  command: string,
+  options: {
+    workdir?: string
+    timeoutMs?: number
+    sandboxPolicy?: {
+      mode: 'read-only' | 'workspace-write' | 'danger-full-access'
+      workspaceRoot: string
+    }
+  } = {},
+): Promise<{ exitCode: number | null; stdout: string; stderr: string }> {
+  const result = await ctx.shell.run(ctx.shell.resolve({
+    command,
+    workdir: options.workdir,
+    timeoutMs: options.timeoutMs ?? 30_000,
+    sandboxPolicy: options.sandboxPolicy,
+  }))
+  return {
+    exitCode: result.exitCode,
+    stdout: result.stdout.text.trim(),
+    stderr: result.stderr?.text?.trim() ?? '',
+  }
+}
 
+async function runChecked(
+  ctx: Context,
+  command: string,
+  options: Parameters<typeof runShell>[2] = {},
+): Promise<string> {
+  const result = await runShell(ctx, command, options)
+  if (result.exitCode !== 0) {
+    throw new Error(`命令退出码 ${result.exitCode}${result.stderr ? `: ${result.stderr}` : ''}`)
+  }
+  return result.stdout
+}
+
+function parseWorktreeList(output: string): WorktreeRecord[] {
+  const records: WorktreeRecord[] = []
+  let path: string | null = null
+  let branch = 'HEAD'
+  for (const line of `${output}\n`.split('\n')) {
+    if (line.startsWith('worktree ')) path = resolve(line.slice('worktree '.length))
+    else if (line.startsWith('branch refs/heads/')) branch = line.slice('branch refs/heads/'.length)
+    else if (line === 'detached') branch = 'HEAD'
+    else if (line === '' && path !== null) {
+      records.push({ path, branch })
+      path = null
+      branch = 'HEAD'
+    }
+  }
+  return records
+}
+
+async function ensureWorktree(
+  ctx: Context,
+  repoPath: string,
+  worktree: string,
+  branch: string,
+  log: LineLog,
+): Promise<void> {
+  const policy = { mode: 'danger-full-access' as const, workspaceRoot: repoPath }
+  const list = await runChecked(ctx, 'git worktree list --porcelain', { workdir: repoPath, sandboxPolicy: policy })
+  const records = parseWorktreeList(list)
+  const normalizedTarget = resolve(worktree)
+  const atPath = records.find((record) => record.path === normalizedTarget)
+  const atBranch = records.find((record) => record.branch === branch)
+  const pathExists = existsSync(normalizedTarget)
+  const pathEmpty = pathExists ? (await readdir(normalizedTarget)).length === 0 : false
+  const branchCheck = await runShell(
+    ctx,
+    `git show-ref --verify --quiet ${shellQuote(`refs/heads/${branch}`)}`,
+    { workdir: repoPath, sandboxPolicy: policy },
+  )
+  const recovery = decideWorktreeRecovery({
+    targetBranch: branch,
+    pathExists,
+    pathEmpty,
+    registeredBranch: atPath?.branch ?? null,
+    branchExists: branchCheck.exitCode === 0,
+    branchWorktree: atBranch?.path ?? null,
+  })
+
+  if (recovery.kind === 'conflict') throw new Error(recovery.reason)
+  if (recovery.kind === 'reuse') {
+    log.appendLine('[clickvibe] worktree 与分支已存在,复用')
+    return
+  }
+  if (recovery.kind === 'attach-detached') {
+    await runChecked(ctx, `git switch -c ${shellQuote(branch)}`, {
+      workdir: normalizedTarget,
+      timeoutMs: 60_000,
+      sandboxPolicy: policy,
+    })
+    log.appendLine('[clickvibe] 已为 detached worktree 创建目标分支')
+    return
+  }
+  if (recovery.kind === 'attach-existing') {
+    await runChecked(ctx, `git switch ${shellQuote(branch)}`, {
+      workdir: normalizedTarget,
+      timeoutMs: 60_000,
+      sandboxPolicy: policy,
+    })
+    log.appendLine('[clickvibe] 已将 detached worktree 切换到现有目标分支')
+    return
+  }
+
+  await mkdir(dirname(normalizedTarget), { recursive: true })
+  const branchArg = recovery.kind === 'add-new-branch'
+    ? `-b ${shellQuote(branch)}`
+    : shellQuote(branch)
+  await runChecked(ctx, `git worktree add ${shellQuote(normalizedTarget)} ${branchArg}`, {
+    workdir: repoPath,
+    timeoutMs: 60_000,
+    sandboxPolicy: policy,
+  })
+  log.appendLine(recovery.kind === 'add-new-branch'
+    ? '[clickvibe] worktree 与分支创建完成'
+    : '[clickvibe] 已从现有分支恢复 worktree')
+}
+
+function buildPrompt(item: Record<string, unknown>): string {
+  const comments = Array.isArray(item.comments)
+    ? (item.comments as { author?: { login?: string } | null; body?: string }[])
+        .map((comment) => `@${comment.author?.login ?? 'unknown'}: ${comment.body ?? ''}`)
+        .join('\n\n---\n\n')
+    : ''
+  return [
+    `请开发这个 GitHub issue: ${item.title ?? ''}`,
+    String(item.url ?? ''),
+    '',
+    '--- issue 正文 ---',
+    String(item.body ?? ''),
+    comments ? `--- 评论 ---\n${comments}` : '',
+    '--- 要求 ---',
+    '1. 先理解需求,如有歧义可自行判断或提问',
+    '2. 实现代码改动',
+    '3. 运行相关测试',
+    '4. 完成后 git commit 并推送分支',
+    '5. 用 gh 创建 PR(若适用)',
+  ].join('\n')
+}
+
+async function fetchIssue(
+  ctx: Context,
+  payload: unknown,
+): Promise<{ ok: true; data: { kind: 'issue' | 'pr'; item: unknown } } | { ok: false; error: string }> {
+  const url = String((payload as { url?: unknown } | undefined)?.url ?? '').trim()
+  const parsed = parseGithubUrl(url)
+  if (!parsed) {
+    return { ok: false, error: '请输入形如 https://github.com/owner/repo/issues/123 或 /pull/123 的链接' }
+  }
+  const isPR = parsed.kind === 'pr'
+  const command = `${isPR ? 'gh pr view' : 'gh issue view'} ${shellQuote(url)} --json ${isPR ? PR_FIELDS : ISSUE_FIELDS}`
+  try {
+    const result = await runShell(ctx, command, { timeoutMs: 20_000 })
+    if (result.exitCode !== 0) {
+      return { ok: false, error: result.stderr || `gh 执行失败(exit ${result.exitCode})` }
+    }
+    return { ok: true, data: { kind: parsed.kind, item: JSON.parse(result.stdout) as unknown } }
+  } catch (error) {
+    return { ok: false, error: `抓取异常: ${String(error instanceof Error ? error.message : error)}` }
+  }
+}
+
+function agentCommand(agent: DevelopAgent): string {
+  if (agent === 'dryrun') return 'pwd && git branch --show-current && git status --short --branch'
+  if (agent === 'claude') return 'claude -p - --output-format stream-json --verbose'
+  return 'codex exec --json -s danger-full-access -'
+}
+
+function drainProcess(task: DevTask): void {
+  if (!task.process) return
+  const read = task.process.readOutput()
+  if (read.delta !== '') task.log.appendChunk(read.delta)
+  if (read.lossy) task.log.appendLine('[clickvibe] agent 原始输出超长,部分内容已截断')
+}
+
+function runTaskProcess(ctx: Context, task: DevTask, prompt: string | undefined): void {
+  const spec = ctx.shell.resolve({
+    command: agentCommand(task.agent),
+    workdir: task.worktree,
+    stdin: prompt,
+    stdoutMaxBytes: 4 * 1024 * 1024,
+    sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: task.worktree },
+  })
+  task.process = ctx.shell.start(spec)
+  task.status = 'running'
+  task.log.appendLine(`[clickvibe] 启动 ${task.agent}…`)
+  const timer = setInterval(() => drainProcess(task), OUTPUT_PUMP_MS)
+  void task.process.done.then(() => {
+    clearInterval(timer)
+    drainProcess(task)
+    task.log.flush()
+    task.exitCode = task.process?.exitCode ?? null
+    task.status = task.exitCode === 0 ? 'done' : 'failed'
+    task.log.appendLine(`[clickvibe] ${task.agent} 结束,退出码 ${task.exitCode}`)
+  })
+}
+
+async function startDevelop(
+  ctx: Context,
+  payload: unknown,
+): Promise<
+  | { ok: true; taskId: string; worktree: string; branch: string }
+  | { ok: false; error: string }
+> {
+  const body = (payload ?? {}) as { url?: unknown; agent?: unknown }
+  const url = String(body.url ?? '').trim()
+  const parsed = parseGithubUrl(url)
+  if (!parsed || parsed.kind !== 'issue') return { ok: false, error: '一键开发仅支持 GitHub issue 链接' }
+
+  let agent: DevelopAgent
+  try {
+    agent = parseAgent(body.agent)
+  } catch (error) {
+    return { ok: false, error: String(error instanceof Error ? error.message : error) }
+  }
+
+  let config: ClickVibeConfig
+  try {
+    config = await loadConfig()
+  } catch (error) {
+    return { ok: false, error: String(error instanceof Error ? error.message : error) }
+  }
+  const repoKey = `${parsed.owner}/${parsed.repo}`
+  const configuredRepo = config.repos[repoKey]
+  if (!configuredRepo) {
+    return { ok: false, error: `本地未配置仓库 ${repoKey},请在 ~/.clickvibe/config.yaml 的 repos 中添加映射` }
+  }
+  const repoPath = resolve(expandHome(configuredRepo))
+  if (!existsSync(repoPath)) return { ok: false, error: `仓库路径不存在: ${repoPath}` }
+
+  const project = basename(repoPath)
+  const branch = `${project}-issue-${parsed.number}`
+  const worktree = join(config.worktreeRoot, project, branch)
+  for (const existing of tasks.values()) {
+    if (existing.repo === repoKey && existing.number === parsed.number
+      && (existing.status === 'creating' || existing.status === 'running')) {
+      if (existing.agent === agent) {
+        return { ok: true, taskId: existing.id, worktree: existing.worktree, branch: existing.branch }
+      }
+      return { ok: false, error: `该 issue 已有 ${existing.agent} 任务运行中` }
+    }
+  }
+
+  const task: DevTask = {
+    id: `dev-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    repo: repoKey,
+    number: parsed.number,
+    worktree,
+    branch,
+    agent,
+    status: 'creating',
+    exitCode: null,
+    log: new LineLog(MAX_LOG_LINES),
+  }
+  tasks.set(task.id, task)
+
+  void (async () => {
+    try {
+      task.log.appendLine(`[clickvibe] worktree: ${worktree}`)
+      await ensureWorktree(ctx, repoPath, worktree, branch, task.log)
+      if (agent === 'dryrun') {
+        runTaskProcess(ctx, task, undefined)
+        return
+      }
+      task.log.appendLine('[clickvibe] 抓取 issue 数据…')
+      const fetched = await fetchIssue(ctx, { url })
+      if (!fetched.ok) throw new Error(fetched.error)
+      runTaskProcess(ctx, task, buildPrompt(fetched.data.item as Record<string, unknown>))
+    } catch (error) {
+      task.status = 'failed'
+      task.log.flush()
+      task.log.appendLine(`[clickvibe] 失败: ${String(error instanceof Error ? error.message : error)}`)
+    }
+  })()
+
+  return { ok: true, taskId: task.id, worktree, branch }
+}
+
+function pollDevelop(payload: unknown):
+  | {
+      ok: true
+      taskId: string
+      status: DevTask['status']
+      exitCode: number | null
+      cursor: number
+      delta: string[]
+      truncated: boolean
+      done: boolean
+    }
+  | { ok: false; error: string } {
+  const body = (payload ?? {}) as { taskId?: unknown; cursor?: unknown }
+  const taskId = String(body.taskId ?? '')
+  const task = tasks.get(taskId)
+  if (!task) return { ok: false, error: `未知任务 ${taskId}` }
+  const cursor = Number(body.cursor ?? 0)
+  const read = task.log.read(cursor)
+  return {
+    ok: true,
+    taskId,
+    status: task.status,
+    exitCode: task.exitCode,
+    cursor: read.cursor,
+    delta: read.lines,
+    truncated: read.truncated,
+    done: task.status === 'done' || task.status === 'failed',
+  }
+}
+
+export const name = 'clickvibe'
 export const inject = ['webServer', 'shell']
 
 export function apply(ctx: Context): void {
@@ -105,9 +483,9 @@ export function apply(ctx: Context): void {
         return
       }
       const pathname = new URL(req.url ?? '/', 'http://clickvibe.internal').pathname
-      const method = pathname.startsWith(`${ROUTE}/`) ? pathname.slice(`${ROUTE}/`.length) : undefined
-      if (method === undefined || method.includes('/')) {
-        writeJson(res, 404, { ok: false, error: 'unknown method' })
+      const method = pathname.startsWith(`${ROUTE}/`) ? pathname.slice(`${ROUTE}/`.length) : ''
+      if (!new Set(['fetch', 'develop', 'develop/poll']).has(method)) {
+        writeJson(res, 404, { ok: false, error: `unknown method "${method}"` })
         return
       }
 
@@ -122,37 +500,13 @@ export function apply(ctx: Context): void {
       if (method === 'fetch') {
         const result = await fetchIssue(ctx, payload)
         writeJson(res, result.ok ? 200 : 400, result)
-        return
+      } else if (method === 'develop') {
+        const result = await startDevelop(ctx, payload)
+        writeJson(res, result.ok ? 200 : 400, result)
+      } else {
+        const result = pollDevelop(payload)
+        writeJson(res, result.ok ? 200 : 400, result)
       }
-
-      writeJson(res, 404, { ok: false, error: `unknown method "${method}"` })
     },
   })
-}
-
-/** Validate the URL and run gh, returning the { ok, ... } envelope. */
-async function fetchIssue(
-  ctx: Context,
-  payload: unknown,
-): Promise<{ ok: true; data: { kind: 'issue' | 'pr'; item: unknown } } | { ok: false; error: string }> {
-  const url = String((payload as { url?: unknown } | undefined)?.url ?? '').trim()
-  const isPR = /^https?:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/.test(url)
-  const isIssue = /^https?:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+/.test(url)
-  if (!isPR && !isIssue) {
-    return { ok: false, error: '请输入形如 https://github.com/owner/repo/issues/123 或 /pull/123 的链接' }
-  }
-
-  const command = `${isPR ? 'gh pr view' : 'gh issue view'} ${url} --json ${isPR ? PR_FIELDS : ISSUE_FIELDS}`
-  try {
-    const spec = ctx.shell.resolve({ command, timeoutMs: 20000 })
-    const result = await ctx.shell.run(spec)
-    if (result.exitCode !== 0) {
-      const stderr = result.stderr?.text ?? ''
-      return { ok: false, error: stderr || `gh 执行失败(exit ${result.exitCode})` }
-    }
-    const parsed = JSON.parse(result.stdout.text) as unknown
-    return { ok: true, data: { kind: isPR ? 'pr' : 'issue', item: parsed } }
-  } catch (error) {
-    return { ok: false, error: `抓取异常: ${String(error instanceof Error ? error.message : error)}` }
-  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -340,11 +340,31 @@ function buildReviewPrompt(workflow: IssueWorkflow): string {
     '要求:',
     '1. 用 git diff 查看改动(相对主干)',
     '2. 检查:需求是否完整实现、是否有 bug/安全隐患、测试是否覆盖',
-    '3. 输出结论,第一行必须是 ✅ 或 ❌:',
-    '   - ✅ Review 通过',
-    '   - ❌ 发现 N 个问题,然后逐条列出(每条含文件/位置/原因/建议)',
-    '不要修改任何文件,只输出 review 结论。',
+    '3. 不要修改任何文件,只做只读 review',
+    '4. 最后一行必须输出一个 JSON 对象(单独一行,不要包裹在代码块里),格式:',
+    '{"passed": true|false, "issues": ["问题1(含文件/位置/原因)", "问题2", ...]}',
+    '   passed=true 表示无问题;有任意问题则 passed=false 并列出全部。',
   ].join('\n')
+}
+
+/** Extract the final JSON verdict object from review log lines. */
+function extractReviewJson(lines: string[]): { passed: boolean; issues: string[] } | null {
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]
+    const match = line.match(/\{.*"passed".*\}/)
+    if (!match) continue
+    try {
+      const obj = JSON.parse(match[0]) as { passed?: unknown; issues?: unknown }
+      if (typeof obj.passed !== 'boolean') continue
+      const issues = Array.isArray(obj.issues)
+        ? obj.issues.filter((x): x is string => typeof x === 'string')
+        : []
+      return { passed: obj.passed, issues }
+    } catch {
+      // 不是合法 JSON,继续找前一行
+    }
+  }
+  return null
 }
 
 /** Create (or reuse) the workflow record and the worktree+branch. */
@@ -654,12 +674,12 @@ async function startReview(
   await appendLog(workflow.key, 'review', `[clickvibe] 启动 ${agent} review…`)
   attachAgentProcess(ctx, live, agentCommand, workflow.worktree, prompt, async (exitCode) => {
     await appendLog(workflow.key, 'review', `[clickvibe] review 结束,退出码 ${exitCode}`)
-    // 读取 review 全文,判断通过/有问题。只认 agent 的 ❌/✅ 结论行,
-    // 忽略 "✅ 本轮完成" 这类 turn 状态行(codex 事件流会混入)。
+    // 优先用 agent 输出的 JSON 结论(完整、不受截断/分块影响);
+    // JSON 缺失时回退到 ❌/✅ 文本判定。
     const lines = await readLogTail(workflow.key, 'review', 200)
-    const verdict = reviewVerdict(lines)
-    const passed = verdict.passed
-    const issues = passed ? [] : extractIssues(lines)
+    const json = extractReviewJson(lines)
+    const passed = json ? json.passed : reviewVerdict(lines).passed
+    const issues = passed ? [] : (json?.issues ?? extractIssues(lines))
     const reloaded = await loadWorkflow(workflow.key)
     if (reloaded) {
       reloaded.reviewResult = { passed, issues }
@@ -691,22 +711,27 @@ function reviewVerdict(lines: string[]): { passed: boolean } {
 /** Extract issue lines from review log lines (lines after a ❌ verdict). */
 function extractIssues(lines: string[]): string[] {
   const out: string[] = []
-  let capturing = false
-  for (const line of lines) {
-    const t = line.trim()
-    if (t.includes('❌')) {
-      capturing = true
-      // ❌ 结论可能与问题条目同行(agent 一次性输出),直接拆分
-      const rest = t.slice(t.indexOf('❌') + 1)
-      const numbered = rest.match(/\d+\.\s*[^0-9][^]*/g)
-      if (numbered) {
-        for (const n of numbered) out.push(n.replace(/^\d+\.\s*/, '').trim())
-      }
-      continue
+  // 只取最后一个包含 ❌ 的行(agent 的最终结论;前面可能有中间自查的 ❌)
+  let verdictIndex = -1
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes('❌')) verdictIndex = i
+  }
+  if (verdictIndex === -1) return []
+  const verdict = lines[verdictIndex]
+  const rest = verdict.slice(verdict.indexOf('❌') + 1)
+  // 按 "N. " 编号切分条目;若无编号条目则走下面的行收集
+  const parts = rest.split(/(?=\d+\.\s)/).filter((s) => /^\d+\./.test(s.trim()))
+  if (parts.length > 0) {
+    for (const p of parts) {
+      const item = p.replace(/^\d+\.\s*/, '').trim()
+      if (item !== '') out.push(item)
     }
-    if (capturing && t !== '' && !/^✅|^⚠️|^🚀|^💭|^🔧|^\[clickvibe\]|本轮完成|会话结束/.test(t)) {
+  } else {
+    // 无编号条目:收集结论行之后非状态、非 clickvibe 的行
+    for (let i = verdictIndex + 1; i < lines.length; i++) {
+      const t = lines[i].trim()
+      if (t === '' || /^✅|^⚠️|^🚀|^💭|^🔧|^\[clickvibe\]|本轮完成|会话结束/.test(t)) break
       out.push(t)
-      if (out.length >= 20) break
     }
   }
   return out.slice(0, 20)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,17 @@
 /**
- * clickvibe host half:
- * - `/clickvibe/api/fetch` — fetch GitHub issue/PR data via gh,
- * - `/clickvibe/api/develop` — start a development task: create a git
- *   worktree + branch for the issue's repo, then run codex/claude
- *   non-interactively inside it,
- * - `/clickvibe/api/develop/poll` — consume incremental task log/status.
+ * clickvibe host half — routes:
+ * - `/clickvibe/api/fetch`          — fetch GitHub issue/PR data via gh
+ * - `/clickvibe/api/state`          — restore panel context (all workflows)
+ * - `/clickvibe/api/develop`        — start dev: worktree+branch+agent
+ * - `/clickvibe/api/develop/poll`   — incremental dev log/status (JSON)
+ * - `/clickvibe/api/stream`         — SSE live status stream for a task
+ * - `/clickvibe/api/review`         — review the dev branch with codex/claude
+ * - `/clickvibe/api/resume`         — resume an interrupted dev session
  *
- * Config lives at ~/.clickvibe/config.yaml (see project README).
+ * Workflow per issue (persisted under ~/.clickvibe/state/):
+ *   developing → review-ready → reviewing → passed
+ *                      ↑                  │
+ *                      └── rework ────────┘
  */
 import type { Context } from '@deepseek-ai/cordis'
 import type { IncomingMessage, ServerResponse } from 'node:http'
@@ -15,6 +20,18 @@ import { existsSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join, basename } from 'node:path'
 import { parse as parseYaml } from 'yaml'
+import {
+  appendLog,
+  issueKey,
+  loadAllWorkflows,
+  loadWorkflow,
+  logPath,
+  readLogTail,
+  saveWorkflow,
+  type IssueWorkflow,
+  type WorkflowStage,
+} from './state.ts'
+import { parseAgentChunk, type AgentKind } from './agent-stream.ts'
 
 declare module '@deepseek-ai/cordis' {
   interface Context {
@@ -52,17 +69,17 @@ declare module '@deepseek-ai/cordis' {
 /** Prefix route owning every /clickvibe/api/<method> request. */
 const ROUTE = '/clickvibe/api'
 
-/** Body size bound of one JSON request (defense against unbounded reads). */
+/** Body size bound of one JSON request. */
 const MAX_BODY_BYTES = 64 * 1024
 
-/** Fields the issue fetch requests from gh (all verified against rc.8). */
+/** Fields the issue fetch requests from gh (verified against rc.8). */
 const ISSUE_FIELDS = [
   'number', 'title', 'state', 'stateReason', 'author', 'createdAt',
   'updatedAt', 'closedAt', 'body', 'url', 'labels', 'assignees',
   'milestone', 'comments', 'reactionGroups', 'isPinned',
 ].join(',')
 
-/** Fields the PR fetch requests from gh (all verified against rc.8). */
+/** Fields the PR fetch requests from gh (verified against rc.8). */
 const PR_FIELDS = [
   'number', 'title', 'state', 'author', 'createdAt', 'updatedAt',
   'closedAt', 'mergedAt', 'body', 'url', 'labels', 'assignees',
@@ -74,6 +91,26 @@ const PR_FIELDS = [
 interface ClickVibeConfig {
   repos: Record<string, string>
   worktreeRoot: string
+}
+
+/** In-memory live task handle: the running process + a status-line buffer. */
+interface LiveTask {
+  taskId: string
+  workflowKey: string
+  kind: 'dev' | 'review'
+  agent: AgentKind
+  process?: ReturnType<Context['shell']['start']>
+  lines: string[]          // 已解析的状态行(供 SSE 增量读取)
+  closed: boolean
+}
+
+const liveTasks = new Map<string, LiveTask>()
+const liveWaiters = new Map<string, Set<() => void>>()
+
+/** Notify SSE waiters that new lines are available for a task. */
+function notifyTask(taskId: string): void {
+  const waiters = liveWaiters.get(taskId)
+  if (waiters) for (const fn of waiters) fn()
 }
 
 /** Expand a leading `~` in a path to the user's home directory. */
@@ -100,22 +137,6 @@ async function loadConfig(): Promise<ClickVibeConfig> {
     }
   }
 }
-
-/** One in-flight development task. */
-interface DevTask {
-  id: string
-  repo: string
-  number: string
-  worktree: string
-  branch: string
-  agent: 'codex' | 'claude'
-  status: 'creating' | 'running' | 'done' | 'failed'
-  exitCode: number | null
-  log: string[]
-  process?: ReturnType<Context['shell']['start']>
-}
-
-const tasks = new Map<string, DevTask>()
 
 /** Extract owner/repo and issue number from a GitHub issue/PR URL. */
 function parseUrl(url: string): { kind: 'issue' | 'pr'; owner: string; repo: string; number: string } | null {
@@ -187,8 +208,7 @@ async function runCommand(
 }
 
 /**
- * The clickvibe plugin: exports the profile-patch plugin contract
- * (inject / apply) the cordis loader expects.
+ * The clickvibe plugin: exports the profile-patch plugin contract.
  */
 export const name = 'clickvibe'
 
@@ -199,18 +219,25 @@ export function apply(ctx: Context): void {
     kind: 'prefix',
     path: ROUTE,
     handler: async (req: IncomingMessage, res: ServerResponse) => {
-      if (req.method !== 'POST') {
+      if (req.method !== 'POST' && req.method !== 'GET') {
         writeJson(res, 405, { ok: false, error: 'method not allowed' })
         return
       }
       const pathname = new URL(req.url ?? '/', 'http://clickvibe.internal').pathname
       const method = pathname.startsWith(`${ROUTE}/`) ? pathname.slice(`${ROUTE}/`.length) : undefined
-      const knownMethods = new Set(['fetch', 'develop', 'develop/poll'])
+      const knownMethods = new Set(['fetch', 'state', 'develop', 'develop/poll', 'stream', 'review', 'resume'])
       if (method === undefined || !knownMethods.has(method)) {
         writeJson(res, 404, { ok: false, error: 'unknown method' })
         return
       }
 
+      // SSE stream endpoint (GET)
+      if (method === 'stream') {
+        handleStream(req, res)
+        return
+      }
+
+      // JSON POST endpoints
       let payload: unknown
       try {
         payload = await readJsonBody(req)
@@ -224,13 +251,28 @@ export function apply(ctx: Context): void {
         writeJson(res, result.ok ? 200 : 400, result)
         return
       }
+      if (method === 'state') {
+        const workflows = await loadAllWorkflows()
+        writeJson(res, 200, { ok: true, workflows })
+        return
+      }
       if (method === 'develop') {
         const result = await startDevelop(ctx, payload)
         writeJson(res, result.ok ? 200 : 400, result)
         return
       }
       if (method === 'develop/poll') {
-        const result = pollDevelop(payload)
+        const result = await pollDevelop(payload)
+        writeJson(res, result.ok ? 200 : 400, result)
+        return
+      }
+      if (method === 'review') {
+        const result = await startReview(ctx, payload)
+        writeJson(res, result.ok ? 200 : 400, result)
+        return
+      }
+      if (method === 'resume') {
+        const result = await resumeDevelop(ctx, payload)
         writeJson(res, result.ok ? 200 : 400, result)
         return
       }
@@ -289,6 +331,128 @@ function buildPrompt(item: Record<string, unknown>): string {
   ].join('\n')
 }
 
+/** Build the review prompt: review the dev branch diff against the issue. */
+function buildReviewPrompt(workflow: IssueWorkflow): string {
+  return [
+    `请 review 分支 ${workflow.branch} 相对其 base 的代码改动,对照 issue:`,
+    workflow.url,
+    '',
+    '要求:',
+    '1. 用 git diff 查看改动(相对主干)',
+    '2. 检查:需求是否完整实现、是否有 bug/安全隐患、测试是否覆盖',
+    '3. 输出结论,第一行必须是 ✅ 或 ❌:',
+    '   - ✅ Review 通过',
+    '   - ❌ 发现 N 个问题,然后逐条列出(每条含文件/位置/原因/建议)',
+    '不要修改任何文件,只输出 review 结论。',
+  ].join('\n')
+}
+
+/** Create (or reuse) the workflow record and the worktree+branch. */
+async function ensureWorktree(ctx: Context, parsed: { owner: string; repo: string; number: string }): Promise<
+  | { ok: true; workflow: IssueWorkflow; worktree: string; branch: string }
+  | { ok: false; error: string }
+> {
+  const config = await loadConfig()
+  const repoKey = `${parsed.owner}/${parsed.repo}`
+  const repoPath = config.repos[repoKey]
+  if (!repoPath) {
+    return { ok: false, error: `本地未配置仓库 ${repoKey},请在 ~/.clickvibe/config.yaml 的 repos 中添加映射` }
+  }
+  const expandedRepo = expandHome(repoPath)
+  if (!existsSync(expandedRepo)) {
+    return { ok: false, error: `仓库路径不存在: ${expandedRepo}` }
+  }
+
+  const key = issueKey(repoKey, parsed.number)
+  let workflow = await loadWorkflow(key)
+  const project = basename(expandedRepo)
+  const branch = `${project}-issue-${parsed.number}`
+  const worktree = join(config.worktreeRoot, project, branch)
+
+  if (!workflow) {
+    workflow = {
+      key,
+      url: `https://github.com/${repoKey}/issues/${parsed.number}`,
+      repoKey,
+      worktree,
+      branch,
+      stage: 'idle',
+      devAgent: null,
+      devTaskId: null,
+      devSessionId: null,
+      devInterrupted: false,
+      reviewAgent: null,
+      reviewTaskId: null,
+      reviewResult: null,
+      updatedAt: Date.now(),
+    }
+  }
+  // 校正路径字段(配置可能变化)
+  workflow.worktree = worktree
+  workflow.branch = branch
+
+  // 幂等建 worktree(无沙箱:git 需要写主仓库 .git/refs)
+  if (!existsSync(worktree)) {
+    await appendLog(workflow.key, 'dev', `[clickvibe] 创建 worktree: ${worktree}`)
+    await runCommand(
+      ctx,
+      `git worktree add ${JSON.stringify(worktree)} -b ${JSON.stringify(branch)}`,
+      {
+        workdir: expandedRepo,
+        timeoutMs: 60000,
+        sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: expandedRepo },
+      },
+    )
+    await appendLog(workflow.key, 'dev', `[clickvibe] worktree 创建完成`)
+  }
+
+  await saveWorkflow(workflow)
+  return { ok: true, workflow, worktree, branch }
+}
+
+/** Start (or restart) a dev task in the live map with status parsing. */
+function attachAgentProcess(
+  ctx: Context,
+  task: LiveTask,
+  command: string,
+  workdir: string,
+  prompt: string,
+  onExit: (exitCode: number | null) => void,
+): void {
+  const spec = ctx.shell.resolve({
+    command,
+    workdir,
+    stdin: prompt,
+    timeoutMs: 600000,
+    sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: workdir },
+  })
+  const process = ctx.shell.start(spec)
+  task.process = process
+
+  // 轮询读取 agent 输出,解析为状态行,写入内存缓冲 + 落盘日志
+  const pump = setInterval(() => {
+    const read = process.readOutput()
+    if (read.delta !== '') {
+      const lines = parseAgentChunk(task.agent, read.delta)
+      for (const line of lines) {
+        task.lines.push(line.text)
+        void appendLog(task.workflowKey, task.kind, line.text)
+      }
+      if (read.lossy) {
+        task.lines.push('[clickvibe] 输出被截断(日志过长)')
+      }
+      notifyTask(task.taskId)
+    }
+  }, 500)
+
+  void process.done.then(() => {
+    clearInterval(pump)
+    task.closed = true
+    notifyTask(task.taskId)
+    onExit(process.exitCode)
+  })
+}
+
 /** Start a development task: worktree + branch + background agent run. */
 async function startDevelop(
   ctx: Context,
@@ -300,7 +464,7 @@ async function startDevelop(
   const body = (payload ?? {}) as { url?: unknown; agent?: unknown }
   const url = String(body.url ?? '').trim()
   const agentRaw = String(body.agent ?? 'codex').trim().toLowerCase()
-  const agent = agentRaw === 'claude' ? 'claude' : 'codex'
+  const agent: AgentKind = agentRaw === 'claude' ? 'claude' : 'codex'
   const parsed = parseUrl(url)
   if (!parsed) {
     return { ok: false, error: '请输入形如 https://github.com/owner/repo/issues/123 的链接' }
@@ -309,130 +473,287 @@ async function startDevelop(
     return { ok: false, error: '一键开发仅支持 issue 链接' }
   }
 
-  const config = await loadConfig()
-  const repoKey = `${parsed.owner}/${parsed.repo}`
-  const repoPath = config.repos[repoKey]
-  if (!repoPath) {
-    return {
-      ok: false,
-      error: `本地未配置仓库 ${repoKey},请在 ~/.clickvibe/config.yaml 的 repos 中添加映射`,
-    }
-  }
-  const expandedRepo = expandHome(repoPath)
-  if (!existsSync(expandedRepo)) {
-    return { ok: false, error: `仓库路径不存在: ${expandedRepo}` }
-  }
+  const ensured = await ensureWorktree(ctx, parsed)
+  if (!ensured.ok) return ensured
+  const { workflow } = ensured
 
-  const project = basename(expandedRepo)
-  const branch = `${project}-issue-${parsed.number}`
-  const worktree = join(config.worktreeRoot, project, branch)
-
-  // 同一 issue 已有任务在跑:直接返回现有任务
-  for (const task of tasks.values()) {
-    if (task.repo === repoKey && task.number === parsed.number && task.status !== 'failed') {
-      return { ok: true, taskId: task.id, worktree: task.worktree, branch: task.branch }
-    }
+  // 已有开发任务在跑:复用
+  if (workflow.devTaskId && liveTasks.has(workflow.devTaskId) && !liveTasks.get(workflow.devTaskId)!.closed) {
+    return { ok: true, taskId: workflow.devTaskId, worktree: workflow.worktree, branch: workflow.branch }
   }
 
   const taskId = `dev-${Date.now()}`
-  const task: DevTask = {
-    id: taskId,
-    repo: repoKey,
-    number: parsed.number,
-    worktree,
-    branch,
+  const live: LiveTask = {
+    taskId,
+    workflowKey: workflow.key,
+    kind: 'dev',
     agent,
-    status: 'creating',
-    exitCode: null,
-    log: [],
+    lines: [],
+    closed: false,
   }
-  tasks.set(taskId, task)
+  liveTasks.set(taskId, live)
+  workflow.devAgent = agent
+  workflow.devTaskId = taskId
+  workflow.devInterrupted = false
+  workflow.stage = 'developing'
+  await saveWorkflow(workflow)
 
   void (async () => {
     try {
-      // 幂等建 worktree:已存在则跳过
-      task.log.push(`[clickvibe] worktree: ${worktree}`)
-      if (!existsSync(worktree)) {
-        const worktreeOut = await runCommand(
-          ctx,
-          `git worktree add ${JSON.stringify(worktree)} -b ${JSON.stringify(branch)}`,
-          {
-            workdir: expandedRepo,
-            timeoutMs: 60000,
-            // git 需要写主仓库的 .git/refs(sandbox 默认 read-only 会以
-            // EPERM 拒绝创建 ref 锁),worktree 创建必须在无沙箱下进行
-            sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: expandedRepo },
-          },
-        )
-        task.log.push(`[clickvibe] worktree 创建完成: ${worktreeOut}`)
-      } else {
-        task.log.push('[clickvibe] worktree 已存在,复用')
-      }
-
-      // 抓 issue 数据拼 prompt
-      task.log.push('[clickvibe] 抓取 issue 数据…')
+      await appendLog(workflow.key, 'dev', `[clickvibe] 抓取 issue 数据…`)
       const fetchResult = await fetchIssue(ctx, { url })
-      if (!fetchResult.ok) {
-        throw new Error(fetchResult.error)
-      }
+      if (!fetchResult.ok) throw new Error(fetchResult.error)
       const prompt = buildPrompt(fetchResult.data.item as Record<string, unknown>)
 
-      // 后台启动 agent
-      task.log.push(`[clickvibe] 启动 ${agent} 开发…`)
-      task.status = 'running'
+      await appendLog(workflow.key, 'dev', `[clickvibe] 启动 ${agent} 开发…`)
       const agentCommand = agent === 'claude'
-        ? 'claude -p - --output-format text'
+        ? 'claude -p --verbose --output-format stream-json'
         : 'codex exec --json -'
-      const spec = ctx.shell.resolve({
-        command: agentCommand,
-        workdir: worktree,
-        stdin: prompt,
-        timeoutMs: 600000,
-        // codex/claude 需要完整的 IPC/进程能力,sandbox 会以 EPERM 拒绝其
-        // app-server 初始化 —— 开发任务必须在无沙箱(danger-full-access)下运行
-        sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: worktree },
-      })
-      const process = ctx.shell.start(spec)
-      task.process = process
-      void process.done.then(() => {
-        task.exitCode = process.exitCode
-        task.status = process.exitCode === 0 ? 'done' : 'failed'
-        task.log.push(`[clickvibe] ${agent} 结束,退出码 ${process.exitCode}`)
+
+      attachAgentProcess(ctx, live, agentCommand, workflow.worktree, prompt, async (exitCode) => {
+        await appendLog(workflow.key, 'dev', `[clickvibe] ${agent} 结束,退出码 ${exitCode}`)
+        const reloaded = await loadWorkflow(workflow.key)
+        if (reloaded) {
+          if (exitCode === 0) {
+            reloaded.stage = 'review-ready'
+            reloaded.devInterrupted = false
+          } else {
+            reloaded.devInterrupted = true
+          }
+          await saveWorkflow(reloaded)
+        }
       })
     } catch (error) {
-      task.status = 'failed'
-      task.exitCode = null
-      task.log.push(`[clickvibe] 失败: ${String(error instanceof Error ? error.message : error)}`)
+      live.closed = true
+      await appendLog(workflow.key, 'dev', `[clickvibe] 失败: ${String(error instanceof Error ? error.message : error)}`)
     }
   })()
 
-  return { ok: true, taskId, worktree, branch }
+  return { ok: true, taskId, worktree: workflow.worktree, branch: workflow.branch }
 }
 
-/** Consume incremental log/status for one task. */
-function pollDevelop(
+/** Consume incremental dev log/status for one task. */
+async function pollDevelop(
   payload: unknown,
-): { ok: true; taskId: string; status: string; exitCode: number | null; delta: string[]; done: boolean } | { ok: false; error: string } {
+): Promise<
+  | { ok: true; taskId: string; status: string; exitCode: number | null; delta: string[]; done: boolean }
+  | { ok: false; error: string }
+> {
   const taskId = String((payload as { taskId?: unknown } | undefined)?.taskId ?? '')
-  const task = tasks.get(taskId)
-  if (!task) {
+  const live = liveTasks.get(taskId)
+  if (!live) {
     return { ok: false, error: `未知任务 ${taskId}` }
   }
-  const delta: string[] = []
-  if (task.process) {
-    const read = task.process.readOutput()
-    if (read.delta !== '') delta.push(read.delta)
-    if (read.lossy) delta.push('[clickvibe] 输出被截断(日志过长)')
-  }
-  // 内部日志(worktree 创建等)增量补发
-  const newLogs = task.log.splice(0, task.log.length)
-  delta.push(...newLogs)
+  const delta = live.lines.splice(0, live.lines.length)
   return {
     ok: true,
     taskId,
-    status: task.status,
-    exitCode: task.exitCode,
+    status: live.closed ? (live.process?.exitCode === 0 ? 'done' : 'failed') : 'running',
+    exitCode: live.process?.exitCode ?? null,
     delta,
-    done: task.status === 'done' || task.status === 'failed',
+    done: live.closed,
   }
+}
+
+/** SSE live stream: pushes parsed status lines for a task as they arrive. */
+function handleStream(req: IncomingMessage, res: ServerResponse): void {
+  const url = new URL(req.url ?? '/', 'http://clickvibe.internal')
+  const taskId = url.searchParams.get('taskId') ?? ''
+  const live = liveTasks.get(taskId)
+  if (!live) {
+    res.writeHead(404, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ ok: false, error: `未知任务 ${taskId}` }))
+    return
+  }
+
+  res.writeHead(200, {
+    'content-type': 'text/event-stream',
+    'cache-control': 'no-cache',
+    connection: 'keep-alive',
+  })
+
+  let index = 0
+  let closed = false
+
+  const flush = () => {
+    if (closed) return
+    while (index < live.lines.length) {
+      const line = live.lines[index]
+      index += 1
+      res.write(`data: ${JSON.stringify(line)}\n\n`)
+    }
+    if (live.closed) {
+      res.write(`data: ${JSON.stringify({ __done: true })}\n\n`)
+      res.end()
+      closed = true
+    }
+  }
+
+  flush()
+  if (!closed) {
+    const wake = () => flush()
+    const waiters = liveWaiters.get(taskId) ?? new Set<() => void>()
+    waiters.add(wake)
+    liveWaiters.set(taskId, waiters)
+    req.on('close', () => {
+      waiters.delete(wake)
+      if (waiters.size === 0) liveWaiters.delete(taskId)
+    })
+  }
+}
+
+/** Start a review task on the dev branch with codex/claude. */
+async function startReview(
+  ctx: Context,
+  payload: unknown,
+): Promise<
+  | { ok: true; taskId: string }
+  | { ok: false; error: string }
+> {
+  const body = (payload ?? {}) as { url?: unknown; agent?: unknown }
+  const url = String(body.url ?? '').trim()
+  const agentRaw = String(body.agent ?? 'codex').trim().toLowerCase()
+  const agent: AgentKind = agentRaw === 'claude' ? 'claude' : 'codex'
+  const parsed = parseUrl(url)
+  if (!parsed) {
+    return { ok: false, error: '请输入形如 https://github.com/owner/repo/issues/123 的链接' }
+  }
+  if (parsed.kind !== 'issue') {
+    return { ok: false, error: 'review 仅支持 issue 链接' }
+  }
+
+  const key = issueKey(`${parsed.owner}/${parsed.repo}`, parsed.number)
+  const workflow = await loadWorkflow(key)
+  if (!workflow || workflow.stage === 'idle' || workflow.stage === 'developing') {
+    return { ok: false, error: '该 issue 尚未完成开发,无法 review' }
+  }
+  if (!existsSync(workflow.worktree)) {
+    return { ok: false, error: `worktree 不存在: ${workflow.worktree}` }
+  }
+
+  const taskId = `review-${Date.now()}`
+  const live: LiveTask = {
+    taskId,
+    workflowKey: workflow.key,
+    kind: 'review',
+    agent,
+    lines: [],
+    closed: false,
+  }
+  liveTasks.set(taskId, live)
+  workflow.reviewAgent = agent
+  workflow.reviewTaskId = taskId
+  workflow.stage = 'reviewing'
+  await saveWorkflow(workflow)
+
+  const prompt = buildReviewPrompt(workflow)
+  const agentCommand = agent === 'claude'
+    ? 'claude -p --verbose --output-format stream-json'
+    : 'codex exec --json -'
+
+  await appendLog(workflow.key, 'review', `[clickvibe] 启动 ${agent} review…`)
+  attachAgentProcess(ctx, live, agentCommand, workflow.worktree, prompt, async (exitCode) => {
+    await appendLog(workflow.key, 'review', `[clickvibe] review 结束,退出码 ${exitCode}`)
+    // 读取 review 全文,判断通过/有问题
+    const lines = await readLogTail(workflow.key, 'review', 200)
+    const full = lines.join('\n')
+    const passed = exitCode === 0 && /^✅|通过/.test(full)
+    const issues = passed ? [] : extractIssues(full)
+    const reloaded = await loadWorkflow(workflow.key)
+    if (reloaded) {
+      reloaded.reviewResult = { passed, issues }
+      reloaded.stage = passed ? 'passed' : 'review-ready' // 有问题 → 可回开发(rework)
+      await saveWorkflow(reloaded)
+      // 发到 GitHub issue 评论
+      void postReviewComment(ctx, workflow.url, passed, issues)
+    }
+  })
+
+  return { ok: true, taskId }
+}
+
+/** Extract issue lines from a review result (lines after a ❌ header). */
+function extractIssues(text: string): string[] {
+  const lines = text.split('\n')
+  const out: string[] = []
+  let capturing = false
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (/^❌/.test(trimmed)) { capturing = true; continue }
+    if (capturing && trimmed !== '' && !/^✅/.test(trimmed)) {
+      out.push(trimmed)
+      if (out.length >= 20) break
+    }
+  }
+  return out
+}
+
+/** Post the review result to the issue's GitHub comments. */
+async function postReviewComment(ctx: Context, issueUrl: string, passed: boolean, issues: string[]): Promise<void> {
+  const body = passed
+    ? '## ✅ ClickVibe Review 通过\n\n自动 review 未发现问题。'
+    : `## ❌ ClickVibe Review 发现问题(${issues.length} 条)\n\n${issues.map((i) => `- ${i}`).join('\n')}`
+  const command = `gh issue comment ${JSON.stringify(issueUrl)} --body ${JSON.stringify(body)}`
+  try {
+    await runCommand(ctx, command, { timeoutMs: 30000 })
+  } catch {
+    // posting is best-effort
+  }
+}
+
+/** Resume an interrupted dev session (codex exec resume / claude --continue). */
+async function resumeDevelop(
+  ctx: Context,
+  payload: unknown,
+): Promise<{ ok: true; taskId: string } | { ok: false; error: string }> {
+  const body = (payload ?? {}) as { url?: unknown }
+  const url = String(body.url ?? '').trim()
+  const parsed = parseUrl(url)
+  if (!parsed || parsed.kind !== 'issue') {
+    return { ok: false, error: '请输入形如 https://github.com/owner/repo/issues/123 的链接' }
+  }
+  const key = issueKey(`${parsed.owner}/${parsed.repo}`, parsed.number)
+  const workflow = await loadWorkflow(key)
+  if (!workflow || !workflow.devInterrupted || !workflow.devTaskId) {
+    return { ok: false, error: '没有可恢复的中断任务' }
+  }
+
+  const oldLive = liveTasks.get(workflow.devTaskId)
+  if (oldLive && !oldLive.closed) {
+    return { ok: true, taskId: oldLive.taskId }
+  }
+
+  const taskId = `dev-${Date.now()}`
+  const live: LiveTask = {
+    taskId,
+    workflowKey: workflow.key,
+    kind: 'dev',
+    agent: workflow.devAgent ?? 'codex',
+    lines: [],
+    closed: false,
+  }
+  liveTasks.set(taskId, live)
+  workflow.devTaskId = taskId
+  workflow.devInterrupted = false
+  workflow.stage = 'developing'
+  await saveWorkflow(workflow)
+
+  // resume 需要会话 id(codex)或 --continue(claude);这里先尝试从日志找 session
+  const command = workflow.devAgent === 'claude'
+    ? 'claude -p --continue --verbose --output-format stream-json'
+    : 'codex exec --json --last -'
+  const prompt = '请继续完成刚才的开发任务。'
+
+  await appendLog(workflow.key, 'dev', `[clickvibe] 恢复 ${workflow.devAgent} 会话…`)
+  attachAgentProcess(ctx, live, command, workflow.worktree, prompt, async (exitCode) => {
+    await appendLog(workflow.key, 'dev', `[clickvibe] ${workflow.devAgent} 恢复结束,退出码 ${exitCode}`)
+    const reloaded = await loadWorkflow(workflow.key)
+    if (reloaded) {
+      reloaded.stage = exitCode === 0 ? 'review-ready' : 'developing'
+      reloaded.devInterrupted = exitCode !== 0
+      await saveWorkflow(reloaded)
+    }
+  })
+
+  return { ok: true, taskId }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { homedir } from 'node:os'
 import { join, basename } from 'node:path'
 import { parse as parseYaml } from 'yaml'
 import {
+  appendEvent,
   appendLog,
   issueKey,
   loadAllWorkflows,
@@ -207,9 +208,48 @@ async function runCommand(
   return result.stdout.text.trim()
 }
 
+/** Read the current HEAD short-hash of a worktree (empty string on failure). */
+async function readWorktreeHead(ctx: Context, worktree: string): Promise<string | null> {
+  try {
+    const spec = ctx.shell.resolve({
+      command: 'git rev-parse --short HEAD',
+      workdir: worktree,
+      timeoutMs: 10000,
+      sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: worktree },
+    })
+    const result = await ctx.shell.run(spec)
+    if (result.exitCode !== 0) return null
+    return result.stdout.text.trim() || null
+  } catch {
+    return null
+  }
+}
+
 /**
- * The clickvibe plugin: exports the profile-patch plugin contract.
+ * Derive the live state of a workflow from git facts + its event history.
+ * The stored `stage`/`reviewResult` stay as-is; this adds `derived` with
+ * the current worktree HEAD and whether commits exist beyond the last
+ * recorded dev event (i.e. un-reviewed work).
  */
+async function deriveWorkflowState(
+  ctx: Context,
+  workflow: IssueWorkflow,
+): Promise<IssueWorkflow & { derived: { head: string | null; hasNewCommits: boolean; lastDevHash: string | null; lastReviewHash: string | null } }> {
+  const head = existsSync(workflow.worktree) ? await readWorktreeHead(ctx, workflow.worktree) : null
+  const events = workflow.events ?? []
+  let lastDevHash: string | null = null
+  let lastReviewHash: string | null = null
+  for (const ev of events) {
+    if (ev.kind === 'dev' || ev.kind === 'rework') lastDevHash = ev.hash ?? lastDevHash
+    if (ev.kind === 'review') lastReviewHash = ev.hash ?? lastReviewHash
+  }
+  // 有新提交 = worktree HEAD 不在已记录的任何 dev/rework 事件哈希里
+  const hasNewCommits = head !== null && lastDevHash !== null && head !== lastDevHash
+  return {
+    ...workflow,
+    derived: { head, hasNewCommits, lastDevHash, lastReviewHash },
+  }
+}
 export const name = 'clickvibe'
 
 export const inject = ['webServer', 'shell']
@@ -253,7 +293,13 @@ export function apply(ctx: Context): void {
       }
       if (method === 'state') {
         const workflows = await loadAllWorkflows()
-        writeJson(res, 200, { ok: true, workflows })
+        // 附加推导状态:worktree HEAD + 相对最新事件的进展(不覆盖存储)
+        const enriched = []
+        for (const w of workflows) {
+          const derived = await deriveWorkflowState(ctx, w)
+          enriched.push(derived)
+        }
+        writeJson(res, 200, { ok: true, workflows: enriched })
         return
       }
       if (method === 'develop') {
@@ -424,8 +470,11 @@ async function ensureWorktree(ctx: Context, parsed: { owner: string; repo: strin
       reviewTaskId: null,
       reviewResult: null,
       updatedAt: Date.now(),
+      events: [],
     }
   }
+  // 旧状态文件兜底:补 events 字段
+  if (!Array.isArray(workflow.events)) workflow.events = []
   // 校正路径字段(配置可能变化)
   workflow.worktree = worktree
   workflow.branch = branch
@@ -560,6 +609,14 @@ async function startDevelop(
           if (exitCode === 0) {
             reloaded.stage = 'review-ready'
             reloaded.devInterrupted = false
+            // 记录开发提交事件:读 worktree HEAD 作为锚定哈希
+            const head = await readWorktreeHead(ctx, workflow.worktree)
+            await appendEvent(reloaded, {
+              kind: extraContext !== '' ? 'rework' : 'dev',
+              at: new Date().toISOString(),
+              hash: head ?? undefined,
+              note: `${agent} 完成开发${extraContext !== '' ? '(按 review 意见返工)' : ''}`,
+            })
           } else {
             reloaded.devInterrupted = true
           }
@@ -707,6 +764,15 @@ async function startReview(
     if (reloaded) {
       reloaded.reviewResult = { passed, issues }
       reloaded.stage = passed ? 'passed' : 'review-ready' // 有问题 → 可回开发(rework)
+      // 记录 review 历史事件:锚定被 review 的 HEAD
+      const reviewedHead = await readWorktreeHead(ctx, workflow.worktree)
+      await appendEvent(reloaded, {
+        kind: 'review',
+        at: new Date().toISOString(),
+        hash: reviewedHead ?? undefined,
+        verdict: { passed, issues },
+        note: `${agent} review${passed ? ' 通过' : ` 发现 ${issues.length} 个问题`}`,
+      })
       await saveWorkflow(reloaded)
       // 发到 GitHub issue 评论
       void postReviewComment(ctx, workflow.url, passed, issues)

--- a/src/state.ts
+++ b/src/state.ts
@@ -62,8 +62,6 @@ export async function loadWorkflow(key: string): Promise<IssueWorkflow | null> {
 /** Load every stored workflow (for panel restore). */
 export async function loadAllWorkflows(): Promise<IssueWorkflow[]> {
   try {
-    const dir = await readFile(stateDir(), 'utf8').then(() => true).catch(() => false)
-    if (!dir) return []
     const { readdir } = await import('node:fs/promises')
     const entries = await readdir(stateDir())
     const workflows: IssueWorkflow[] = []

--- a/src/state.ts
+++ b/src/state.ts
@@ -30,6 +30,7 @@ export interface IssueWorkflow {
   devInterrupted: boolean
   reviewAgent: 'codex' | 'claude' | null
   reviewTaskId: string | null
+  reviewSessionId: string | null
   reviewResult: { passed: boolean; issues: string[]; commentUrl?: string } | null
   updatedAt: number
   /** 完整历史事件链:每次开发提交/review/恢复各一条,按时间追加。 */

--- a/src/state.ts
+++ b/src/state.ts
@@ -34,6 +34,8 @@ export interface IssueWorkflow {
   reviewResult: { passed: boolean; issues: string[]; commentUrl?: string } | null
   /** 关联的 PR 号(开发分支的代码产物);issue 为 key,PR 记录在这里。 */
   prNumber: string | null
+  /** 开发基线:开 worktree 时基于的分支与提交(如 origin/main @ a8a7b5f)。 */
+  baseRef: string | null
   updatedAt: number
   /** 完整历史事件链:每次开发提交/review/恢复各一条,按时间追加。 */
   events: WorkflowEvent[]

--- a/src/state.ts
+++ b/src/state.ts
@@ -32,6 +32,8 @@ export interface IssueWorkflow {
   reviewTaskId: string | null
   reviewSessionId: string | null
   reviewResult: { passed: boolean; issues: string[]; commentUrl?: string } | null
+  /** 关联的 PR 号(开发分支的代码产物);issue 为 key,PR 记录在这里。 */
+  prNumber: string | null
   updatedAt: number
   /** 完整历史事件链:每次开发提交/review/恢复各一条,按时间追加。 */
   events: WorkflowEvent[]

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,121 @@
+/**
+ * clickvibe persistent workflow state.
+ *
+ * One JSON document per issue under ~/.clickvibe/state/, plus per-issue log
+ * files. Survives web restarts and page refreshes so the panel can restore
+ * its context (the issue being viewed + its dev/review workflow stage).
+ */
+import { mkdir, readFile, writeFile, appendFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join, dirname } from 'node:path'
+
+/** The workflow stage of one issue. */
+export type WorkflowStage =
+  | 'idle'        // 未开始开发
+  | 'developing'  // 开发中(可能有中断)
+  | 'review-ready'// 开发完成,待 review
+  | 'reviewing'   // review 中
+  | 'passed'      // review 通过
+
+export interface IssueWorkflow {
+  key: string
+  url: string
+  repoKey: string
+  worktree: string
+  branch: string
+  stage: WorkflowStage
+  devAgent: 'codex' | 'claude' | null
+  devTaskId: string | null
+  devSessionId: string | null
+  devInterrupted: boolean
+  reviewAgent: 'codex' | 'claude' | null
+  reviewTaskId: string | null
+  reviewResult: { passed: boolean; issues: string[]; commentUrl?: string } | null
+  updatedAt: number
+}
+
+/** Derive the per-issue state directory. */
+export function stateDir(): string {
+  return join(homedir(), '.clickvibe', 'state')
+}
+
+/** Derive the state file path for one issue key. */
+export function statePath(key: string): string {
+  return join(stateDir(), `${key}.json`)
+}
+
+/** Derive the log file path for one issue's dev/review log. */
+export function logPath(key: string, kind: 'dev' | 'review'): string {
+  return join(stateDir(), key, `${kind}.log`)
+}
+
+/** Load one issue's workflow state; missing file yields a fresh idle record. */
+export async function loadWorkflow(key: string): Promise<IssueWorkflow | null> {
+  try {
+    const raw = await readFile(statePath(key), 'utf8')
+    return JSON.parse(raw) as IssueWorkflow
+  } catch {
+    return null
+  }
+}
+
+/** Load every stored workflow (for panel restore). */
+export async function loadAllWorkflows(): Promise<IssueWorkflow[]> {
+  try {
+    const dir = await readFile(stateDir(), 'utf8').then(() => true).catch(() => false)
+    if (!dir) return []
+    const { readdir } = await import('node:fs/promises')
+    const entries = await readdir(stateDir())
+    const workflows: IssueWorkflow[] = []
+    for (const entry of entries) {
+      if (!entry.endsWith('.json')) continue
+      try {
+        const raw = await readFile(join(stateDir(), entry), 'utf8')
+        workflows.push(JSON.parse(raw) as IssueWorkflow)
+      } catch {
+        // corrupt state file: skip
+      }
+    }
+    return workflows.sort((a, b) => b.updatedAt - a.updatedAt)
+  } catch {
+    return []
+  }
+}
+
+/** Persist one issue's workflow state (atomic-ish: write then ignore errors). */
+export async function saveWorkflow(workflow: IssueWorkflow): Promise<void> {
+  try {
+    await mkdir(stateDir(), { recursive: true })
+    workflow.updatedAt = Date.now()
+    await writeFile(statePath(workflow.key), JSON.stringify(workflow, null, 2), 'utf8')
+  } catch {
+    // state persistence must never break the request path
+  }
+}
+
+/** Append one line to an issue's log file (creating the directory). */
+export async function appendLog(key: string, kind: 'dev' | 'review', line: string): Promise<void> {
+  try {
+    const dir = dirname(logPath(key, kind))
+    await mkdir(dir, { recursive: true })
+    await appendFile(logPath(key, kind), `${line}\n`, 'utf8')
+  } catch {
+    // log persistence is best-effort
+  }
+}
+
+/** Read a log file's tail; returns up to `limit` last lines. */
+export async function readLogTail(key: string, kind: 'dev' | 'review', limit = 500): Promise<string[]> {
+  try {
+    const raw = await readFile(logPath(key, kind), 'utf8')
+    const lines = raw.split('\n')
+    return lines.slice(Math.max(0, lines.length - limit - 1), lines.length - 1)
+  } catch {
+    return []
+  }
+}
+
+/** Derive a stable issue key from repo + number (safe for filenames). */
+export function issueKey(repoKey: string, number: string): string {
+  return `${repoKey.replace(/[^A-Za-z0-9_.-]/g, '-')}-${number}`
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -32,6 +32,26 @@ export interface IssueWorkflow {
   reviewTaskId: string | null
   reviewResult: { passed: boolean; issues: string[]; commentUrl?: string } | null
   updatedAt: number
+  /** 完整历史事件链:每次开发提交/review/恢复各一条,按时间追加。 */
+  events: WorkflowEvent[]
+}
+
+/** One historical event in an issue's workflow timeline. */
+export interface WorkflowEvent {
+  kind: 'dev' | 'review' | 'rework' | 'resume' | 'note'
+  at: string
+  /** commit hash 短码(dev/review 锚定的提交)。 */
+  hash?: string
+  /** review 结论(仅 review 事件)。 */
+  verdict?: { passed: boolean; issues: string[] }
+  note?: string
+}
+
+/** Append one event to a workflow and persist. */
+export async function appendEvent(workflow: IssueWorkflow, event: WorkflowEvent): Promise<void> {
+  workflow.events = workflow.events ?? []
+  workflow.events.push(event)
+  await saveWorkflow(workflow)
 }
 
 /** Derive the per-issue state directory. */

--- a/tests/develop.test.ts
+++ b/tests/develop.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  LineLog,
+  decideWorktreeRecovery,
+  parseAgent,
+  parseGithubUrl,
+  shellQuote,
+} from '../src/develop.ts'
+
+test('parseAgent accepts only the three supported agents', () => {
+  assert.equal(parseAgent('codex'), 'codex')
+  assert.equal(parseAgent('CLAUDE'), 'claude')
+  assert.equal(parseAgent(' dryrun '), 'dryrun')
+  assert.equal(parseAgent(undefined), 'codex')
+  assert.throws(() => parseAgent('other'), /不支持的 agent/)
+})
+
+test('parseGithubUrl accepts exact issue and PR URLs only', () => {
+  assert.deepEqual(parseGithubUrl('https://github.com/ai-daming/clickvibe/issues/1'), {
+    kind: 'issue', owner: 'ai-daming', repo: 'clickvibe', number: '1',
+  })
+  assert.equal(parseGithubUrl('https://github.com/a/b/issues/1/extra'), null)
+  assert.equal(parseGithubUrl('https://evil.example/a/b/issues/1'), null)
+})
+
+test('shellQuote prevents POSIX shell expansion', () => {
+  assert.equal(shellQuote('/tmp/simple'), "'/tmp/simple'")
+  assert.equal(shellQuote("/tmp/a'b$(touch nope)"), "'/tmp/a'\\''b$(touch nope)'")
+})
+
+test('LineLog buffers complete lines and flushes a final fragment', () => {
+  const log = new LineLog(10)
+  log.appendChunk('one\ntw')
+  assert.deepEqual(log.read(0), { cursor: 1, lines: ['one'], truncated: false })
+  log.appendChunk('o\nthree\r\n')
+  log.appendChunk('last')
+  log.flush()
+  assert.deepEqual(log.read(1), {
+    cursor: 4,
+    lines: ['two', 'three', 'last'],
+    truncated: false,
+  })
+})
+
+test('LineLog keeps readers independent and reports truncation', () => {
+  const log = new LineLog(3)
+  log.appendLine('one')
+  log.appendLine('two')
+  assert.deepEqual(log.read(0).lines, ['one', 'two'])
+  assert.deepEqual(log.read(0).lines, ['one', 'two'])
+  log.appendLine('three')
+  log.appendLine('four')
+  assert.deepEqual(log.read(0), {
+    cursor: 4,
+    lines: ['[clickvibe] 较早日志已截断', 'two', 'three', 'four'],
+    truncated: true,
+  })
+})
+
+test('worktree recovery creates or reuses the intended branch', () => {
+  assert.deepEqual(decideWorktreeRecovery({
+    targetBranch: 'clickvibe-issue-1',
+    pathExists: false, pathEmpty: false, registeredBranch: null,
+    branchExists: false, branchWorktree: null,
+  }), { kind: 'add-new-branch' })
+  assert.deepEqual(decideWorktreeRecovery({
+    targetBranch: 'clickvibe-issue-1',
+    pathExists: true, pathEmpty: true, registeredBranch: null,
+    branchExists: true, branchWorktree: null,
+  }), { kind: 'add-existing-branch' })
+  assert.deepEqual(decideWorktreeRecovery({
+    targetBranch: 'clickvibe-issue-1',
+    pathExists: true, pathEmpty: false, registeredBranch: 'clickvibe-issue-1',
+    branchExists: true, branchWorktree: '/target',
+  }), { kind: 'reuse' })
+  assert.deepEqual(decideWorktreeRecovery({
+    targetBranch: 'clickvibe-issue-1',
+    pathExists: true, pathEmpty: false, registeredBranch: 'HEAD',
+    branchExists: false, branchWorktree: null,
+  }), { kind: 'attach-detached' })
+  assert.deepEqual(decideWorktreeRecovery({
+    targetBranch: 'clickvibe-issue-1',
+    pathExists: true, pathEmpty: false, registeredBranch: 'HEAD',
+    branchExists: true, branchWorktree: null,
+  }), { kind: 'attach-existing' })
+})
+
+test('worktree recovery fails closed for conflicting partial states', () => {
+  assert.match(decideWorktreeRecovery({
+    targetBranch: 'clickvibe-issue-1',
+    pathExists: true, pathEmpty: false, registeredBranch: null,
+    branchExists: false, branchWorktree: null,
+  }).reason ?? '', /非空目录/)
+  assert.match(decideWorktreeRecovery({
+    targetBranch: 'clickvibe-issue-1',
+    pathExists: true, pathEmpty: false, registeredBranch: 'other',
+    branchExists: true, branchWorktree: null,
+  }).reason ?? '', /其他分支/)
+  assert.match(decideWorktreeRecovery({
+    targetBranch: 'clickvibe-issue-1',
+    pathExists: false, pathEmpty: false, registeredBranch: null,
+    branchExists: true, branchWorktree: '/elsewhere',
+  }).reason ?? '', /其他 worktree/)
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
+    "allowImportingTsExtensions": true,
     "declaration": true,
     "emitDeclarationOnly": false
   },


### PR DESCRIPTION
## 概要

- 增加 `dryrun` agent，通过同一 worktree/任务/轮询链路执行只读的 cwd、分支和 Git 状态检查
- 增加有界按行日志、独立 cursor 增量轮询，以及 Host/面板双重超长截断提示
- 恢复缺分支、缺 worktree、detached、注册路径失踪或被掏空等半完成状态，并对冲突目录/分支失败关闭
- 在 Issue 面板加入 Codex、Claude 和安全演练入口，实时显示日志与终态
- 增加真实 YAML 配置解析、安全 shell 参数转义和真实 agent 执行确认

## 验证

- `pnpm test`：7 项通过
- `pnpm run typecheck`：通过
- `pnpm run build`：Host/Client bundle 通过
- 精确链接当前 worktree 的隔离 DSH Host：curl dry-run 返回 `taskId`，cursor 轮询到 `done`、exit code 0，前后 HEAD/status/diff 完全一致
- Playwright 真实浏览器：Issue #1 可抓取，安全演练完成后面板日志区显示 worktree、branch、status 增量输出与完成状态
- 真实 Git 夹具：注册目录失踪和注册目录为空两种状态均可重建到原分支并恢复文件
- 自举：ClickVibe 创建并复用 `clickvibe-issue-1` worktree/分支，Codex 在该 worktree 完成提交并推送远端

Closes #1
