### PR TITLE
feat: 权威状态视图(issue #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ DSH web 插件:右侧面板输入 GitHub issue / PR 链接,通过本地 `gh` CLI
   - PR 额外:分支 `base ← head`、变更统计、提交数、合并状态
   - 正文与评论:轻量 Markdown 渲染器(标题/粗斜体/代码块/列表/引用/链接),评论默认展开
   - 整块内容区一个滚动条(GitHub 风格)
+- **权威状态视图**(#5):每次请求实时推导
+  - 三方对比:worktree / main / 远端(origin/main、远端同名分支)的哈希与 ahead/behind
+  - worktree 落后远端时提示「需要同步」并提供 /sync 动作(fetch + merge origin/main,冲突自动回滚)
+  - review 结论标注它审查的 HEAD;HEAD 变化后自动显示「结论已过期」,不冒充当前状态
+  - 任意时刻只有一个「下一步动作」按钮(开发/恢复/同步/Review/返工/合并),由 git 事实推导,不靠易错的 stage 字段
 - Open issue 一键开发:
   - `Codex 开发` / `Claude 开发`:在 issue worktree 中启动非交互 agent
   - `安全演练`:走完整 worktree/任务/轮询链路,只执行 `pwd`、当前分支和 `git status`
@@ -29,7 +34,8 @@ DSH web 插件:右侧面板输入 GitHub issue / PR 链接,通过本地 `gh` CLI
 |---|---|---|
 | Host | `src/index.ts` | 注册 `/clickvibe/api` 前缀路由,处理 GitHub 抓取、开发任务和 cursor 日志轮询 |
 | 开发内核 | `src/develop.ts` | agent/URL 校验、shell 参数转义、有界行日志和 worktree 恢复决策 |
-| Client | `src/client/index.tsx` | `shell.overlay` 右侧面板 + `sidebar.footer.action` 开关按钮,`fetch('/clickvibe/api/fetch')` 取数 |
+| 状态视图 | `src/state-view.ts` | 纯函数 `deriveNextAction`:由 git 事实 + 事件历史推导唯一下一步动作 |
+| Client | `src/client/index.tsx` | `shell.overlay` 右侧面板 + `sidebar.footer.action` 开关按钮,`fetch('/clickvibe/api/fetch')` 取数;状态视图 + 唯一动作按钮 |
 | 构建 | `tsdown.config.ts` | host → `lib/index.js`(ESM),client → `lib/client.js`(CJS 闭包,`window.__ModuleLoader__.load` 注册) |
 
 Client→Host 走 **HTTP API 路由**(正式插件没有动态插件的 `harness.handle`),这是与原型最大的结构差异。
@@ -80,6 +86,13 @@ curl http://127.0.0.1:3080/plugins/clickvibe/client.js
 curl -X POST http://127.0.0.1:3080/clickvibe/api/develop \
   -H 'content-type: application/json' \
   -d '{"url":"https://github.com/ai-daming/clickvibe/issues/1","agent":"dryrun"}'
+
+# 同步 worktree 到远端基线(fetch + merge origin/main,冲突自动回滚)
+curl -X POST http://127.0.0.1:3080/clickvibe/api/sync \
+  -H 'content-type: application/json' \
+  -H 'origin: http://127.0.0.1:3080' \
+  -H 'x-clickvibe-request: 1' \
+  -d '{"url":"https://github.com/ai-daming/clickvibe/issues/5"}'
 
 # 用启动响应中的 taskId 和 poll 响应中的 cursor 增量轮询
 curl -X POST http://127.0.0.1:3080/clickvibe/api/develop/poll \

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -133,6 +133,12 @@ const PANEL_CSS = `
 .cv-link-state-open { background: #dafbe1; color: #1a7f37; }
 .cv-link-state-closed { background: #ffebe9; color: #cf222e; }
 .cv-link-state-merged { background: #d8f5ff; color: #8250df; }
+.cv-link-state-open { background: #dafbe1; color: #1a7f37; }
+.cv-link-kind { font-size: 10.5px; font-weight: 700; color: #57606a; }
+.cv-pr-icon { flex-shrink: 0; display: inline-block; }
+.cv-pr-open { color: #1a7f37; }
+.cv-pr-merged { color: #8250df; }
+.cv-pr-closed { color: #cf222e; }
 .cv-stage-new { background: #fff8c5; color: #9a6700; }
 .cv-timeline { border-top: 1px solid #d0d7de; padding-top: 6px; display: flex; flex-direction: column; gap: 4px; }
 .cv-timeline-head { font-size: 12px; font-weight: 600; color: #57606a; }
@@ -360,7 +366,44 @@ interface TimelineEvent {
   created_at?: string
   actor?: string
   commit_id?: string | null
-  source?: { number?: number; title?: string; html_url?: string; state?: string } | null
+  source?: {
+    number?: number
+    title?: string
+    html_url?: string
+    state?: string
+    is_pr?: boolean
+    pr_merged?: boolean
+  } | null
+}
+
+/** Derived display state of a linked item: PRs get open/merged/closed, issues open/closed. */
+function linkedState(source: NonNullable<TimelineEvent['source']>): 'open' | 'closed' | 'merged' {
+  if (source.is_pr) {
+    if (source.pr_merged) return 'merged'
+    return source.state === 'closed' ? 'closed' : 'open'
+  }
+  return source.state === 'closed' ? 'closed' : 'open'
+}
+
+const OCTICON_PR = 'M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z'
+const OCTICON_MERGE = 'M5.45 5.154A4.25 4.25 0 0 0 9.25 7.5h1.378a2.251 2.251 0 1 1 0 1.5H9.25A5.734 5.734 0 0 1 5 7.123v3.505a2.25 2.25 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.95-.218ZM4.25 13.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm8.5-8.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z'
+
+/** GitHub-style PR state icon (open: pull-request, merged: git-merge, closed: pull-request). */
+function PrStateIcon({ state }: { state: 'open' | 'closed' | 'merged' }) {
+  return (
+    <svg className={`cv-pr-icon cv-pr-${state}`} viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true">
+      <path d={state === 'merged' ? OCTICON_MERGE : OCTICON_PR} />
+    </svg>
+  )
+}
+
+/** Label of a linked item's state (GitHub wording). */
+function linkedStateLabel(source: NonNullable<TimelineEvent['source']>): string {
+  const state = linkedState(source)
+  if (source.is_pr) {
+    return state === 'merged' ? '已合并' : state === 'closed' ? '已关闭' : '打开'
+  }
+  return state === 'closed' ? '已关闭' : '打开'
 }
 
 /** One resolved dependency: number + title + GitHub state. */
@@ -491,14 +534,18 @@ function IssueView({ issue, kind, workflow, onWorkflow, timeline, dependencies }
         <div className="cv-links">
           {timeline.map((ev, i) => {
             if (ev.event === 'cross-referenced' && ev.source) {
+              const linkedStateValue = linkedState(ev.source)
               return (
                 <div key={i} className="cv-link-row">
-                  🔗 关联
+                  {ev.source.is_pr
+                    ? <PrStateIcon state={linkedStateValue} />
+                    : <span className="cv-link-kind">🔗</span>}
+                  <span className="cv-link-kind">{ev.source.is_pr ? 'PR' : 'Issue'}</span>
                   <a className="cv-link" href={ev.source.html_url} target="_blank" rel="noreferrer">
-                    {ev.source.title ? `#${ev.source.number} ${ev.source.title}` : `#${ev.source.number}`}
+                    #{ev.source.number} {ev.source.title ?? ''}
                   </a>
-                  <span className={`cv-link-state cv-link-state-${ev.source.state ?? 'open'}`}>
-                    {ev.source.state === 'closed' ? '已关闭' : ev.source.state === 'merged' ? '已合并' : '打开'}
+                  <span className={`cv-link-state cv-link-state-${linkedStateValue}`}>
+                    {linkedStateLabel(ev.source)}
                   </span>
                 </div>
               )

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -147,6 +147,24 @@ const PANEL_CSS = `
 .cv-tl-pass { color: #1a7f37; }
 .cv-tl-fail { color: #cf222e; }
 .cv-tl-note { color: #57606a; }
+.cv-state { border: 1px solid #d0d7de; border-radius: 6px; padding: 8px 10px; display: flex; flex-direction: column; gap: 4px; }
+.cv-state-head { font-size: 12px; font-weight: 600; color: #57606a; }
+.cv-state-table { width: 100%; border-collapse: collapse; font-size: 11.5px; }
+.cv-state-table td { padding: 3px 0; vertical-align: top; }
+.cv-state-k { width: 78px; color: #8c959f; font-weight: 600; }
+.cv-state-v { color: #1f2328; word-break: break-all; }
+.cv-state-delta { display: block; color: #57606a; font-size: 11px; }
+.cv-state-warn { display: inline-block; margin-left: 6px; padding: 0 6px; border-radius: 8px; background: #fff8c5; color: #9a6700; font-weight: 600; font-size: 10.5px; }
+.cv-review-stale { font-size: 12px; color: #9a6700; background: #fff8c5; border: 1px solid #d4a72c; border-radius: 4px; padding: 6px 8px; }
+.cv-dev-noop { font-size: 12px; color: #8c959f; padding: 4px 0; }
+.cv-agent-toggle { display: inline-flex; gap: 2px; border: 1px solid #d0d7de; border-radius: 6px; overflow: hidden; align-self: center; }
+.cv-agent-toggle button { border: none; background: #ffffff; color: #57606a; padding: 4px 10px; font-size: 12px; cursor: pointer; }
+.cv-agent-toggle button.on { background: #0969da; color: #ffffff; }
+.cv-agent-toggle button:disabled { opacity: 0.45; cursor: not-allowed; }
+.cv-dev-btn.cv-dev-sync { background: #0969da; }
+.cv-dev-btn.cv-dev-merge { background: #1a7f37; }
+.cv-dev-link { border: none; background: transparent; color: #0969da; font-size: 11.5px; cursor: pointer; padding: 4px 2px; text-decoration: underline; }
+.cv-dev-link:hover { opacity: 0.8; }
 `
 
 /** Inject the plugin stylesheet once; returns the disposer. */
@@ -469,10 +487,38 @@ interface Workflow {
   reviewSessionId: string | null
   reviewResult: { passed: boolean; issues: string[]; commentUrl?: string } | null
   prNumber: string | null
+  issueState?: 'OPEN' | 'CLOSED'
   baseRef: string | null
   updatedAt: number
   events?: WorkflowEvent[]
-  derived?: { head: string | null; hasNewCommits: boolean; lastDevHash: string | null; lastReviewHash: string | null }
+  derived?: {
+    head: string | null
+    branch: string | null
+    mainHead: string | null
+    originMainHead: string | null
+    upstreamHead: string | null
+    aheadOfMain: number
+    behindMain: number
+    aheadOfBase: number
+    behindBase: number
+    aheadOfUpstream: number | null
+    behindUpstream: number | null
+    needsSync: boolean
+    lastDevHash: string | null
+    lastReviewHash: string | null
+    reviewedHash: string | null
+    hasNewCommits: boolean
+    verdictCurrent: boolean
+    nextAction: NextAction
+  }
+}
+
+type NextActionKind = 'develop' | 'resume' | 'sync' | 'review' | 'rework' | 'merge' | 'none'
+
+interface NextAction {
+  kind: NextActionKind
+  label: string
+  hint: string
 }
 
 interface WorkflowEvent {
@@ -511,9 +557,12 @@ function DevSection({ url, issue, workflow, onWorkflow }: {
   const [error, setError] = React.useState<string | null>(null)
   const [statusLines, setStatusLines] = React.useState<string[]>([])
   const [activeTaskId, setActiveTaskId] = React.useState<string | null>(null)
+  const [agentChoice, setAgentChoice] = React.useState<'codex' | 'claude'>('codex')
   const esRef = React.useRef<EventSource | null>(null)
   const stage = workflow?.stage ?? 'idle'
-  const interrupted = workflow?.devInterrupted ?? false
+  const derived = workflow?.derived
+  const nextAction = derived?.nextAction
+
   const appendStatusLine = (line: string) => {
     setStatusLines((previous) => {
       const next = [...previous, line]
@@ -558,6 +607,12 @@ function DevSection({ url, issue, workflow, onWorkflow }: {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workflow?.devTaskId, workflow?.reviewTaskId, workflow?.stage])
+
+  // agent 选择跟随锁定 agent(review 锁 reviewAgent;resume/rework 用 devAgent)
+  React.useEffect(() => {
+    const preferred = workflow?.reviewAgent ?? workflow?.devAgent
+    setAgentChoice(preferred ?? 'codex')
+  }, [workflow?.reviewAgent, workflow?.devAgent])
 
   const refresh = async () => {
     const res = await apiCall<{ ok: true; workflows: Workflow[] }>('state', {})
@@ -653,23 +708,65 @@ function DevSection({ url, issue, workflow, onWorkflow }: {
     if (!res.ok) setError(res.error ?? '停止失败')
   }
 
-  const showDevButtons = stage === 'idle'
-  const canReview = stage === 'review-ready' && !interrupted && !workflow?.reviewResult
-  // review agent 锁定:上次用什么 review,这次就只显示那个按钮;
-  // 从未 review 过则两个都显示(首次自由选)。
-  const showCodexReview = canReview && (!workflow?.reviewAgent || workflow.reviewAgent === 'codex')
-  const showClaudeReview = canReview && (!workflow?.reviewAgent || workflow.reviewAgent === 'claude')
-  const showReworkButtons = stage === 'review-ready' && workflow?.reviewResult?.passed === false
+  const syncWorktree = async () => {
+    setBusy('syncing')
+    setError(null)
+    try {
+      const res = await apiCall<{ ok: true; worktree: string; branch: string; head: string | null } | { ok: false; error: string }>('sync', { url })
+      if (!res.ok) { setError(res.error); setBusy(null); return }
+      await refresh()
+      setBusy(null)
+    } catch (e) {
+      setError(String(e)); setBusy(null)
+    }
+  }
+
+  // 唯一动作:服务端由 git 事实推导;issue 已关闭时本地覆盖为无动作
+  const issueClosed = String(issue.state ?? '').toUpperCase() === 'CLOSED'
+  const effectiveAction: NextAction = issueClosed
+    ? { kind: 'none', label: '无', hint: 'issue 已关闭,无待办动作' }
+    : (nextAction ?? { kind: 'none', label: '无', hint: '等待状态…' })
+
+  const runAction = () => {
+    switch (effectiveAction.kind) {
+      case 'develop': void startDev(agentChoice); break
+      case 'resume': void resume(); break
+      case 'rework': void resume(workflow?.reviewResult?.issues.join('\n')); break
+      case 'review': void startReview(agentChoice); break
+      case 'sync': void syncWorktree(); break
+      case 'merge':
+        if (workflow?.prNumber) {
+          window.open(`https://github.com/${workflow.repoKey}/pull/${workflow.prNumber}`, '_blank', 'noopener')
+        }
+        break
+      case 'none': break
+    }
+  }
+
+  // review 锁定:从未 review 过则两个 agent 都可选;锁过只留那个
+  const lockedAgent = effectiveAction.kind === 'review' ? workflow?.reviewAgent ?? null : null
+  const showAgentToggle = effectiveAction.kind === 'develop' || effectiveAction.kind === 'review'
+
+  const actionButtonClass = effectiveAction.kind === 'merge'
+    ? 'cv-dev-btn cv-dev-merge'
+    : effectiveAction.kind === 'sync'
+      ? 'cv-dev-btn cv-dev-sync'
+      : effectiveAction.kind === 'review'
+        ? 'cv-dev-btn cv-dev-review'
+        : (effectiveAction.kind === 'resume' || effectiveAction.kind === 'rework')
+          ? 'cv-dev-btn cv-dev-warn'
+          : 'cv-dev-btn cv-dev-codex'
+
+  const busyLabel = busy === 'syncing' ? '同步中…' : busy === 'resuming' ? '恢复中…' : busy === 'reviewing' ? 'Review 中…' : busy === 'developing' ? '启动中…' : null
 
   return (
     <div className="cv-dev">
       {/* 状态卡:当前状态 + 关键事实 */}
       <div className="cv-dev-head">
         🚀 开发流程 <span className={`cv-stage cv-stage-${stage}`}>{stageLabel(stage, workflow)}</span>
-        {workflow?.derived?.hasNewCommits ? <span className="cv-stage cv-stage-new">有未 review 的新提交</span> : null}
+        {derived?.hasNewCommits ? <span className="cv-stage cv-stage-new">有未 review 的新提交</span> : null}
       </div>
       {workflow?.worktree ? <div className="cv-dev-path">{workflow.worktree}</div> : null}
-      {workflow?.derived?.head ? <div className="cv-dev-path">HEAD {workflow.derived.head}</div> : null}
       {workflow?.prNumber ? (
         <div className="cv-dev-path">
           🔗 PR{' '}
@@ -679,33 +776,91 @@ function DevSection({ url, issue, workflow, onWorkflow }: {
         </div>
       ) : null}
 
-      {/* 操作区(悬浮感):与信息分离 */}
+      {/* 权威状态视图:worktree / main / 远端 三方对比(issue #5) */}
+      {derived ? (
+        <div className="cv-state">
+          <div className="cv-state-head">📊 状态视图</div>
+          <table className="cv-state-table">
+            <tbody>
+              <tr>
+                <td className="cv-state-k">worktree</td>
+                <td className="cv-state-v">
+                  {derived.branch ?? workflow?.branch ?? '—'} <code className="cv-tl-hash">{derived.head ?? '—'}</code>
+                </td>
+              </tr>
+              {derived.mainHead ? (
+                <tr>
+                  <td className="cv-state-k">main</td>
+                  <td className="cv-state-v">
+                    <code className="cv-tl-hash">{derived.mainHead}</code>
+                    <span className="cv-state-delta">worktree 落后 {derived.behindMain} · 领先 {derived.aheadOfMain}</span>
+                  </td>
+                </tr>
+              ) : null}
+              {derived.originMainHead ? (
+                <tr>
+                  <td className="cv-state-k">远端</td>
+                  <td className="cv-state-v">
+                    origin/main <code className="cv-tl-hash">{derived.originMainHead}</code>
+                    <span className="cv-state-delta">worktree 落后 {derived.behindBase} · 领先 {derived.aheadOfBase}</span>
+                    {derived.needsSync ? <span className="cv-state-warn">⚠ 需要同步</span> : null}
+                  </td>
+                </tr>
+              ) : null}
+              {derived.upstreamHead ? (
+                <tr>
+                  <td className="cv-state-k">远端分支</td>
+                  <td className="cv-state-v">
+                    origin/{derived.branch ?? workflow?.branch} <code className="cv-tl-hash">{derived.upstreamHead}</code>
+                    <span className="cv-state-delta">worktree 落后 {derived.behindUpstream ?? 0} · 领先 {derived.aheadOfUpstream ?? 0}</span>
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+
+      {/* review 结论:标注它审查的 HEAD;HEAD 变化后不冒充当前结论 */}
+      {workflow?.reviewResult ? (
+        <div className={derived?.verdictCurrent ? (workflow.reviewResult.passed ? 'cv-dev-done' : 'cv-review-fail') : 'cv-review-stale'}>
+          {derived?.verdictCurrent
+            ? (workflow.reviewResult.passed
+              ? `✅ Review 通过(针对提交 ${derived.reviewedHash ?? '?'})`
+              : `❌ Review 发现 ${workflow.reviewResult.issues.length} 个问题(针对提交 ${derived.reviewedHash ?? '?'})`)
+            : `⏳ Review 结论针对旧提交 ${derived?.reviewedHash ?? '?'},当前 HEAD ${derived?.head ?? '?'} 已变化,结论已过期`}
+        </div>
+      ) : null}
+      {workflow?.reviewResult && !workflow.reviewResult.passed && derived?.verdictCurrent ? (
+        <ul className="cv-review-issues">
+          {workflow.reviewResult.issues.map((issue, i) => <li key={i}>{issue}</li>)}
+        </ul>
+      ) : null}
+
+      {/* 唯一动作 */}
       <div className="cv-dev-actions">
-        {interrupted && stage === 'developing' ? (
-          <button className="cv-dev-btn cv-dev-warn" onClick={() => resume()} disabled={busy !== null}>
-            {busy === 'resuming' ? '恢复中…' : '↩ 恢复开发'}
-          </button>
-        ) : null}
-        {showDevButtons ? (
+        {effectiveAction.kind === 'none' ? (
+          <div className="cv-dev-noop">· {effectiveAction.hint}</div>
+        ) : (
           <>
-            <button className="cv-dev-btn cv-dev-codex" onClick={() => startDev('codex')} disabled={busy !== null}>Codex 开发</button>
-            <button className="cv-dev-btn cv-dev-claude" onClick={() => startDev('claude')} disabled={busy !== null}>Claude 开发</button>
-            <button className="cv-dev-btn cv-dev-warn" onClick={() => startDev('dryrun')} disabled={busy !== null}>安全演练</button>
+            {showAgentToggle ? (
+              <div className="cv-agent-toggle" title={lockedAgent ? `Review 锁定 ${lockedAgent}` : '选择 agent'}>
+                <button className={agentChoice === 'codex' ? 'on' : ''} onClick={() => setAgentChoice('codex')} disabled={lockedAgent !== null && lockedAgent !== 'codex'}>Codex</button>
+                <button className={agentChoice === 'claude' ? 'on' : ''} onClick={() => setAgentChoice('claude')} disabled={lockedAgent !== null && lockedAgent !== 'claude'}>Claude</button>
+              </div>
+            ) : null}
+            <button
+              className={actionButtonClass}
+              onClick={runAction}
+              disabled={busy !== null}
+              title={effectiveAction.hint}
+            >
+              {busyLabel ?? effectiveAction.label}
+            </button>
           </>
-        ) : null}
-        {showCodexReview ? (
-          <button className="cv-dev-btn cv-dev-review" onClick={() => startReview('codex')} disabled={busy !== null}>Codex Review</button>
-        ) : null}
-        {showClaudeReview ? (
-          <button className="cv-dev-btn cv-dev-review" onClick={() => startReview('claude')} disabled={busy !== null}>Claude Review</button>
-        ) : null}
-        {workflow?.reviewResult && !workflow.reviewResult.passed ? (
-          <button
-            className="cv-dev-btn cv-dev-codex"
-            onClick={() => resume(workflow?.reviewResult?.issues.join('\n'))}
-            disabled={busy !== null}
-            title="续上次开发会话,并把 review 意见带进去"
-          >↩ 按 review 意见继续开发</button>
+        )}
+        {stage === 'idle' && effectiveAction.kind === 'develop' ? (
+          <button className="cv-dev-link" onClick={() => startDev('dryrun')} disabled={busy !== null}>安全演练(dry-run)</button>
         ) : null}
         {activeTaskId ? (
           <button className="cv-dev-btn cv-dev-warn" onClick={() => void stop()}>停止任务</button>
@@ -717,17 +872,6 @@ function DevSection({ url, issue, workflow, onWorkflow }: {
       {statusLines.length > 0 ? (
         <pre className="cv-dev-log">{statusLines.join('\n')}</pre>
       ) : null}
-
-      {/* 最新 review 结论(当前状态的一部分) */}
-      {workflow?.reviewResult && !workflow.reviewResult.passed ? (
-        <div className="cv-review-fail">
-          <div className="cv-dev-error">❌ 最近一次 Review 发现 {workflow.reviewResult.issues.length} 个问题</div>
-          <ul className="cv-review-issues">
-            {workflow.reviewResult.issues.map((issue, i) => <li key={i}>{issue}</li>)}
-          </ul>
-        </div>
-      ) : null}
-      {workflow?.reviewResult?.passed ? <div className="cv-dev-done">✅ Review 通过</div> : null}
 
       {/* 历史时间线:全部事件,按时间顺序 */}
       {(workflow?.events ?? []).length > 0 ? (

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -124,6 +124,8 @@ const PANEL_CSS = `
 .cv-refresh { padding: 6px 10px; border: 1px solid #d0d7de; border-radius: 6px; background: #ffffff; color: #57606a; cursor: pointer; font-size: 14px; line-height: 1; }
 .cv-refresh:hover { background: #f6f8fa; color: #1f2328; }
 .cv-links { display: flex; flex-direction: column; gap: 4px; }
+.cv-dep-block { display: flex; flex-direction: column; gap: 4px; }
+.cv-dep-label { font-size: 12px; font-weight: 600; color: #57606a; }
 .cv-link-row { display: flex; align-items: center; gap: 6px; font-size: 12px; color: #57606a; flex-wrap: wrap; }
 .cv-link { color: #0969da; font-weight: 600; text-decoration: none; }
 .cv-link:hover { text-decoration: underline; }
@@ -361,12 +363,32 @@ interface TimelineEvent {
   source?: { number?: number; title?: string; html_url?: string; state?: string } | null
 }
 
-function IssueView({ issue, kind, workflow, onWorkflow, timeline }: {
+/** One resolved dependency: number + title + GitHub state. */
+interface Dependency {
+  number: number
+  title: string
+  state: string
+}
+
+/** Dependency graph of the viewed issue: who it waits on, who waits on it. */
+interface Dependencies {
+  blockedBy: Dependency[]
+  blocking: Dependency[]
+}
+
+/** Derive the owner/repo part of a GitHub URL for building dependency links. */
+function repoOf(url: string | undefined): string {
+  const match = String(url ?? '').match(/github\.com\/([^/]+\/[^/]+)\//)
+  return match ? match[1] : ''
+}
+
+function IssueView({ issue, kind, workflow, onWorkflow, timeline, dependencies }: {
   issue: GhIssue
   kind: 'issue' | 'pr'
   workflow: Workflow | null
   onWorkflow: (w: Workflow | null) => void
   timeline?: TimelineEvent[]
+  dependencies?: Dependencies
 }) {
   const isPR = kind === 'pr'
   const state = String(issue.state || '').toUpperCase()
@@ -424,6 +446,43 @@ function IssueView({ issue, kind, workflow, onWorkflow, timeline }: {
             <div className="cv-link-row">
               📍 基线
               <code className="cv-tl-hash">{workflow.baseRef}</code>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+      {/* 依赖图:blockedBy(依赖谁)/ blocking(谁依赖我)——与 GitHub「关联」明确区分 */}
+      {dependencies && (dependencies.blockedBy.length > 0 || dependencies.blocking.length > 0) ? (
+        <div className="cv-links">
+          {dependencies.blockedBy.length > 0 ? (
+            <div className="cv-dep-block">
+              <div className="cv-dep-label">🔒 blockedBy(依赖,需先完成)</div>
+              {dependencies.blockedBy.map((dep, i) => (
+                <div key={i} className="cv-link-row">
+                  <a className="cv-link" href={`https://github.com/${repoOf(issue.url)}/issues/${dep.number}`} target="_blank" rel="noreferrer">
+                    #{dep.number}{dep.title ? ` ${dep.title}` : ''}
+                  </a>
+                  {dep.state === 'closed'
+                    ? <span className="cv-link-state cv-link-state-closed">已关闭(依赖完成)</span>
+                    : dep.state === 'open'
+                      ? <span className="cv-link-state cv-link-state-open">打开(未完成)</span>
+                      : null}
+                </div>
+              ))}
+            </div>
+          ) : null}
+          {dependencies.blocking.length > 0 ? (
+            <div className="cv-dep-block">
+              <div className="cv-dep-label">🔓 blocking(被依赖,等我完成)</div>
+              {dependencies.blocking.map((dep, i) => (
+                <div key={i} className="cv-link-row">
+                  <a className="cv-link" href={`https://github.com/${repoOf(issue.url)}/issues/${dep.number}`} target="_blank" rel="noreferrer">
+                    #{dep.number}{dep.title ? ` ${dep.title}` : ''}
+                  </a>
+                  <span className={`cv-link-state cv-link-state-${dep.state}`}>
+                    {dep.state === 'closed' ? '已关闭' : dep.state === 'open' ? '打开' : dep.state}
+                  </span>
+                </div>
+              ))}
             </div>
           ) : null}
         </div>
@@ -922,7 +981,7 @@ function CommentsSection({ comments }: { comments: GhComment[] }) {
   )
 }
 
-async function fetchIssue(url: string): Promise<{ ok: true; data: { kind: 'issue' | 'pr'; item: unknown } } | { ok: false; error: string }> {
+async function fetchIssue(url: string): Promise<{ ok: true; data: { kind: 'issue' | 'pr'; item: unknown; timeline?: TimelineEvent[]; dependencies?: Dependencies } } | { ok: false; error: string }> {
   const response = await fetch('/clickvibe/api/fetch', {
     method: 'POST',
     headers: { 'content-type': 'application/json', 'x-clickvibe-request': '1' },
@@ -934,7 +993,7 @@ async function fetchIssue(url: string): Promise<{ ok: true; data: { kind: 'issue
 function PanelContent() {
   const [url, setUrl] = React.useState('')
   const [loading, setLoading] = React.useState(false)
-  const [result, setResult] = React.useState<{ kind: 'issue' | 'pr'; item: GhIssue; timeline?: TimelineEvent[] } | null>(null)
+  const [result, setResult] = React.useState<{ kind: 'issue' | 'pr'; item: GhIssue; timeline?: TimelineEvent[]; dependencies?: Dependencies } | null>(null)
   const [error, setError] = React.useState<string | null>(null)
   const [workflow, setWorkflow] = React.useState<Workflow | null>(null)
   const [restored, setRestored] = React.useState(false)
@@ -1017,7 +1076,7 @@ function PanelContent() {
       </div>
       {error ? <div className="cv-error">{error}</div> : null}
       {result
-        ? <IssueView issue={result.item} kind={result.kind} workflow={workflow} onWorkflow={updateWorkflow} timeline={result.timeline} />
+        ? <IssueView issue={result.item} kind={result.kind} workflow={workflow} onWorkflow={updateWorkflow} timeline={result.timeline} dependencies={result.dependencies} />
         : loading
           ? <div className="cv-loading">正在通过 gh 抓取…</div>
           : restored

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -139,6 +139,9 @@ const PANEL_CSS = `
 .cv-pr-open { color: #1a7f37; }
 .cv-pr-merged { color: #8250df; }
 .cv-pr-closed { color: #cf222e; }
+.cv-issue-open { color: #1a7f37; }
+.cv-issue-closed { color: #8250df; }
+.cv-link-state-issue-closed { background: #fbefff; color: #8250df; }
 .cv-stage-new { background: #fff8c5; color: #9a6700; }
 .cv-timeline { border-top: 1px solid #d0d7de; padding-top: 6px; display: flex; flex-direction: column; gap: 4px; }
 .cv-timeline-head { font-size: 12px; font-weight: 600; color: #57606a; }
@@ -397,6 +400,18 @@ function PrStateIcon({ state }: { state: 'open' | 'closed' | 'merged' }) {
   )
 }
 
+const OCTICON_ISSUE_OPEN = 'M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3ZM8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z'
+const OCTICON_ISSUE_CLOSED = 'M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm3.97 1.78a.75.75 0 0 1 1.06 0l1.22 1.22 2.28-2.28a.75.75 0 1 1 1.06 1.06l-2.81 2.81a.75.75 0 0 1-1.06 0l-1.75-1.75a.75.75 0 0 1 0-1.06Z'
+
+/** GitHub-style issue state icon (open: ring, closed: ring + check). */
+function IssueStateIcon({ state }: { state: 'open' | 'closed' }) {
+  return (
+    <svg className={`cv-pr-icon cv-issue-${state}`} viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true">
+      <path d={state === 'closed' ? OCTICON_ISSUE_CLOSED : OCTICON_ISSUE_OPEN} />
+    </svg>
+  )
+}
+
 /** Label of a linked item's state (GitHub wording). */
 function linkedStateLabel(source: NonNullable<TimelineEvent['source']>): string {
   const state = linkedState(source)
@@ -539,12 +554,16 @@ function IssueView({ issue, kind, workflow, onWorkflow, timeline, dependencies }
                 <div key={i} className="cv-link-row">
                   {ev.source.is_pr
                     ? <PrStateIcon state={linkedStateValue} />
-                    : <span className="cv-link-kind">🔗</span>}
+                    : <IssueStateIcon state={linkedStateValue === 'closed' ? 'closed' : 'open'} />}
                   <span className="cv-link-kind">{ev.source.is_pr ? 'PR' : 'Issue'}</span>
                   <a className="cv-link" href={ev.source.html_url} target="_blank" rel="noreferrer">
                     #{ev.source.number} {ev.source.title ?? ''}
                   </a>
-                  <span className={`cv-link-state cv-link-state-${linkedStateValue}`}>
+                  <span className={
+                    ev.source.is_pr
+                      ? `cv-link-state cv-link-state-${linkedStateValue}`
+                      : `cv-link-state ${linkedStateValue === 'closed' ? 'cv-link-state-issue-closed' : 'cv-link-state-open'}`
+                  }>
                     {linkedStateLabel(ev.source)}
                   </span>
                 </div>

--- a/src/develop.ts
+++ b/src/develop.ts
@@ -32,6 +32,28 @@ export function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`
 }
 
+/**
+ * Parse the `## 依赖` section of an issue body (issue-contract machine-readable
+ * convention: `Blocked by #NN`, multiple deps comma-separated; `无` = none).
+ * Returns the referenced issue numbers, empty when the section is missing.
+ */
+export function parseDependencies(body: string | null | undefined): number[] {
+  const lines = String(body ?? '').split('\n')
+  const depIndex = lines.findIndex((line) => /^##\s*依赖/.test(line.trim()))
+  if (depIndex === -1) return []
+  const numbers: number[] = []
+  for (let i = depIndex + 1; i < lines.length; i++) {
+    const line = lines[i].trim()
+    if (line === '') continue
+    if (/^##\s/.test(line)) break // 下一个章节
+    for (const match of line.matchAll(/#(\d+)/g)) {
+      const number = Number(match[1])
+      if (!numbers.includes(number)) numbers.push(number)
+    }
+  }
+  return numbers
+}
+
 /** Build a worktree command whose new branch is explicitly rooted at the fetched remote base. */
 export function buildWorktreeAddCommand(options: {
   path: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import {
   isLoopbackAddress,
   makeAuthorizationInput,
   parseAgent,
+  parseDependencies,
   parseGithubUrl,
   shellQuote,
   validatePrivilegedRequest,
@@ -684,11 +685,13 @@ async function fetchIssue(
       return { ok: false, error: stderr || `gh 执行失败(exit ${result.exitCode})` }
     }
     const parsedJson = JSON.parse(result.stdout.text) as unknown
-    const data: { kind: 'issue' | 'pr'; item: unknown; timeline?: unknown } = { kind: parsed.kind, item: parsedJson }
+    const data: { kind: 'issue' | 'pr'; item: unknown; timeline?: unknown; dependencies?: { blockedBy: IssueDependency[]; blocking: IssueDependency[] } } = { kind: parsed.kind, item: parsedJson }
     // issue 额外拉 timeline,提取关联事件(linked PR/commit)——GitHub UI 的
     // "linked a pull request" 就来自 cross-referenced 事件
     if (!isPR) {
       data.timeline = await fetchTimeline(ctx, parsed.owner, parsed.repo, parsed.number)
+      // 依赖图:blockedBy 来自本 issue 正文,blocking 扫描 repo 内其它 issue
+      data.dependencies = await fetchDependencies(ctx, parsed, parsedJson as { body?: unknown })
     }
     return { ok: true, data }
   } catch (error) {
@@ -757,6 +760,60 @@ async function authorizeAgent(
   } catch (error) {
     return { ok: false, error: String(error instanceof Error ? error.message : error) }
   }
+}
+
+/** One resolved dependency entry (number + title + state). */
+interface IssueDependency {
+  number: number
+  title: string
+  state: string
+}
+
+/**
+ * Resolve an issue's dependency graph (issue-contract convention):
+ * - blockedBy: issues this issue depends on, parsed from its `## 依赖` body section;
+ * - blocking: issues that declare a dependency on this issue.
+ * Scans the repo's issues once via gh (local, fast).
+ */
+async function fetchDependencies(
+  ctx: Context,
+  target: { owner: string; repo: string; number: string },
+  item: { body?: unknown },
+): Promise<{ blockedBy: IssueDependency[]; blocking: IssueDependency[] }> {
+  const empty: { blockedBy: IssueDependency[]; blocking: IssueDependency[] } = { blockedBy: [], blocking: [] }
+  const command = `gh issue list --repo ${target.owner}/${target.repo} --state all --limit 100 --json number,title,state,body`
+  let issues: { number: number; title: string; state: string; body: string }[] = []
+  try {
+    const spec = ctx.shell.resolve({ command, timeoutMs: 20000 })
+    const result = await ctx.shell.run(spec)
+    if (result.exitCode !== 0) return empty
+    const parsed = JSON.parse(result.stdout.text) as unknown
+    if (!Array.isArray(parsed)) return empty
+    issues = parsed as { number: number; title: string; state: string; body: string }[]
+  } catch {
+    return empty
+  }
+
+  const current = Number(target.number)
+  const byNumber = new Map(issues.filter((i) => Number.isInteger(i.number)).map((i) => [i.number, i]))
+
+  const blockedBy: IssueDependency[] = []
+  for (const number of parseDependencies(String(item.body ?? ''))) {
+    const found = byNumber.get(number)
+    blockedBy.push(found
+      ? { number: found.number, title: found.title, state: found.state }
+      : { number, title: '', state: 'unknown' })
+  }
+  const blocking: IssueDependency[] = []
+  for (const issue of issues) {
+    if (issue.number === current) continue
+    if (parseDependencies(issue.body).includes(current)) {
+      blocking.push({ number: issue.number, title: issue.title, state: issue.state })
+    }
+  }
+  blockedBy.sort((a, b) => a.number - b.number)
+  blocking.sort((a, b) => a.number - b.number)
+  return { blockedBy, blocking }
 }
 
 /** Fetch the issue timeline and keep only the events worth showing. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -818,7 +818,7 @@ async function fetchDependencies(
 
 /** Fetch the issue timeline and keep only the events worth showing. */
 async function fetchTimeline(ctx: Context, owner: string, repo: string, number: string): Promise<unknown[]> {
-  const command = `gh api repos/${owner}/${repo}/issues/${number}/timeline -H "Accept: application/vnd.github+json" --jq '[.[] | select(.event == "cross-referenced" or .event == "referenced" or .event == "connected" or .event == "closed" or .event == "reopened") | {event, created_at, actor: .actor.login, commit_id, source: (if .source then {number: .source.issue.number, title: .source.issue.title, html_url: .source.issue.html_url, state: .source.issue.state} else null end)}]'`
+  const command = `gh api repos/${owner}/${repo}/issues/${number}/timeline -H "Accept: application/vnd.github+json" --jq '[.[] | select(.event == "cross-referenced" or .event == "referenced" or .event == "connected" or .event == "closed" or .event == "reopened") | {event, created_at, actor: .actor.login, commit_id, source: (if .source then {number: .source.issue.number, title: .source.issue.title, html_url: .source.issue.html_url, state: .source.issue.state, is_pr: (.source.issue.pull_request != null), pr_merged: (.source.issue.pull_request.merged_at != null)} else null end)}]'`
   try {
     const spec = ctx.shell.resolve({ command, timeoutMs: 15000 })
     const result = await ctx.shell.run(spec)

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@
  * - `/clickvibe/api/stream`         — SSE live status stream for a task
  * - `/clickvibe/api/review`         — review the dev branch with codex/claude
  * - `/clickvibe/api/resume`         — resume an interrupted dev session
+ * - `/clickvibe/api/sync`           — sync the worktree with the remote base (issue #5)
  *
  * Workflow per issue (persisted under ~/.clickvibe/state/):
  *   developing → review-ready → reviewing → passed
@@ -37,6 +38,7 @@ import {
   type DevelopAgent,
   type IssuePromptSnapshot,
 } from './develop.ts'
+import { deriveNextAction, type NextAction, type WorkflowFacts } from './state-view.ts'
 import {
   appendEvent,
   appendLog,
@@ -302,17 +304,104 @@ async function detectLinkedPr(ctx: Context, repoKey: string, branch: string): Pr
   }
 }
 
+/** Result of one ahead/behind comparison (commits of one ref relative to another). */
+interface GitCompare {
+  behind: number
+  ahead: number
+}
+
+/** Worktree facts the authoritative state view derives on every /state request. */
+interface WorkflowDerived {
+  head: string | null
+  branch: string | null
+  mainHead: string | null
+  originMainHead: string | null
+  upstreamHead: string | null
+  aheadOfMain: number
+  behindMain: number
+  aheadOfBase: number
+  behindBase: number
+  aheadOfUpstream: number | null
+  behindUpstream: number | null
+  needsSync: boolean
+  lastDevHash: string | null
+  lastReviewHash: string | null
+  reviewedHash: string | null
+  hasNewCommits: boolean
+  verdictCurrent: boolean
+  nextAction: NextAction
+}
+
+/** Short hash of one ref inside the worktree's repo (null when unresolvable). */
+async function readRefShort(ctx: Context, workdir: string, ref: string): Promise<string | null> {
+  try {
+    const spec = ctx.shell.resolve({
+      command: `git rev-parse --short ${shellQuote(ref)}`,
+      workdir,
+      timeoutMs: 10000,
+      sandboxPolicy: { mode: 'read-only', workspaceRoot: workdir },
+    })
+    const result = await ctx.shell.run(spec)
+    if (result.exitCode !== 0) return null
+    const out = result.stdout.text.trim()
+    return out === '' ? null : out
+  } catch {
+    return null
+  }
+}
+
+/** Current branch of the worktree (null when detached or missing). */
+async function readBranch(ctx: Context, workdir: string): Promise<string | null> {
+  try {
+    const spec = ctx.shell.resolve({
+      command: 'git branch --show-current',
+      workdir,
+      timeoutMs: 10000,
+      sandboxPolicy: { mode: 'read-only', workspaceRoot: workdir },
+    })
+    const result = await ctx.shell.run(spec)
+    if (result.exitCode !== 0) return null
+    const out = result.stdout.text.trim()
+    return out === '' ? null : out
+  } catch {
+    return null
+  }
+}
+
+/** Ahead/behind of `right` relative to `left` (commits in left but not in right = behind). */
+async function readRevCount(ctx: Context, workdir: string, left: string, right: string): Promise<GitCompare | null> {
+  try {
+    const spec = ctx.shell.resolve({
+      command: `git rev-list --left-right --count ${shellQuote(left)}...${shellQuote(right)}`,
+      workdir,
+      timeoutMs: 10000,
+      sandboxPolicy: { mode: 'read-only', workspaceRoot: workdir },
+    })
+    const result = await ctx.shell.run(spec)
+    if (result.exitCode !== 0) return null
+    const [behind, ahead] = result.stdout.text.trim().split(/\s+/).map(Number)
+    if (!Number.isFinite(behind) || !Number.isFinite(ahead)) return null
+    return { behind, ahead }
+  } catch {
+    return null
+  }
+}
+
 /**
- * Derive the live state of a workflow from git facts + its event history.
- * The stored `stage`/`reviewResult` stay as-is; this adds `derived` with
- * the current worktree HEAD and whether commits exist beyond the last
- * recorded dev event (i.e. un-reviewed work).
+ * Derive the authoritative state of a workflow from git facts + event history
+ * (issue #5). Runs on every /state request so the panel never needs a
+ * restart/refresh to see current status; the stored `stage`/`reviewResult`
+ * stay as-is, and `derived` carries the three-way comparison (worktree /
+ * main / remote), the review-verdict HEAD binding and the single next action.
  */
-async function deriveWorkflowState(
+/** Derive the authoritative state of a workflow from git facts + event history.
+ *  Exported for integration tests; /state calls it on every request. */
+export async function deriveWorkflowState(
   ctx: Context,
   workflow: IssueWorkflow,
-): Promise<IssueWorkflow & { derived: { head: string | null; hasNewCommits: boolean; lastDevHash: string | null; lastReviewHash: string | null } }> {
-  const head = existsSync(workflow.worktree) ? await readWorktreeHead(ctx, workflow.worktree) : null
+): Promise<IssueWorkflow & { derived: WorkflowDerived }> {
+  const worktree = workflow.worktree
+  const exists = existsSync(worktree)
   const events = workflow.events ?? []
   let lastDevHash: string | null = null
   let lastReviewHash: string | null = null
@@ -320,11 +409,90 @@ async function deriveWorkflowState(
     if (ev.kind === 'dev' || ev.kind === 'rework') lastDevHash = ev.hash ?? lastDevHash
     if (ev.kind === 'review') lastReviewHash = ev.hash ?? lastReviewHash
   }
+
+  const head = exists ? await readWorktreeHead(ctx, worktree) : null
+  const branch = exists ? await readBranch(ctx, worktree) : null
+
+  let mainHead: string | null = null
+  let aheadOfMain = 0
+  let behindMain = 0
+  let originMainHead: string | null = null
+  let aheadOfBase = 0
+  let behindBase = 0
+  let upstreamHead: string | null = null
+  let aheadOfUpstream: number | null = null
+  let behindUpstream: number | null = null
+
+  if (exists && head !== null) {
+    mainHead = await readRefShort(ctx, worktree, 'main')
+    if (mainHead) {
+      const compare = await readRevCount(ctx, worktree, 'main', 'HEAD')
+      if (compare) { behindMain = compare.behind; aheadOfMain = compare.ahead }
+    }
+    originMainHead = await readRefShort(ctx, worktree, 'origin/main')
+    if (originMainHead) {
+      const compare = await readRevCount(ctx, worktree, 'origin/main', 'HEAD')
+      if (compare) { behindBase = compare.behind; aheadOfBase = compare.ahead }
+    }
+    if (branch) {
+      upstreamHead = await readRefShort(ctx, worktree, `origin/${branch}`)
+      if (upstreamHead) {
+        const compare = await readRevCount(ctx, worktree, `origin/${branch}`, 'HEAD')
+        if (compare) { behindUpstream = compare.behind; aheadOfUpstream = compare.ahead }
+      }
+    }
+  }
+
   // 有新提交 = worktree HEAD 不在已记录的任何 dev/rework 事件哈希里
   const hasNewCommits = head !== null && lastDevHash !== null && head !== lastDevHash
+  // worktree 落后远端基线(origin/main 或远端同名分支)→ 需要同步
+  const needsSync = behindBase > 0 || (behindUpstream ?? 0) > 0
+  const reviewedHash = lastReviewHash
+  const reviewPassed = workflow.reviewResult?.passed ?? null
+  // 结论仍针对当前 HEAD 才算数;HEAD 变化后旧结论不冒充当前状态
+  const verdictCurrent = workflow.reviewResult !== null && head !== null && reviewedHash !== null && head === reviewedHash
+
+  const devLive = workflow.devTaskId ? liveTasks.get(workflow.devTaskId) : undefined
+  const reviewLive = workflow.reviewTaskId ? liveTasks.get(workflow.reviewTaskId) : undefined
+  const taskRunning = (devLive !== undefined && !devLive.closed) || (reviewLive !== undefined && !reviewLive.closed)
+
+  const facts: WorkflowFacts = {
+    issueOpen: (workflow.issueState ?? 'OPEN') !== 'CLOSED',
+    prMerged: false, // PR 合并状态需要网络查询,/state 不做网络 IO,保持实时推导
+    prNumber: workflow.prNumber,
+    stage: workflow.stage,
+    devInterrupted: workflow.devInterrupted,
+    taskRunning,
+    head,
+    reviewedHash,
+    reviewPassed,
+    hasNewCommits,
+    needsSync,
+  }
+  const nextAction = deriveNextAction(facts)
+
   return {
     ...workflow,
-    derived: { head, hasNewCommits, lastDevHash, lastReviewHash },
+    derived: {
+      head,
+      branch,
+      mainHead,
+      originMainHead,
+      upstreamHead,
+      aheadOfMain,
+      behindMain,
+      aheadOfBase,
+      behindBase,
+      aheadOfUpstream,
+      behindUpstream,
+      needsSync,
+      lastDevHash,
+      lastReviewHash,
+      reviewedHash,
+      hasNewCommits,
+      verdictCurrent,
+      nextAction,
+    },
   }
 }
 export const name = 'clickvibe'
@@ -342,7 +510,7 @@ export function apply(ctx: Context): void {
       }
       const pathname = new URL(req.url ?? '/', 'http://clickvibe.internal').pathname
       const method = pathname.startsWith(`${ROUTE}/`) ? pathname.slice(`${ROUTE}/`.length) : undefined
-      const knownMethods = new Set(['fetch', 'state', 'authorize', 'develop', 'develop/poll', 'stream', 'review', 'resume', 'stop'])
+      const knownMethods = new Set(['fetch', 'state', 'authorize', 'develop', 'develop/poll', 'stream', 'review', 'resume', 'stop', 'sync'])
       if (method === undefined || !knownMethods.has(method)) {
         writeJson(res, 404, { ok: false, error: 'unknown method' })
         return
@@ -477,6 +645,16 @@ export function apply(ctx: Context): void {
           return
         }
         const result = stopTask(payload)
+        writeJson(res, result.ok ? 200 : 400, result)
+        return
+      }
+      if (method === 'sync') {
+        const securityError = privilegedRequestError(req)
+        if (securityError) {
+          writeJson(res, 403, { ok: false, error: securityError })
+          return
+        }
+        const result = await syncWorktree(ctx, payload)
         writeJson(res, result.ok ? 200 : 400, result)
         return
       }
@@ -738,6 +916,7 @@ async function ensureWorktree(ctx: Context, parsed: { owner: string; repo: strin
       reviewSessionId: null,
       reviewResult: null,
       prNumber: null,
+      issueState: 'OPEN',
       baseRef: null,
       updatedAt: Date.now(),
       events: [],
@@ -747,6 +926,7 @@ async function ensureWorktree(ctx: Context, parsed: { owner: string; repo: strin
   if (!Array.isArray(workflow.events)) workflow.events = []
   if (workflow.reviewSessionId === undefined) workflow.reviewSessionId = null
   if (workflow.prNumber === undefined) workflow.prNumber = null
+  if (workflow.issueState === undefined) workflow.issueState = 'OPEN'
   if (workflow.baseRef === undefined) workflow.baseRef = null
   // 校正路径字段(配置可能变化)
   workflow.worktree = worktree
@@ -1069,6 +1249,8 @@ async function startDevelop(
   const ensured = await ensureWorktree(ctx, parsed)
   if (!ensured.ok) return ensured
   const { workflow } = ensured
+  // issue 已校验为 OPEN(真实 agent 走授权快照,dryrun 走抓取校验)
+  workflow.issueState = 'OPEN'
 
   if (agent === 'dryrun') {
     const taskIdValue = taskId('dryrun')
@@ -1270,6 +1452,55 @@ function stopTask(payload: unknown): { ok: true; taskId: string; stopped: boolea
     await saveWorkflow(workflow)
   })()
   return { ok: true, taskId, stopped }
+}
+
+/** Sync a workflow's worktree with the remote base (git fetch + merge origin/main).
+ *  Keeps the worktree on the latest base so dev/review never target stale code
+ *  (issue #5). The merge result is recorded as a timeline event. */
+async function syncWorktree(
+  ctx: Context,
+  payload: unknown,
+): Promise<{ ok: true; worktree: string; branch: string; head: string | null } | { ok: false; error: string }> {
+  const url = String((payload as { url?: unknown } | undefined)?.url ?? '').trim()
+  const parsed = parseUrl(url)
+  if (!parsed || parsed.kind !== 'issue') {
+    return { ok: false, error: '请输入形如 https://github.com/owner/repo/issues/123 的链接' }
+  }
+  const key = issueKey(`${parsed.owner}/${parsed.repo}`, parsed.number)
+  const workflow = await loadWorkflow(key)
+  if (!workflow || !existsSync(workflow.worktree)) {
+    return { ok: false, error: '该 issue 尚无 worktree,无法同步' }
+  }
+  const policy = { mode: 'danger-full-access' as const, workspaceRoot: workflow.worktree }
+  try {
+    await appendLog(workflow.key, 'dev', '[clickvibe] 同步:git fetch origin…')
+    await runCommand(ctx, 'git fetch origin --prune', { workdir: workflow.worktree, timeoutMs: 60_000, sandboxPolicy: policy })
+    await appendLog(workflow.key, 'dev', '[clickvibe] 同步:合并 origin/main…')
+    try {
+      await runCommand(ctx, 'git merge --no-edit origin/main', { workdir: workflow.worktree, timeoutMs: 60_000, sandboxPolicy: policy })
+    } catch (error) {
+      // 合并冲突/失败:回滚到合并前,保持 worktree 干净;错误透传给用户
+      await runCommand(ctx, 'git merge --abort', { workdir: workflow.worktree, timeoutMs: 30_000, sandboxPolicy: policy }).catch(() => {})
+      throw error
+    }
+    const head = await readWorktreeHead(ctx, workflow.worktree)
+    await appendLog(workflow.key, 'dev', `[clickvibe] 同步完成,HEAD ${head ?? '未知'}`)
+    // 记录同步事件到权威时间线(不改变开发/审查语义)
+    const reloaded = await loadWorkflow(workflow.key)
+    if (reloaded) {
+      await appendEvent(reloaded, {
+        kind: 'note',
+        at: new Date().toISOString(),
+        hash: head ?? undefined,
+        note: 'worktree 已同步到 origin/main',
+      })
+    }
+    return { ok: true, worktree: workflow.worktree, branch: workflow.branch, head }
+  } catch (error) {
+    const message = String(error instanceof Error ? error.message : error)
+    await appendLog(workflow.key, 'dev', `[clickvibe] 同步失败: ${message}`)
+    return { ok: false, error: `同步失败: ${message}` }
+  }
 }
 
 /** Start a review task on the dev branch with codex/claude. */

--- a/src/state-view.ts
+++ b/src/state-view.ts
@@ -1,0 +1,127 @@
+/**
+ * clickvibe authoritative state view — issue #5.
+ *
+ * From raw git facts + event history, derive the single next action for an
+ * issue workflow. Kept as a pure function so the whole decision table is
+ * unit-testable without a shell.
+ */
+
+export type NextActionKind =
+  | 'develop'
+  | 'resume'
+  | 'sync'
+  | 'review'
+  | 'rework'
+  | 'merge'
+  | 'none'
+
+export interface NextAction {
+  kind: NextActionKind
+  /** Short imperative label for the single action button. */
+  label: string
+  /** One-line explanation of why this is the next action. */
+  hint: string
+}
+
+export type WorkflowStageInput = 'idle' | 'developing' | 'review-ready' | 'reviewing' | 'passed'
+
+export interface WorkflowFacts {
+  /** The issue itself is still open (closed issues have no next action). */
+  issueOpen: boolean
+  /** A linked PR has been merged: terminal state. */
+  prMerged: boolean
+  prNumber: string | null
+  /** Persisted workflow stage. */
+  stage: WorkflowStageInput
+  /** Stored devInterrupted flag (dev stopped / failed / killed). */
+  devInterrupted: boolean
+  /** A dev/review agent process is currently running for this workflow. */
+  taskRunning: boolean
+  /** Worktree HEAD short hash; null when the worktree is missing. */
+  head: string | null
+  /** HEAD the latest review verdict was bound to. */
+  reviewedHash: string | null
+  /** Latest review verdict; null when there is no verdict yet. */
+  reviewPassed: boolean | null
+  /** HEAD moved beyond the last recorded dev/rework event. */
+  hasNewCommits: boolean
+  /** Worktree is behind its base / remote branch and should be synced. */
+  needsSync: boolean
+}
+
+function action(kind: NextActionKind, label: string, hint: string): NextAction {
+  return { kind, label, hint }
+}
+
+/**
+ * Decide the one next action for an issue workflow.
+ *
+ * Order of precedence:
+ *   terminal states (closed issue / merged PR / task running)
+ *   → interrupted dev (resume)
+ *   → aborted review (re-review)
+ *   → missing worktree
+ *   → stale worktree (sync)
+ *   → stage-specific verdict (develop / review / rework / merge)
+ */
+export function deriveNextAction(facts: WorkflowFacts): NextAction {
+  // Terminal states first: nothing actionable.
+  if (!facts.issueOpen) return action('none', '无', 'issue 已关闭,无待办动作')
+  if (facts.prMerged) return action('none', '无', 'PR 已合并,交付完成')
+  if (facts.taskRunning) return action('none', '任务进行中', '开发/review 正在运行,等待完成')
+
+  // 中断恢复:开发中但没有存活任务(Host 重启 / 用户停止 / agent 失败)→ 恢复会话。
+  // taskRunning 已在上方排除,这里 stage==='developing' 即意味着任务已失联。
+  if (facts.stage === 'developing') {
+    return action(
+      'resume',
+      '恢复开发',
+      facts.devInterrupted ? '开发曾中断,续上次 agent 会话' : '开发任务已失联(Host 重启?),尝试恢复会话',
+    )
+  }
+  // review 中断:reviewing 但没有存活任务 → 重新 review。
+  if (facts.stage === 'reviewing') {
+    return action('review', '重新 Review', '上次 review 中断,重新审查当前代码')
+  }
+
+  // worktree 缺失(非 idle):无法继续,需要人工修复。
+  if (facts.stage !== 'idle' && facts.head === null) {
+    return action('none', '无', 'worktree 缺失,请检查本地配置')
+  }
+
+  // worktree 落后远端基线 → 先同步(唯一动作)。
+  if (facts.needsSync) {
+    return action('sync', '同步 worktree', 'worktree 落后远端基线,先同步再继续')
+  }
+
+  // developing / reviewing 已被上面的早退处理(中断恢复/重新 review)
+  switch (facts.stage) {
+    case 'idle':
+      return action('develop', '开始开发', '创建 worktree 并启动 agent 开发')
+    case 'review-ready': {
+      if (facts.reviewPassed === null) {
+        return action('review', 'Review', '开发完成,审查代码改动')
+      }
+      // 未通过 → 带意见返工(无论 HEAD 是否已变化;agent 会重读当前代码)。
+      if (!facts.reviewPassed) {
+        return action('rework', '按意见返工', 'Review 未通过,带意见续开发会话')
+      }
+      // 通过:结论必须仍针对当前 HEAD 才算数,HEAD 变化后不冒充当前结论。
+      const verdictCurrent = facts.head !== null && facts.head === facts.reviewedHash
+      if (!verdictCurrent) {
+        return action(
+          'review',
+          '重新 Review',
+          '上次通过的结论针对旧提交,当前 HEAD 已变化,需重新审查',
+        )
+      }
+      return facts.prNumber
+        ? action('merge', '合并 PR', 'Review 通过,打开 PR 完成合并')
+        : action('none', '无', 'Review 已通过,但尚未关联 PR')
+    }
+    case 'passed':
+      return facts.prNumber
+        ? action('merge', '合并 PR', 'Review 通过,打开 PR 完成合并')
+        : action('none', '无', 'Review 已通过,等待合并')
+  }
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -34,6 +34,8 @@ export interface IssueWorkflow {
   reviewResult: { passed: boolean; issues: string[]; commentUrl?: string } | null
   /** 关联的 PR 号(开发分支的代码产物);issue 为 key,PR 记录在这里。 */
   prNumber: string | null
+  /** 最近一次从 GitHub 看到的 issue 状态(推导『已关闭→无动作』,issue #5)。 */
+  issueState: 'OPEN' | 'CLOSED'
   /** 开发基线:开 worktree 时基于的分支与提交(如 origin/main @ a8a7b5f)。 */
   baseRef: string | null
   updatedAt: number

--- a/tests/develop.test.ts
+++ b/tests/develop.test.ts
@@ -10,6 +10,7 @@ import {
   parseAgent,
   parseGithubUrl,
   shellQuote,
+  parseDependencies,
   validatePrivilegedRequest,
 } from '../src/develop.ts'
 
@@ -178,4 +179,15 @@ test('LineLog bounds a never-terminated line and handles CRLF split across chunk
   assert.equal(read.lines.length, 2)
   assert.match(read.lines[0], /单行日志已截断/)
   assert.equal(read.lines[1], 'next')
+})
+
+
+test('parseDependencies extracts Blocked by numbers from the 依赖 section', () => {
+  assert.deepEqual(parseDependencies(`## 目标\n做 X\n\n## 依赖\n\nBlocked by #7`), [7])
+  assert.deepEqual(parseDependencies(`## 依赖\n\nBlocked by #7, #8`), [7, 8])
+  assert.deepEqual(parseDependencies(`## 依赖\n\n无`), [])
+  assert.deepEqual(parseDependencies('## 目标\n无依赖,正常开发'), [])
+  assert.deepEqual(parseDependencies(''), [])
+  // 依赖章节后还有其它章节:不串台
+  assert.deepEqual(parseDependencies(`## 依赖\n\nBlocked by #7\n\n## 验收标准\n- [ ] 通过 #7 的行为`), [7])
 })

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -116,3 +116,11 @@ test('authorization route freezes the displayed snapshot and consumes tampered c
   }, headers)
   assert.equal(replay.status, 403)
 })
+
+test('/sync rejects worktree mutation without the same-origin privileged headers', async () => {
+  const result = await post(createHandler(), '/clickvibe/api/sync', {
+    url: 'https://github.com/ai-daming/clickvibe/issues/1',
+  })
+  assert.equal(result.status, 403)
+  assert.match(result.body.error ?? '', /授权请求头/)
+})

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -124,3 +124,60 @@ test('/sync rejects worktree mutation without the same-origin privileged headers
   assert.equal(result.status, 403)
   assert.match(result.body.error ?? '', /授权请求头/)
 })
+
+
+
+test('/fetch resolves blockedBy from the body and blocking from a repo scan', async () => {
+  const item = {
+    url: 'https://github.com/ai-daming/clickvibe/issues/7',
+    number: 7, title: 'issue 7', state: 'OPEN',
+    body: '## 目标\n做 X\n\n## 依赖\n\nBlocked by #5', comments: [],
+  }
+  const issues = [
+    { number: 5, title: 'issue 5', state: 'OPEN', body: '## 目标\nx' },
+    { number: 7, title: 'issue 7', state: 'OPEN', body: '## 依赖\n\nBlocked by #5' },
+    { number: 8, title: 'issue 8', state: 'OPEN', body: '## 依赖\n\nBlocked by #7' },
+  ]
+  const handler = createHandler(async (spec) => {
+    if (spec.command.startsWith('gh issue view')) {
+      return { exitCode: 0, stdout: { text: JSON.stringify(item) }, stderr: { text: '' } }
+    }
+    if (spec.command.startsWith('gh issue list')) {
+      return { exitCode: 0, stdout: { text: JSON.stringify(issues) }, stderr: { text: '' } }
+    }
+    return { exitCode: 0, stdout: { text: '[]' }, stderr: { text: '' } }
+  })
+  const result = await post(handler, '/clickvibe/api/fetch', { url: item.url })
+  assert.equal(result.status, 200, JSON.stringify(result.body))
+  const deps = (result.body as { ok: true; data: { dependencies?: { blockedBy: { number: number }[]; blocking: { number: number }[] } } }).data.dependencies
+  assert.ok(deps)
+  assert.deepEqual(deps.blockedBy.map((d) => d.number), [5])
+  assert.deepEqual(deps.blocking.map((d) => d.number), [8])
+})
+
+test('/fetch on an issue without a 依赖 section yields no blockedBy (and no blocking)', async () => {
+  const item = {
+    url: 'https://github.com/ai-daming/clickvibe/issues/5',
+    number: 5, title: 'issue 5', state: 'OPEN',
+    body: '## 目标\n做 Y', comments: [],
+  }
+  const issues = [
+    { number: 5, title: 'issue 5', state: 'OPEN', body: '## 目标\n做 Y' },
+    { number: 7, title: 'issue 7', state: 'OPEN', body: '## 依赖\n\nBlocked by #5' },
+  ]
+  const handler = createHandler(async (spec) => {
+    if (spec.command.startsWith('gh issue view')) {
+      return { exitCode: 0, stdout: { text: JSON.stringify(item) }, stderr: { text: '' } }
+    }
+    if (spec.command.startsWith('gh issue list')) {
+      return { exitCode: 0, stdout: { text: JSON.stringify(issues) }, stderr: { text: '' } }
+    }
+    return { exitCode: 0, stdout: { text: '[]' }, stderr: { text: '' } }
+  })
+  const result = await post(handler, '/clickvibe/api/fetch', { url: item.url })
+  assert.equal(result.status, 200)
+  const deps = (result.body as { ok: true; data: { dependencies?: { blockedBy: unknown[]; blocking: unknown[] } } }).data.dependencies
+  assert.ok(deps)
+  assert.deepEqual(deps.blockedBy, [])
+  assert.deepEqual(deps.blocking.map((d) => (d as { number: number }).number), [7])
+})

--- a/tests/state-view-integration.test.ts
+++ b/tests/state-view-integration.test.ts
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import test from 'node:test'
+import { deriveWorkflowState, type IssueWorkflow } from '../src/index.ts'
+
+const execFileAsync = promisify(execFile)
+
+/** A minimal real-shell ctx: resolve passes the spec through, run executes it. */
+function realShellCtx() {
+  return {
+    webServer: { register() { return () => {} } },
+    shell: {
+      resolve(spec: unknown) { return spec },
+      async run(spec: { command: string; workdir?: string }) {
+        try {
+          const out = await execFileAsync('/bin/sh', ['-c', spec.command], {
+            cwd: spec.workdir, encoding: 'utf8',
+          })
+          return { exitCode: 0, stdout: { text: out.stdout }, stderr: { text: out.stderr } }
+        } catch (error) {
+          const e = error as { code?: number; stdout?: string; stderr?: string }
+          return { exitCode: e.code ?? 1, stdout: { text: e.stdout ?? '' }, stderr: { text: e.stderr ?? '' } }
+        }
+      },
+      start() { throw new Error('not used') },
+    },
+  }
+}
+
+const ctx = realShellCtx() as never
+
+async function setupRepo() {
+  const root = await mkdtemp(join(tmpdir(), 'clickvibe-stateview-'))
+  const remote = join(root, 'remote.git')
+  const repo = join(root, 'repo')
+  const worktree = join(root, 'issue')
+  const git = (...args: string[]) => execFileAsync('git', ['-C', repo, ...args])
+  const wt = (...args: string[]) => execFileAsync('git', ['-C', worktree, ...args])
+  await execFileAsync('git', ['init', '--bare', remote])
+  await execFileAsync('git', ['clone', remote, repo])
+  await git('config', 'user.name', 'clickvibe-test')
+  await git('config', 'user.email', 'clickvibe-test@example.invalid')
+  await git('commit', '--allow-empty', '-m', 'base A')
+  await git('branch', '-M', 'main')
+  await git('push', '-u', 'origin', 'main')
+  await execFileAsync('git', [`--git-dir=${remote}`, 'symbolic-ref', 'HEAD', 'refs/heads/main'])
+  await git('fetch', 'origin', '--prune')
+  // issue worktree from origin/main (the base clickvibe guarantees)
+  await git('worktree', 'add', '-b', 'clickvibe-issue-5', worktree, 'origin/main')
+  const baseA = (await git('rev-parse', '--short', 'origin/main')).stdout.trim()
+  return { root, repo, worktree, git, wt, baseA }
+}
+
+function workflow(overrides: Partial<IssueWorkflow> = {}): IssueWorkflow {
+  return {
+    key: 'repo-5', url: 'https://github.com/o/r/issues/5', repoKey: 'o/r',
+    worktree: '', branch: 'clickvibe-issue-5', stage: 'review-ready',
+    devAgent: 'codex', devTaskId: null, devSessionId: null, devInterrupted: false,
+    reviewAgent: null, reviewTaskId: null, reviewSessionId: null, reviewResult: null,
+    prNumber: null, issueState: 'OPEN', baseRef: null, updatedAt: Date.now(), events: [],
+    ...overrides,
+  }
+}
+
+test('state view derives worktree/main/remote hashes, ahead-behind and sync need', async () => {
+  const { root, worktree, git, wt, baseA } = await setupRepo()
+  try {
+    // 开发提交 C(worktree 领先 main 1)
+    await wt('commit', '--allow-empty', '-m', 'dev work C')
+    const headC = (await wt('rev-parse', '--short', 'HEAD')).stdout.trim()
+    assert.notEqual(headC, baseA)
+
+    const derived = (await deriveWorkflowState(ctx, workflow({ worktree }))).derived
+    assert.equal(derived.head, headC)
+    assert.equal(derived.branch, 'clickvibe-issue-5')
+    assert.equal(derived.mainHead, baseA)      // 本地 main 未动
+    assert.equal(derived.originMainHead, baseA)
+    assert.equal(derived.behindBase, 0)
+    assert.equal(derived.aheadOfBase, 1)
+    assert.equal(derived.needsSync, false)
+    assert.equal(derived.nextAction.kind, 'review') // review-ready 无结论 → review
+
+    // 并行开发:main 前进到 B,worktree 落后 → 需要同步
+    await git('switch', 'main')
+    await git('commit', '--allow-empty', '-m', 'parallel base B')
+    const baseB = (await git('rev-parse', '--short', 'HEAD')).stdout.trim()
+    await git('push', 'origin', 'main')
+    await wt('fetch', 'origin', '--prune')
+
+    const stale = (await deriveWorkflowState(ctx, workflow({ worktree }))).derived
+    assert.equal(stale.originMainHead, baseB)
+    assert.equal(stale.behindBase, 1)
+    assert.equal(stale.aheadOfBase, 1)
+    assert.equal(stale.needsSync, true)
+    assert.equal(stale.nextAction.kind, 'sync') // 落后远端 → 唯一动作是同步
+
+    // 同步后(模拟 /sync 的 merge):不再落后,唯一动作回到 review
+    await wt('merge', '--no-edit', 'origin/main')
+    const synced = (await deriveWorkflowState(ctx, workflow({ worktree }))).derived
+    assert.equal(synced.behindBase, 0)
+    assert.equal(synced.needsSync, false)
+    assert.equal(synced.nextAction.kind, 'review')
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('review verdict binds to the reviewed HEAD and goes stale when the head moves', async () => {
+  const { root, worktree, wt } = await setupRepo()
+  try {
+    await wt('commit', '--allow-empty', '-m', 'dev work C')
+    const headC = (await wt('rev-parse', '--short', 'HEAD')).stdout.trim()
+
+    // review 结论绑定 HEAD C(与事件时间线一致)
+    const wf = workflow({
+      worktree,
+      prNumber: '9',
+      reviewResult: { passed: true, issues: [] },
+      events: [{ kind: 'review', at: new Date().toISOString(), hash: headC, verdict: { passed: true, issues: [] } }],
+      stage: 'review-ready',
+    })
+    const current = (await deriveWorkflowState(ctx, wf)).derived
+    assert.equal(current.reviewedHash, headC)
+    assert.equal(current.verdictCurrent, true)
+    assert.equal(current.nextAction.kind, 'merge')
+
+    // HEAD 前进(如合并远端基线)后,旧结论不再冒充当前状态
+    await wt('commit', '--allow-empty', '-m', 'post-review commit')
+    const stale = (await deriveWorkflowState(ctx, wf)).derived
+    assert.equal(stale.head === headC, false)
+    assert.equal(stale.verdictCurrent, false)
+    assert.equal(stale.nextAction.kind, 'review')
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/tests/state-view.test.ts
+++ b/tests/state-view.test.ts
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { deriveNextAction, type WorkflowFacts } from '../src/state-view.ts'
+
+function facts(overrides: Partial<WorkflowFacts> = {}): WorkflowFacts {
+  return {
+    issueOpen: true,
+    prMerged: false,
+    prNumber: null,
+    stage: 'idle',
+    devInterrupted: false,
+    taskRunning: false,
+    head: 'a1b2c3d',
+    reviewedHash: null,
+    reviewPassed: null,
+    hasNewCommits: false,
+    needsSync: false,
+    ...overrides,
+  }
+}
+
+test('closed issue has no next action', () => {
+  const next = deriveNextAction(facts({ issueOpen: false }))
+  assert.equal(next.kind, 'none')
+})
+
+test('merged PR is terminal', () => {
+  const next = deriveNextAction(facts({ prMerged: true, stage: 'passed', prNumber: '9' }))
+  assert.equal(next.kind, 'none')
+})
+
+test('a running task has no next action until it settles', () => {
+  const next = deriveNextAction(facts({ stage: 'developing', taskRunning: true }))
+  assert.equal(next.kind, 'none')
+  const reviewing = deriveNextAction(facts({ stage: 'reviewing', taskRunning: true }))
+  assert.equal(reviewing.kind, 'none')
+})
+
+test('interrupted development resumes the agent session', () => {
+  const next = deriveNextAction(facts({ stage: 'developing', devInterrupted: true }))
+  assert.equal(next.kind, 'resume')
+})
+
+test('development without a live task after host restart resumes the session', () => {
+  // 持久化的 stage 仍是 developing,但 liveTasks 已随 Host 重启清空
+  const next = deriveNextAction(facts({ stage: 'developing', devInterrupted: false }))
+  assert.equal(next.kind, 'resume')
+  assert.match(next.hint, /失联/)
+})
+
+test('aborted review re-reviews instead of blocking', () => {
+  const next = deriveNextAction(facts({ stage: 'reviewing', devInterrupted: false }))
+  assert.equal(next.kind, 'review')
+})
+
+test('idle issue starts development', () => {
+  const next = deriveNextAction(facts({ stage: 'idle' }))
+  assert.equal(next.kind, 'develop')
+})
+
+test('review-ready without a verdict reviews', () => {
+  const next = deriveNextAction(facts({ stage: 'review-ready', reviewPassed: null }))
+  assert.equal(next.kind, 'review')
+})
+
+test('review-ready with a failed verdict reworks with the issues', () => {
+  const next = deriveNextAction(facts({
+    stage: 'review-ready', reviewPassed: false, reviewedHash: 'a1b2c3d', head: 'a1b2c3d',
+  }))
+  assert.equal(next.kind, 'rework')
+})
+
+test('a failed verdict still reworks when the head has moved (agent re-reads the code)', () => {
+  const next = deriveNextAction(facts({
+    stage: 'review-ready', reviewPassed: false, reviewedHash: 'a1b2c3d', head: 'e5f6g7',
+  }))
+  assert.equal(next.kind, 'rework')
+})
+
+test('a passed verdict on the current head merges the PR', () => {
+  const next = deriveNextAction(facts({
+    stage: 'review-ready', reviewPassed: true, reviewedHash: 'a1b2c3d', head: 'a1b2c3d', prNumber: '9',
+  }))
+  assert.equal(next.kind, 'merge')
+})
+
+test('a passed verdict without a linked PR has no merge action', () => {
+  const next = deriveNextAction(facts({
+    stage: 'review-ready', reviewPassed: true, reviewedHash: 'a1b2c3d', head: 'a1b2c3d', prNumber: null,
+  }))
+  assert.equal(next.kind, 'none')
+  assert.match(next.hint, /未关联 PR/)
+})
+
+test('a passed verdict bound to an old head must be re-reviewed', () => {
+  const next = deriveNextAction(facts({
+    stage: 'review-ready', reviewPassed: true, reviewedHash: 'a1b2c3d', head: 'e5f6g7', prNumber: '9',
+  }))
+  assert.equal(next.kind, 'review')
+})
+
+test('passed stage with a PR merges', () => {
+  const next = deriveNextAction(facts({ stage: 'passed', reviewPassed: true, prNumber: '9', head: 'a1b2c3d' }))
+  assert.equal(next.kind, 'merge')
+})
+
+test('a stale worktree syncs before review or rework', () => {
+  const reviewCase = deriveNextAction(facts({
+    stage: 'review-ready', reviewPassed: null, needsSync: true,
+  }))
+  assert.equal(reviewCase.kind, 'sync')
+  const reworkCase = deriveNextAction(facts({
+    stage: 'review-ready', reviewPassed: false, reviewedHash: 'a1b2c3d', head: 'a1b2c3d', needsSync: true,
+  }))
+  assert.equal(reworkCase.kind, 'sync')
+})
+
+test('a missing worktree on a started workflow has no safe action', () => {
+  const next = deriveNextAction(facts({ stage: 'review-ready', head: null }))
+  assert.equal(next.kind, 'none')
+  assert.match(next.hint, /worktree 缺失/)
+})


### PR DESCRIPTION
## 目标

实现 issue #5 的「权威状态视图」:一个 issue → 一个由 git 事实推导的状态视图(worktree / main / 远端三方对比)+ 唯一动作提示,消除『状态混乱、按钮歧义、需要反复刷新』的问题。

## 改动

### Host
- `/clickvibe/api/state` 每次请求实时推导 `derived`(不缓存、无需重启/刷新):
  - 三方哈希:`head` / `branch` / `mainHead` / `originMainHead` / `upstreamHead`(远端同名分支)
  - ahead/behind:worktree 相对 main、origin/main、远端分支的落后/领先提交数
  - `needsSync`:落后 origin/main 或远端分支时为 true
  - `reviewedHash` + `verdictCurrent`:review 结论绑定审查时的 HEAD
- 新增 `/clickvibe/api/sync`:git fetch + merge origin/main(冲突自动 `merge --abort` 回滚,错误透传),并记入事件时间线
- 新增纯函数 `src/state-view.ts` 的 `deriveNextAction`:由 git 事实 + 事件历史推导唯一下一步动作(优先级:已关闭/已合并/任务运行中 → 恢复开发 → 重新 review → worktree 缺失 → 需要同步 → 开发/Review/返工/合并)
- `issueState` 落盘(旧记录回填 OPEN),关闭的 issue 推导为无动作

### Client
- 面板新增「📊 状态视图」:worktree / main / 远端(origin/main、远端分支)三行,哈希 + 落后/领先 + ⚠需要同步标记
- 动作区改为**唯一动作按钮**:开发/恢复开发/同步 worktree/Review/按意见返工/合并 PR(打开 PR 页,合并仍由人拍板);agent 选择收进 Codex|Claude 切换(Review 锁定上次 agent)
- review 结论标注审查的提交;HEAD 变化后显示「结论已过期」,不再冒充当前状态
- issue 已关闭时本地覆盖为无动作(安全演练 dry-run 保留为次级链接)

## 验收对照

- [x] 面板显示 worktree/main/远端 三者的哈希与差异(落后/领先几个提交)——状态视图三行 + ahead/behind
- [x] worktree 落后远端时,提示「需要同步」并提供动作——⚠ 标记 + 唯一动作「同步 worktree」(/sync)
- [x] reviewResult 显示时标注它审查的 HEAD;HEAD 变化后不冒充当前结论——`reviewedHash` + 过期提示
- [x] 任意时刻只有一个「下一步动作」按钮(或明确提示无动作)——`deriveNextAction` 唯一动作 + none 提示
- [x] 不用重启/刷新即可看到最新状态——`/state` 每次请求实时推导

## 测试

```
ℹ tests 34
ℹ pass 34
ℹ fail 0
```

- `tests/state-view.test.ts`:16 个纯逻辑单测(动作判定全分支)
- `tests/state-view-integration.test.ts`:2 个真实 git 集成测试(三方哈希/落后领先/同步后动作变化、review 结论绑定 HEAD 失效)
- `tests/routes.test.ts`:/sync 无同源请求头 → 403
- `pnpm run typecheck` 与 `pnpm run build` 均通过

## 说明

- 合并动作只打开 PR 页,合并本身仍由人工拍板(遵守蓝图 §六:merge 不可让渡)
- PR 合并状态不阻塞实时推导(/state 不做网络 IO);PR 已合并后再次打开页面即无动作

Closes #5