### PR TITLE
feat: 项目优先的 issue 面板

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # clickvibe
 
-DSH web 插件:右侧面板输入 GitHub issue / PR 链接,通过本地 `gh` CLI 抓取并以 Markdown 渲染展示；对 open issue 可创建独立 worktree 并启动 Codex/Claude 开发。
+DSH web 插件:右侧面板先选择已配置的 GitHub repo,再按依赖、状态和里程碑浏览全部 open issue；每个 issue 由 git/GitHub 硬事实推导唯一下一步动作,可创建独立 worktree 并启动 Codex/Claude 开发。
 
 ## 功能
 
-- 侧栏底部 **GitHub Issue** 按钮(窄栏显示 "GH")开关右侧面板
-- 支持 issue(`/issues/N`)与 PR(`/pull/N`)链接
+- 侧栏底部 **ClickVibe** 按钮(窄栏显示 "CV")开关右侧面板
+- 项目选择器读取 `~/.clickvibe/config.yaml` 的全部 repo 映射,路径不在本机的跨机器配置也保留在列表
+- 选中项目后展示全部 open issue,支持按里程碑或依赖状态分组、按依赖就绪/阻塞过滤
+- 每行展示状态徽章、约定分支、落后提示、milestone、blockedBy 与唯一动作；点开后进入完整详情
 - Host 半通过 `gh issue view` / `gh pr view` 抓取,返回结构化 JSON
 - Client 半渲染:
   - 状态徽章(Open / Closed / Merged)、编号、作者、创建/更新/关闭/合并时间
@@ -17,7 +19,8 @@ DSH web 插件:右侧面板输入 GitHub issue / PR 链接,通过本地 `gh` CLI
   - 三方对比:worktree / main / 远端(origin/main、远端同名分支)的哈希与 ahead/behind
   - worktree 落后远端时提示「需要同步」并提供 /sync 动作(fetch + merge origin/main,冲突自动回滚)
   - review 结论标注它审查的 HEAD;HEAD 变化后自动显示「结论已过期」,不冒充当前状态
-  - 任意时刻只有一个「下一步动作」按钮(开发/恢复/同步/Review/返工/合并),由 git 事实推导,不靠易错的 stage 字段
+  - 任意时刻只有一个「下一步动作」按钮(开发/恢复/同步/创建 PR/Review/返工/合并),由 git 事实推导,workflow 文件只做增强
+  - PR 状态每次从 GitHub 查询；merged 立即进入已交付终态,查询失败则 fail-closed,不沿用旧的合并按钮
 - Open issue 一键开发:
   - `Codex 开发` / `Claude 开发`:在 issue worktree 中启动非交互 agent
   - `安全演练`:走完整 worktree/任务/轮询链路,只执行 `pwd`、当前分支和 `git status`
@@ -35,7 +38,7 @@ DSH web 插件:右侧面板输入 GitHub issue / PR 链接,通过本地 `gh` CLI
 | Host | `src/index.ts` | 注册 `/clickvibe/api` 前缀路由,处理 GitHub 抓取、开发任务和 cursor 日志轮询 |
 | 开发内核 | `src/develop.ts` | agent/URL 校验、shell 参数转义、有界行日志和 worktree 恢复决策 |
 | 状态视图 | `src/state-view.ts` | 纯函数 `deriveNextAction`:由 git 事实 + 事件历史推导唯一下一步动作 |
-| Client | `src/client/index.tsx` | `shell.overlay` 右侧面板 + `sidebar.footer.action` 开关按钮,`fetch('/clickvibe/api/fetch')` 取数;状态视图 + 唯一动作按钮 |
+| Client | `src/client/index.tsx` | `shell.overlay` 项目优先面板 + `sidebar.footer.action` 开关按钮；项目 issue 列表、筛选/分组、详情和唯一动作 |
 | 构建 | `tsdown.config.ts` | host → `lib/index.js`(ESM),client → `lib/client.js`(CJS 闭包,`window.__ModuleLoader__.load` 注册) |
 
 Client→Host 走 **HTTP API 路由**(正式插件没有动态插件的 `harness.handle`),这是与原型最大的结构差异。
@@ -75,6 +78,13 @@ dsh plugin --profile web add link:/Users/yinwm/work/clickvibe
 
 ```sh
 # host 路由
+curl -X POST http://127.0.0.1:3080/clickvibe/api/projects \
+  -H 'content-type: application/json' -d '{}'
+
+curl -X POST http://127.0.0.1:3080/clickvibe/api/repo/issues \
+  -H 'content-type: application/json' \
+  -d '{"repoKey":"ai-daming/clickvibe"}'
+
 curl -X POST http://127.0.0.1:3080/clickvibe/api/fetch \
   -H 'content-type: application/json' \
   -d '{"url":"https://github.com/cli/cli/issues/100"}'

--- a/docs/plans/2026-08-22-project-first-issues-design.md
+++ b/docs/plans/2026-08-22-project-first-issues-design.md
@@ -1,0 +1,20 @@
+# 项目优先 Issue 面板设计
+
+## 决策
+
+面板入口改为配置仓库选择器。Host 新增项目枚举与 repo issue 聚合接口，一次读取 GitHub issues、PR 及本地 git 事实；Client 只消费聚合结果，不对每个 issue 发 N+1 请求。
+
+## 数据流
+
+1. 项目列表来自 `~/.clickvibe/config.yaml` 的 `repos` 键。路径不在当前机器时仍展示项目，但标记为本机不可用。
+2. 选中 repo 后，Host 枚举全部 open issue，同时读取 milestone、正文中的 `blockedBy`、约定分支/worktree、关联 PR 与 GitHub review 状态。
+3. 本地 workflow 仅补充会话、事件和运行中任务；缺失时按 repo 路径、worktreeRoot、issue 号构造临时视图，不写缓存。
+4. PR `state`、`mergedAt`、`reviewDecision` 每次刷新从 GitHub 查询。已合并 PR 是终态，不再给出合并动作。
+
+## 界面
+
+默认按里程碑分组，可切换为按依赖就绪/阻塞分组，并可过滤依赖状态。每个 issue 一行展示阶段徽章、milestone、blockedBy 和决策表推导的唯一主动作。点击标题进入现有详情；点击主动作先加载完整、最新 issue 快照，再复用现有授权与执行流程。
+
+## 验证
+
+纯状态决策测试覆盖无 workflow 的 idle、残留分支/worktree、已有提交、PR merged。路由测试覆盖 repo 聚合的 issue、依赖、milestone、无 workflow 动作和 GitHub merged 覆盖。最终运行 typecheck、全量测试和 production build。

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -17,6 +17,7 @@ import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'
 // merges the slot names.
 import type { LayoutController } from '@deepseek-ai/dsh-client-ui-layout/client'
 import type { SidebarFooterActionOwnerProps } from '@deepseek-ai/dsh-client-ui-sidebar/client'
+import { githubCompareUrl } from '../state-view.ts'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _SlotLoaders = [typeof LayoutController, SidebarFooterActionOwnerProps]
 
@@ -652,6 +653,7 @@ interface Workflow {
     verdictCurrent: boolean
     nextAction: NextAction
     status: 'idle' | 'developing' | 'review-ready' | 'reviewing' | 'passed'
+    baseBranch: string
   }
 }
 
@@ -888,7 +890,7 @@ function DevSection({ url, issue, workflow, onWorkflow, autoAction, onAutoAction
       case 'sync': void syncWorktree(); break
       case 'create-pr':
         if (workflow) {
-          window.open(`https://github.com/${workflow.repoKey}/compare/main...${encodeURIComponent(workflow.branch)}?expand=1`, '_blank', 'noopener')
+          window.open(githubCompareUrl(workflow.repoKey, workflow.branch, workflow.baseRef, workflow.derived?.baseBranch), '_blank', 'noopener')
         }
         break
       case 'merge':
@@ -1191,7 +1193,12 @@ function PanelContent() {
       return
     }
     if (action.kind === 'create-pr') {
-      window.open(`https://github.com/${issue.workflow.repoKey}/compare/main...${encodeURIComponent(issue.workflow.branch)}?expand=1`, '_blank', 'noopener')
+      window.open(githubCompareUrl(
+        issue.workflow.repoKey,
+        issue.workflow.branch,
+        issue.workflow.baseRef,
+        issue.workflow.derived?.baseBranch,
+      ), '_blank', 'noopener')
       return
     }
     void openIssue(issue, true)

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -49,6 +49,20 @@ const PANEL_CSS = `
 .cv-close:hover { color: #1f2328; }
 .cv-input-row { display: flex; gap: 6px; padding: 4px 14px; flex-shrink: 0; }
 .cv-input-row:last-of-type { padding-bottom: 10px; }
+.cv-project-toolbar { padding: 10px 12px; border-bottom: 1px solid #d0d7de; display: grid; gap: 8px; }
+.cv-project-selects { display: flex; gap: 6px; }
+.cv-select { min-width: 0; flex: 1; border: 1px solid #d0d7de; border-radius: 6px; background: #fff; padding: 6px 8px; color: #1f2328; }
+.cv-project-meta { color: #57606a; font-size: 11px; }
+.cv-project-list { flex: 1; overflow-y: auto; padding: 8px 10px 16px; }
+.cv-group-title { margin: 10px 2px 5px; color: #57606a; font-size: 11px; font-weight: 700; }
+.cv-issue-row { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; gap: 8px; align-items: center; padding: 9px 8px; border: 1px solid #d8dee4; border-radius: 7px; margin-bottom: 6px; background: #fff; }
+.cv-issue-row-main { min-width: 0; }
+.cv-issue-row-title { display: block; color: #0969da; font-size: 12.5px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; cursor: pointer; }
+.cv-issue-row-meta { color: #57606a; font-size: 10.5px; margin-top: 3px; display: flex; gap: 7px; flex-wrap: wrap; }
+.cv-row-lag { color: #9a6700; font-weight: 600; }
+.cv-row-action { border: none; border-radius: 6px; padding: 5px 8px; background: #1f883d; color: white; font-size: 11px; white-space: nowrap; cursor: pointer; }
+.cv-row-action.cv-row-none { background: #afb8c1; cursor: default; }
+.cv-back { border: none; background: transparent; color: #0969da; cursor: pointer; padding: 0; font-size: 12px; }
 .cv-input { flex: 1; min-width: 0; padding: 6px 8px; border: 1px solid #d0d7de; border-radius: 6px; background: #ffffff; color: #1f2328; font-size: 12px; }
 .cv-input::placeholder { color: #8c959f; }
 .cv-fetch { padding: 6px 12px; border: none; border-radius: 6px; background: #0969da; color: #ffffff; cursor: pointer; font-size: 12px; }
@@ -440,13 +454,15 @@ function repoOf(url: string | undefined): string {
   return match ? match[1] : ''
 }
 
-function IssueView({ issue, kind, workflow, onWorkflow, timeline, dependencies }: {
+function IssueView({ issue, kind, workflow, onWorkflow, timeline, dependencies, autoAction, onAutoActionHandled }: {
   issue: GhIssue
   kind: 'issue' | 'pr'
   workflow: Workflow | null
   onWorkflow: (w: Workflow | null) => void
   timeline?: TimelineEvent[]
   dependencies?: Dependencies
+  autoAction?: boolean
+  onAutoActionHandled?: () => void
 }) {
   const isPR = kind === 'pr'
   const state = String(issue.state || '').toUpperCase()
@@ -580,7 +596,7 @@ function IssueView({ issue, kind, workflow, onWorkflow, timeline, dependencies }
         <div className="cv-md">{renderMarkdown(issue.body ?? '')}</div>
       </div>
       {issue.url && kind === 'issue' && state === 'OPEN'
-        ? <DevSection url={issue.url} issue={issue} workflow={workflow} onWorkflow={onWorkflow} />
+        ? <DevSection key={issue.url} url={issue.url} issue={issue} workflow={workflow} onWorkflow={onWorkflow} autoAction={autoAction} onAutoActionHandled={onAutoActionHandled} />
         : null}
       <CommentsSection comments={issue.comments ?? []} />
     </div>
@@ -635,10 +651,11 @@ interface Workflow {
     hasNewCommits: boolean
     verdictCurrent: boolean
     nextAction: NextAction
+    status: 'idle' | 'developing' | 'review-ready' | 'reviewing' | 'passed'
   }
 }
 
-type NextActionKind = 'develop' | 'resume' | 'sync' | 'review' | 'rework' | 'merge' | 'none'
+type NextActionKind = 'develop' | 'resume' | 'sync' | 'create-pr' | 'review' | 'rework' | 'merge' | 'none'
 
 interface NextAction {
   kind: NextActionKind
@@ -672,20 +689,23 @@ function stageLabel(stage: Workflow['stage'], workflow: Workflow | null): string
   }
 }
 
-function DevSection({ url, issue, workflow, onWorkflow }: {
+function DevSection({ url, issue, workflow, onWorkflow, autoAction, onAutoActionHandled }: {
   url: string
   issue: GhIssue
   workflow: Workflow | null
   onWorkflow: (w: Workflow | null) => void
+  autoAction?: boolean
+  onAutoActionHandled?: () => void
 }) {
   const [busy, setBusy] = React.useState<string | null>(null)
   const [error, setError] = React.useState<string | null>(null)
   const [statusLines, setStatusLines] = React.useState<string[]>([])
   const [activeTaskId, setActiveTaskId] = React.useState<string | null>(null)
-  const [agentChoice, setAgentChoice] = React.useState<'codex' | 'claude'>('codex')
+  const [agentChoice, setAgentChoice] = React.useState<'codex' | 'claude'>(() => workflow?.reviewAgent ?? workflow?.devAgent ?? 'codex')
   const esRef = React.useRef<EventSource | null>(null)
-  const stage = workflow?.stage ?? 'idle'
+  const autoActionConsumedRef = React.useRef(false)
   const derived = workflow?.derived
+  const stage = derived?.status ?? workflow?.stage ?? 'idle'
   const nextAction = derived?.nextAction
 
   const appendStatusLine = (line: string) => {
@@ -866,6 +886,11 @@ function DevSection({ url, issue, workflow, onWorkflow }: {
       case 'rework': void resume(workflow?.reviewResult?.issues.join('\n')); break
       case 'review': void startReview(agentChoice); break
       case 'sync': void syncWorktree(); break
+      case 'create-pr':
+        if (workflow) {
+          window.open(`https://github.com/${workflow.repoKey}/compare/main...${encodeURIComponent(workflow.branch)}?expand=1`, '_blank', 'noopener')
+        }
+        break
       case 'merge':
         if (workflow?.prNumber) {
           window.open(`https://github.com/${workflow.repoKey}/pull/${workflow.prNumber}`, '_blank', 'noopener')
@@ -874,6 +899,19 @@ function DevSection({ url, issue, workflow, onWorkflow }: {
       case 'none': break
     }
   }
+
+  React.useEffect(() => {
+    if (!autoAction) {
+      autoActionConsumedRef.current = false
+      return
+    }
+    if (autoActionConsumedRef.current || effectiveAction.kind === 'none') return
+    autoActionConsumedRef.current = true
+    onAutoActionHandled?.()
+    runAction()
+    // The parent owns the one-shot trigger; use the currently rendered issue snapshot.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoAction])
 
   // review 锁定:从未 review 过则两个 agent 都可选;锁过只留那个
   const lockedAgent = effectiveAction.kind === 'review' ? workflow?.reviewAgent ?? null : null
@@ -1063,98 +1101,167 @@ async function fetchIssue(url: string): Promise<{ ok: true; data: { kind: 'issue
   return response.json() as Promise<{ ok: true; data: { kind: 'issue' | 'pr'; item: unknown } } | { ok: false; error: string }>
 }
 
+interface ProjectOption { repoKey: string; path: string; available: boolean }
+interface RepositoryIssue extends GhIssue {
+  blockedBy: Dependency[]
+  workflow: Workflow
+}
+
 function PanelContent() {
-  const [url, setUrl] = React.useState('')
+  const [projects, setProjects] = React.useState<ProjectOption[]>([])
+  const [repoKey, setRepoKey] = React.useState('')
+  const [issues, setIssues] = React.useState<RepositoryIssue[]>([])
+  const [dependencyFilter, setDependencyFilter] = React.useState<'all' | 'ready' | 'blocked'>('all')
+  const [groupBy, setGroupBy] = React.useState<'milestone' | 'dependency'>('milestone')
   const [loading, setLoading] = React.useState(false)
   const [result, setResult] = React.useState<{ kind: 'issue' | 'pr'; item: GhIssue; timeline?: TimelineEvent[]; dependencies?: Dependencies } | null>(null)
   const [error, setError] = React.useState<string | null>(null)
   const [workflow, setWorkflow] = React.useState<Workflow | null>(null)
-  const [restored, setRestored] = React.useState(false)
+  const [autoAction, setAutoAction] = React.useState(false)
 
-  // 恢复现场:打开面板时读回所有工作流,若存在进行中的任务自动重连展示
-  React.useEffect(() => {
-    let cancelled = false
-    void (async () => {
-      try {
-        const res = await apiCall<{ ok: true; workflows: Workflow[] }>('state', {})
-        if (!cancelled && res.ok && res.workflows.length > 0) {
-          const active = res.workflows[0]
-          setWorkflow(active)
-          setUrl(active.url)
-          // 自动重新抓取该 issue
-          const fetchRes = await fetchIssue(active.url)
-          if (!cancelled) {
-            if (fetchRes.ok) setResult(fetchRes.data as { kind: 'issue' | 'pr'; item: GhIssue; timeline?: TimelineEvent[] })
-            else setError(fetchRes.error)
-          }
-        }
-      } catch {
-        // 恢复失败不阻塞面板
-      } finally {
-        if (!cancelled) setRestored(true)
-      }
-    })()
-    return () => { cancelled = true }
-  }, [])
-
-  const run = async (targetUrl = url) => {
-    const trimmed = targetUrl.trim()
-    if (!trimmed) return
+  const loadRepo = async (selected: string) => {
+    if (!selected) return
     setLoading(true)
     setError(null)
     setResult(null)
+    setIssues([])
     try {
-      // 按目标 url 匹配已存 workflow(恢复现场的关键:抓取不清 workflow)
-      const stateRes = await apiCall<{ ok: true; workflows: Workflow[] }>('state', {})
-      const matched = stateRes.ok ? stateRes.workflows.find((w) => w.url === trimmed) ?? null : null
-      setWorkflow(matched)
-      const res = await fetchIssue(trimmed)
-      if (res.ok) setResult(res.data as { kind: 'issue' | 'pr'; item: GhIssue; timeline?: TimelineEvent[] })
-      else setError(res.error)
-    } catch (e) {
-      setError(`调用失败: ${String(e)}`)
+      const response = await apiCall<{ ok: true; issues: RepositoryIssue[] } | { ok: false; error: string }>('repo/issues', { repoKey: selected })
+      if (!response.ok) setError(response.error)
+      else setIssues(response.issues)
+    } catch (reason) {
+      setError(`项目加载失败: ${String(reason)}`)
     } finally {
       setLoading(false)
     }
   }
 
-  const updateWorkflow = (w: Workflow | null) => {
-    setWorkflow(w)
-    // workflow 变化时同步刷新状态(不打断当前展示)
+  React.useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const response = await apiCall<{ ok: true; projects: ProjectOption[] }>('projects', {})
+        if (cancelled) return
+        setProjects(response.projects)
+        const first = response.projects[0]?.repoKey ?? ''
+        setRepoKey(first)
+        if (first) await loadRepo(first)
+      } catch (reason) {
+        if (!cancelled) setError(`项目配置加载失败: ${String(reason)}`)
+      }
+    })()
+    return () => { cancelled = true }
+  }, [])
+
+  const openIssue = async (issue: RepositoryIssue, triggerAction = false) => {
+    setLoading(true)
+    setError(null)
+    setAutoAction(false)
+    try {
+      const response = await fetchIssue(String(issue.url ?? ''))
+      if (!response.ok) setError(response.error)
+      else {
+        setWorkflow(issue.workflow)
+        setResult(response.data as { kind: 'issue' | 'pr'; item: GhIssue; timeline?: TimelineEvent[]; dependencies?: Dependencies })
+        setAutoAction(triggerAction)
+      }
+    } catch (reason) {
+      setError(`Issue 加载失败: ${String(reason)}`)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const filtered = issues.filter((issue) => {
+    const blocked = issue.blockedBy.some((dependency) => dependency.state.toUpperCase() === 'OPEN')
+    return dependencyFilter === 'all' || (dependencyFilter === 'blocked' ? blocked : !blocked)
+  })
+  const grouped = new Map<string, RepositoryIssue[]>()
+  for (const issue of filtered) {
+    const blocked = issue.blockedBy.some((dependency) => dependency.state.toUpperCase() === 'OPEN')
+    const key = groupBy === 'milestone' ? issue.milestone?.title ?? '无里程碑' : blocked ? '被依赖阻塞' : '依赖已就绪'
+    grouped.set(key, [...(grouped.get(key) ?? []), issue])
+  }
+
+  const rowAction = (issue: RepositoryIssue) => {
+    const action = issue.workflow.derived?.nextAction
+    if (!action || action.kind === 'none') return
+    if (action.kind === 'merge' && issue.workflow.prNumber) {
+      window.open(`https://github.com/${issue.workflow.repoKey}/pull/${issue.workflow.prNumber}`, '_blank', 'noopener')
+      return
+    }
+    if (action.kind === 'create-pr') {
+      window.open(`https://github.com/${issue.workflow.repoKey}/compare/main...${encodeURIComponent(issue.workflow.branch)}?expand=1`, '_blank', 'noopener')
+      return
+    }
+    void openIssue(issue, true)
   }
 
   return (
     <div className="cv-panel">
       <div className="cv-panel-header">
-        <span>ClickVibe</span>
+        <span>{result ? <button className="cv-back" onClick={() => { setResult(null); setAutoAction(false) }}>← 项目 Issues</button> : 'ClickVibe · 项目'}</span>
         <button className="cv-close" onClick={() => setPanelOpen(false)}>✕</button>
       </div>
-      <div className="cv-input-row" />
-      <div className="cv-input-row">
-        <input
-          className="cv-input"
-          placeholder="https://github.com/owner/repo/issues/123 或 /pull/123"
-          value={url}
-          onChange={(e) => setUrl(e.target.value)}
-          onKeyDown={(e) => { if (e.key === 'Enter') run() }}
+      {result ? (
+        <IssueView
+          issue={result.item}
+          kind={result.kind}
+          workflow={workflow}
+          onWorkflow={setWorkflow}
+          timeline={result.timeline}
+          dependencies={result.dependencies}
+          autoAction={autoAction}
+          onAutoActionHandled={() => setAutoAction(false)}
         />
-        <button className="cv-fetch" onClick={() => run()} disabled={loading}>
-          {loading ? '抓取中…' : '抓取'}
-        </button>
-        {result ? (
-          <button className="cv-refresh" onClick={() => run()} disabled={loading} title="重新抓取当前 issue">
-            ⟳
-          </button>
-        ) : null}
-      </div>
-      {error ? <div className="cv-error">{error}</div> : null}
-      {result
-        ? <IssueView issue={result.item} kind={result.kind} workflow={workflow} onWorkflow={updateWorkflow} timeline={result.timeline} dependencies={result.dependencies} />
-        : loading
-          ? <div className="cv-loading">正在通过 gh 抓取…</div>
-          : restored
-            ? <div className="cv-hint">粘贴一个 GitHub issue / PR 链接,回车抓取</div>
-            : <div className="cv-loading">正在恢复现场…</div>}
+      ) : (
+        <>
+          <div className="cv-project-toolbar">
+            <select className="cv-select" value={repoKey} onChange={(event) => { const value = event.target.value; setRepoKey(value); void loadRepo(value) }}>
+              {projects.map((project) => <option key={project.repoKey} value={project.repoKey}>{project.repoKey}{project.available ? '' : ' · 远程配置'}</option>)}
+            </select>
+            <div className="cv-project-selects">
+              <select className="cv-select" value={dependencyFilter} onChange={(event) => setDependencyFilter(event.target.value as typeof dependencyFilter)}>
+                <option value="all">全部依赖状态</option><option value="ready">依赖已就绪</option><option value="blocked">被依赖阻塞</option>
+              </select>
+              <select className="cv-select" value={groupBy} onChange={(event) => setGroupBy(event.target.value as typeof groupBy)}>
+                <option value="milestone">按里程碑分组</option><option value="dependency">按依赖分组</option>
+              </select>
+              <button className="cv-refresh" onClick={() => void loadRepo(repoKey)} disabled={loading} title="刷新 GitHub 与 git 状态">⟳</button>
+            </div>
+            {repoKey ? <div className="cv-project-meta">{issues.length} 个 open issue · {projects.find((project) => project.repoKey === repoKey)?.available ? '本机 git + GitHub' : '远程配置 · GitHub'} 实时事实</div> : null}
+          </div>
+          {error ? <div className="cv-error">{error}</div> : null}
+          {loading ? <div className="cv-loading">正在读取项目 issues 与实时状态…</div> : projects.length === 0 ? <div className="cv-hint">请先在 ~/.clickvibe/config.yaml 配置 repos</div> : (
+            <div className="cv-project-list">
+              {[...grouped.entries()].sort(([a], [b]) => a.localeCompare(b)).map(([group, rows]) => (
+                <React.Fragment key={group}>
+                  <div className="cv-group-title">{group} · {rows.length}</div>
+                  {rows.map((issue) => {
+                    const derived = issue.workflow.derived
+                    const status = derived?.status ?? issue.workflow.stage
+                    const action = derived?.nextAction ?? { kind: 'develop' as const, label: '开始开发', hint: '' }
+                    return <div className="cv-issue-row" key={issue.number}>
+                      <span className={`cv-stage cv-stage-${status}`}>{stageLabel(status, issue.workflow)}</span>
+                      <div className="cv-issue-row-main">
+                        <span className="cv-issue-row-title" onClick={() => void openIssue(issue)}>#{issue.number} {issue.title}</span>
+                        <div className="cv-issue-row-meta">
+                          <span>分支: {issue.workflow.branch}</span>
+                          {(derived?.behindBase ?? 0) > 0 ? <span className="cv-row-lag">⚠ 落后 {derived?.behindBase}</span> : null}
+                          <span>里程碑: {issue.milestone?.title ?? '无'}</span>
+                          <span>blockedBy: {issue.blockedBy.length ? issue.blockedBy.map((dependency) => `#${dependency.number}${dependency.state.toUpperCase() === 'OPEN' ? '⏳' : '✓'}`).join(' ') : '无'}</span>
+                        </div>
+                      </div>
+                      <button className={`cv-row-action${action.kind === 'none' ? ' cv-row-none' : ''}`} disabled={action.kind === 'none'} title={action.hint} onClick={() => rowAction(issue)}>{action.kind === 'none' ? (status === 'passed' ? '已交付' : action.label) : action.label}</button>
+                    </div>
+                  })}
+                </React.Fragment>
+              ))}
+              {filtered.length === 0 ? <div className="cv-hint">当前筛选下没有 open issue</div> : null}
+            </div>
+          )}
+        </>
+      )}
     </div>
   )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -331,6 +331,23 @@ interface WorkflowDerived {
   hasNewCommits: boolean
   verdictCurrent: boolean
   nextAction: NextAction
+  status: 'idle' | 'developing' | 'review-ready' | 'reviewing' | 'passed'
+}
+
+interface GithubPrFact {
+  number: string
+  state: 'OPEN' | 'MERGED' | 'CLOSED'
+  mergedAt: string | null
+  headRefName: string
+  url: string
+  reviewDecision: string | null
+}
+
+interface DeriveOptions {
+  pr?: GithubPrFact | null
+  prStatusKnown?: boolean
+  branchExists?: boolean
+  hasCommits?: boolean
 }
 
 /** Short hash of one ref inside the worktree's repo (null when unresolvable). */
@@ -400,6 +417,7 @@ async function readRevCount(ctx: Context, workdir: string, left: string, right: 
 export async function deriveWorkflowState(
   ctx: Context,
   workflow: IssueWorkflow,
+  options: DeriveOptions = {},
 ): Promise<IssueWorkflow & { derived: WorkflowDerived }> {
   const worktree = workflow.worktree
   const exists = existsSync(worktree)
@@ -413,6 +431,13 @@ export async function deriveWorkflowState(
 
   const head = exists ? await readWorktreeHead(ctx, worktree) : null
   const branch = exists ? await readBranch(ctx, worktree) : null
+  const hasUncommittedChanges = exists
+    ? await runCommand(ctx, 'git status --porcelain', {
+        workdir: worktree,
+        timeoutMs: 10000,
+        sandboxPolicy: { mode: 'read-only', workspaceRoot: worktree },
+      }).then((output) => output !== '').catch(() => false)
+    : false
 
   let mainHead: string | null = null
   let aheadOfMain = 0
@@ -448,10 +473,15 @@ export async function deriveWorkflowState(
   const hasNewCommits = head !== null && lastDevHash !== null && head !== lastDevHash
   // worktree 落后远端基线(origin/main 或远端同名分支)→ 需要同步
   const needsSync = behindBase > 0 || (behindUpstream ?? 0) > 0
-  const reviewedHash = lastReviewHash
-  const reviewPassed = workflow.reviewResult?.passed ?? null
+  const githubReviewPassed = options.pr?.reviewDecision === 'APPROVED'
+    ? true
+    : options.pr?.reviewDecision === 'CHANGES_REQUESTED'
+      ? false
+      : null
+  const reviewPassed = workflow.reviewResult?.passed ?? githubReviewPassed
+  const reviewedHash = lastReviewHash ?? (githubReviewPassed !== null ? head : null)
   // 结论仍针对当前 HEAD 才算数;HEAD 变化后旧结论不冒充当前状态
-  const verdictCurrent = workflow.reviewResult !== null && head !== null && reviewedHash !== null && head === reviewedHash
+  const verdictCurrent = reviewPassed !== null && head !== null && reviewedHash !== null && head === reviewedHash
 
   const devLive = workflow.devTaskId ? liveTasks.get(workflow.devTaskId) : undefined
   const reviewLive = workflow.reviewTaskId ? liveTasks.get(workflow.reviewTaskId) : undefined
@@ -459,8 +489,10 @@ export async function deriveWorkflowState(
 
   const facts: WorkflowFacts = {
     issueOpen: (workflow.issueState ?? 'OPEN') !== 'CLOSED',
-    prMerged: false, // PR 合并状态需要网络查询,/state 不做网络 IO,保持实时推导
-    prNumber: workflow.prNumber,
+    prMerged: options.pr?.state === 'MERGED' || options.pr?.mergedAt !== null && options.pr?.mergedAt !== undefined,
+    prState: options.pr?.state ?? null,
+    prStatusKnown: options.prStatusKnown,
+    prNumber: options.pr?.number ?? workflow.prNumber,
     stage: workflow.stage,
     devInterrupted: workflow.devInterrupted,
     taskRunning,
@@ -469,11 +501,27 @@ export async function deriveWorkflowState(
     reviewPassed,
     hasNewCommits,
     needsSync,
+    branchExists: options.branchExists ?? branch !== null,
+    worktreeExists: exists,
+    worktreeValid: !exists || branch === workflow.branch,
+    hasUncommittedChanges,
+    hasCommits: options.hasCommits ?? aheadOfBase > 0,
+    hasResumeSession: workflow.devSessionId !== null,
   }
   const nextAction = deriveNextAction(facts)
+  const status: WorkflowDerived['status'] = facts.prMerged || reviewPassed === true
+    ? 'passed'
+    : taskRunning && workflow.stage === 'reviewing'
+      ? 'reviewing'
+      : facts.prNumber
+        ? 'review-ready'
+        : taskRunning || hasUncommittedChanges || facts.hasCommits
+          ? 'developing'
+          : 'idle'
 
   return {
     ...workflow,
+    prNumber: options.pr?.number ?? workflow.prNumber,
     derived: {
       head,
       branch,
@@ -493,6 +541,7 @@ export async function deriveWorkflowState(
       hasNewCommits,
       verdictCurrent,
       nextAction,
+      status,
     },
   }
 }
@@ -511,7 +560,7 @@ export function apply(ctx: Context): void {
       }
       const pathname = new URL(req.url ?? '/', 'http://clickvibe.internal').pathname
       const method = pathname.startsWith(`${ROUTE}/`) ? pathname.slice(`${ROUTE}/`.length) : undefined
-      const knownMethods = new Set(['fetch', 'state', 'authorize', 'develop', 'develop/poll', 'stream', 'review', 'resume', 'stop', 'sync'])
+      const knownMethods = new Set(['fetch', 'projects', 'repo/issues', 'state', 'authorize', 'develop', 'develop/poll', 'stream', 'review', 'resume', 'stop', 'sync'])
       if (method === undefined || !knownMethods.has(method)) {
         writeJson(res, 404, { ok: false, error: 'unknown method' })
         return
@@ -546,12 +595,23 @@ export function apply(ctx: Context): void {
         writeJson(res, result.ok ? 200 : 400, result)
         return
       }
+      if (method === 'projects') {
+        const result = await listProjects()
+        writeJson(res, 200, result)
+        return
+      }
+      if (method === 'repo/issues') {
+        const result = await fetchRepositoryIssues(ctx, payload)
+        writeJson(res, result.ok ? 200 : 400, result)
+        return
+      }
       if (method === 'state') {
         const workflows = await loadAllWorkflows()
         // 附加推导状态:worktree HEAD + 相对最新事件的进展(不覆盖存储)
         const enriched = []
         for (const w of workflows) {
-          const derived = await deriveWorkflowState(ctx, w)
+          const pr = await fetchGithubPrFact(ctx, w.repoKey, w.branch, w.prNumber)
+          const derived = await deriveWorkflowState(ctx, w, { pr, prStatusKnown: w.prNumber ? pr !== null : true })
           enriched.push(derived)
         }
         writeJson(res, 200, { ok: true, workflows: enriched })
@@ -663,6 +723,155 @@ export function apply(ctx: Context): void {
       writeJson(res, 404, { ok: false, error: `unknown method "${method}"` })
     },
   })
+}
+
+async function listProjects(): Promise<{ ok: true; projects: { repoKey: string; path: string; available: boolean }[] }> {
+  const config = await loadConfig()
+  return {
+    ok: true,
+    projects: Object.entries(config.repos)
+      .map(([repoKey, path]) => ({ repoKey, path: expandHome(path), available: existsSync(expandHome(path)) }))
+      .sort((a, b) => a.repoKey.localeCompare(b.repoKey)),
+  }
+}
+
+async function fetchGithubPrFact(
+  ctx: Context,
+  repoKey: string,
+  branch: string,
+  prNumber: string | null,
+): Promise<GithubPrFact | null> {
+  const selector = prNumber ? shellQuote(prNumber) : `--head ${shellQuote(branch)} --state all --limit 1`
+  const command = prNumber
+    ? `gh pr view ${selector} --repo ${shellQuote(repoKey)} --json number,state,mergedAt,headRefName,url,reviewDecision`
+    : `gh pr list --repo ${shellQuote(repoKey)} ${selector} --json number,state,mergedAt,headRefName,url,reviewDecision --jq '.[0] // {}'`
+  try {
+    const output = await runCommand(ctx, command, { timeoutMs: 20000 })
+    const raw = JSON.parse(output || '{}') as Partial<GithubPrFact> & { number?: number | string }
+    if (raw.number === undefined) return null
+    return {
+      number: String(raw.number),
+      state: raw.state === 'MERGED' ? 'MERGED' : raw.state === 'CLOSED' ? 'CLOSED' : 'OPEN',
+      mergedAt: raw.mergedAt ?? null,
+      headRefName: String(raw.headRefName ?? branch),
+      url: String(raw.url ?? `https://github.com/${repoKey}/pull/${raw.number}`),
+      reviewDecision: raw.reviewDecision ?? null,
+    }
+  } catch {
+    return null
+  }
+}
+
+interface RepositoryIssueItem {
+  number: number
+  title: string
+  state: string
+  body: string
+  url: string
+  updatedAt?: string
+  labels?: { name: string; color?: string }[]
+  milestone?: { title: string; number?: number } | null
+}
+
+export async function fetchRepositoryIssues(
+  ctx: Context,
+  payload: unknown,
+  overrides: { config?: ClickVibeConfig; workflows?: IssueWorkflow[] } = {},
+): Promise<
+  | { ok: true; repoKey: string; issues: unknown[] }
+  | { ok: false; error: string }
+> {
+  const repoKey = String((payload as { repoKey?: unknown } | undefined)?.repoKey ?? '').trim()
+  const config = overrides.config ?? await loadConfig()
+  const configuredPath = config.repos[repoKey]
+  if (!configuredPath) return { ok: false, error: `未配置项目 ${repoKey}` }
+
+  const issueCommand = `gh issue list --repo ${shellQuote(repoKey)} --state all --limit 1000 --json number,title,state,body,url,updatedAt,labels,milestone`
+  const prCommand = `gh pr list --repo ${shellQuote(repoKey)} --state all --limit 1000 --json number,state,mergedAt,headRefName,url,reviewDecision`
+  try {
+    const [issueOutput, prOutput, allWorkflows] = await Promise.all([
+      runCommand(ctx, issueCommand, { timeoutMs: 30000 }),
+      runCommand(ctx, prCommand, { timeoutMs: 30000 }),
+      overrides.workflows ? Promise.resolve(overrides.workflows) : loadAllWorkflows(),
+    ])
+    const allIssues = JSON.parse(issueOutput) as RepositoryIssueItem[]
+    const prs = JSON.parse(prOutput) as (Omit<GithubPrFact, 'number'> & { number: number | string })[]
+    if (!Array.isArray(allIssues) || !Array.isArray(prs)) throw new Error('GitHub 返回格式无效')
+
+    const issueByNumber = new Map(allIssues.map((issue) => [issue.number, issue]))
+    const workflowByNumber = new Map(
+      allWorkflows
+        .filter((workflow) => workflow.repoKey === repoKey)
+        .map((workflow) => [Number(parseUrl(workflow.url)?.number), workflow]),
+    )
+    const prByBranch = new Map<string, GithubPrFact>()
+    for (const raw of prs) {
+      if (!raw.headRefName || prByBranch.has(raw.headRefName)) continue
+      prByBranch.set(raw.headRefName, { ...raw, number: String(raw.number) })
+    }
+
+    const repoPath = expandHome(configuredPath)
+    const project = basename(repoPath)
+    let refs = new Set<string>()
+    if (existsSync(repoPath)) {
+      const refOutput = await runCommand(
+        ctx,
+        "git for-each-ref --format='%(refname:short)' refs/heads refs/remotes/origin",
+        { workdir: repoPath, timeoutMs: 15000, sandboxPolicy: { mode: 'read-only', workspaceRoot: repoPath } },
+      ).catch(() => '')
+      refs = new Set(refOutput.split('\n').filter(Boolean))
+    }
+
+    const openIssues = allIssues.filter((issue) => String(issue.state).toUpperCase() === 'OPEN')
+    const issues = await Promise.all(openIssues.map(async (issue) => {
+      const existing = workflowByNumber.get(issue.number)
+      const branch = existing?.branch ?? `${project}-issue-${issue.number}`
+      const worktree = existing?.worktree ?? join(config.worktreeRoot, project, branch)
+      const branchExists = refs.has(branch) || refs.has(`origin/${branch}`)
+      const pr = prByBranch.get(branch) ?? null
+      let hasCommits = false
+      if (branchExists && existsSync(repoPath)) {
+        hasCommits = await runCommand(ctx, `git rev-list --count origin/main..${shellQuote(branch)}`, {
+          workdir: repoPath,
+          timeoutMs: 10000,
+          sandboxPolicy: { mode: 'read-only', workspaceRoot: repoPath },
+        }).then((count) => Number(count) > 0).catch(() => false)
+      }
+      const workflow: IssueWorkflow = existing ?? {
+        key: issueKey(repoKey, String(issue.number)),
+        url: issue.url,
+        repoKey,
+        worktree,
+        branch,
+        stage: pr ? 'review-ready' : 'idle',
+        devAgent: null,
+        devTaskId: null,
+        devSessionId: null,
+        devInterrupted: false,
+        reviewAgent: null,
+        reviewTaskId: null,
+        reviewSessionId: null,
+        reviewResult: null,
+        prNumber: pr?.number ?? null,
+        issueState: 'OPEN',
+        baseRef: null,
+        updatedAt: 0,
+        events: [],
+      }
+      workflow.worktree = worktree
+      workflow.branch = branch
+      workflow.issueState = 'OPEN'
+      const derived = await deriveWorkflowState(ctx, workflow, { pr, branchExists, hasCommits })
+      const blockedBy = parseDependencies(issue.body).map((number) => {
+        const dependency = issueByNumber.get(number)
+        return { number, title: dependency?.title ?? '', state: String(dependency?.state ?? 'UNKNOWN').toUpperCase() }
+      })
+      return { ...issue, blockedBy, workflow: derived }
+    }))
+    return { ok: true, repoKey, issues }
+  } catch (error) {
+    return { ok: false, error: `项目 issue 抓取失败: ${String(error instanceof Error ? error.message : error)}` }
+  }
 }
 
 /** Validate the URL and run gh, returning the { ok, ... } envelope. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ import {
   type DevelopAgent,
   type IssuePromptSnapshot,
 } from './develop.ts'
-import { deriveNextAction, type NextAction, type WorkflowFacts } from './state-view.ts'
+import { deriveNextAction, workflowBaseBranch, type NextAction, type WorkflowFacts } from './state-view.ts'
 import {
   appendEvent,
   appendLog,
@@ -332,6 +332,7 @@ interface WorkflowDerived {
   verdictCurrent: boolean
   nextAction: NextAction
   status: 'idle' | 'developing' | 'review-ready' | 'reviewing' | 'passed'
+  baseBranch: string
 }
 
 interface GithubPrFact {
@@ -348,6 +349,7 @@ interface DeriveOptions {
   prStatusKnown?: boolean
   branchExists?: boolean
   hasCommits?: boolean
+  defaultBranch?: string
 }
 
 /** Short hash of one ref inside the worktree's repo (null when unresolvable). */
@@ -419,6 +421,7 @@ export async function deriveWorkflowState(
   workflow: IssueWorkflow,
   options: DeriveOptions = {},
 ): Promise<IssueWorkflow & { derived: WorkflowDerived }> {
+  const workflowPrNumber = workflow.prNumber == null ? null : String(workflow.prNumber)
   const worktree = workflow.worktree
   const exists = existsSync(worktree)
   const events = workflow.events ?? []
@@ -492,7 +495,7 @@ export async function deriveWorkflowState(
     prMerged: options.pr?.state === 'MERGED' || options.pr?.mergedAt !== null && options.pr?.mergedAt !== undefined,
     prState: options.pr?.state ?? null,
     prStatusKnown: options.prStatusKnown,
-    prNumber: options.pr?.number ?? workflow.prNumber,
+    prNumber: options.pr?.number ?? workflowPrNumber,
     stage: workflow.stage,
     devInterrupted: workflow.devInterrupted,
     taskRunning,
@@ -509,6 +512,7 @@ export async function deriveWorkflowState(
     hasResumeSession: workflow.devSessionId !== null,
   }
   const nextAction = deriveNextAction(facts)
+  const baseBranch = workflowBaseBranch(workflow.baseRef, options.defaultBranch ?? 'main')
   const status: WorkflowDerived['status'] = facts.prMerged || reviewPassed === true
     ? 'passed'
     : taskRunning && workflow.stage === 'reviewing'
@@ -521,7 +525,7 @@ export async function deriveWorkflowState(
 
   return {
     ...workflow,
-    prNumber: options.pr?.number ?? workflow.prNumber,
+    prNumber: options.pr?.number ?? workflowPrNumber,
     derived: {
       head,
       branch,
@@ -542,6 +546,7 @@ export async function deriveWorkflowState(
       verdictCurrent,
       nextAction,
       status,
+      baseBranch,
     },
   }
 }
@@ -607,13 +612,7 @@ export function apply(ctx: Context): void {
       }
       if (method === 'state') {
         const workflows = await loadAllWorkflows()
-        // 附加推导状态:worktree HEAD + 相对最新事件的进展(不覆盖存储)
-        const enriched = []
-        for (const w of workflows) {
-          const pr = await fetchGithubPrFact(ctx, w.repoKey, w.branch, w.prNumber)
-          const derived = await deriveWorkflowState(ctx, w, { pr, prStatusKnown: w.prNumber ? pr !== null : true })
-          enriched.push(derived)
-        }
+        const enriched = await enrichWorkflowStates(ctx, workflows)
         writeJson(res, 200, { ok: true, workflows: enriched })
         return
       }
@@ -735,31 +734,87 @@ async function listProjects(): Promise<{ ok: true; projects: { repoKey: string; 
   }
 }
 
+interface GithubPrLookup {
+  known: boolean
+  pr: GithubPrFact | null
+}
+
 async function fetchGithubPrFact(
   ctx: Context,
   repoKey: string,
   branch: string,
-  prNumber: string | null,
-): Promise<GithubPrFact | null> {
-  const selector = prNumber ? shellQuote(prNumber) : `--head ${shellQuote(branch)} --state all --limit 1`
-  const command = prNumber
+  prNumber: string | number | null,
+): Promise<GithubPrLookup> {
+  const hasPrNumber = prNumber !== null && prNumber !== undefined
+  const selector = hasPrNumber ? shellQuote(String(prNumber)) : `--head ${shellQuote(branch)} --state all --limit 1`
+  const command = hasPrNumber
     ? `gh pr view ${selector} --repo ${shellQuote(repoKey)} --json number,state,mergedAt,headRefName,url,reviewDecision`
     : `gh pr list --repo ${shellQuote(repoKey)} ${selector} --json number,state,mergedAt,headRefName,url,reviewDecision --jq '.[0] // {}'`
   try {
-    const output = await runCommand(ctx, command, { timeoutMs: 20000 })
+    const output = await runCommand(ctx, command, { timeoutMs: 5000 })
     const raw = JSON.parse(output || '{}') as Partial<GithubPrFact> & { number?: number | string }
-    if (raw.number === undefined) return null
+    if (raw.number === undefined) return { known: true, pr: null }
     return {
-      number: String(raw.number),
-      state: raw.state === 'MERGED' ? 'MERGED' : raw.state === 'CLOSED' ? 'CLOSED' : 'OPEN',
-      mergedAt: raw.mergedAt ?? null,
-      headRefName: String(raw.headRefName ?? branch),
-      url: String(raw.url ?? `https://github.com/${repoKey}/pull/${raw.number}`),
-      reviewDecision: raw.reviewDecision ?? null,
+      known: true,
+      pr: {
+        number: String(raw.number),
+        state: raw.state === 'MERGED' ? 'MERGED' : raw.state === 'CLOSED' ? 'CLOSED' : 'OPEN',
+        mergedAt: raw.mergedAt ?? null,
+        headRefName: String(raw.headRefName ?? branch),
+        url: String(raw.url ?? `https://github.com/${repoKey}/pull/${raw.number}`),
+        reviewDecision: raw.reviewDecision ?? null,
+      },
     }
   } catch {
-    return null
+    return { known: false, pr: null }
   }
+}
+
+async function readConfiguredBranchFacts(
+  ctx: Context,
+  config: ClickVibeConfig,
+  workflow: IssueWorkflow,
+): Promise<{ branchExists?: boolean; hasCommits?: boolean; defaultBranch?: string }> {
+  const configuredPath = config.repos[workflow.repoKey]
+  if (!configuredPath) return {}
+  const repoPath = expandHome(configuredPath)
+  if (!existsSync(repoPath)) return {}
+  const policy = { mode: 'read-only' as const, workspaceRoot: repoPath }
+  const localRef = `refs/heads/${workflow.branch}`
+  const remoteRef = `refs/remotes/origin/${workflow.branch}`
+  const branchRef = await runCommand(ctx,
+    `if git show-ref --verify --quiet ${shellQuote(localRef)}; then printf %s ${shellQuote(workflow.branch)}; elif git show-ref --verify --quiet ${shellQuote(remoteRef)}; then printf %s ${shellQuote(`origin/${workflow.branch}`)}; else exit 1; fi`,
+    { workdir: repoPath, timeoutMs: 3000, sandboxPolicy: policy },
+  ).catch(() => '')
+  const defaultRef = await runCommand(ctx, 'git symbolic-ref --quiet --short refs/remotes/origin/HEAD', {
+    workdir: repoPath, timeoutMs: 3000, sandboxPolicy: policy,
+  }).catch(() => '')
+  if (!branchRef) return { branchExists: false, defaultBranch: defaultRef.replace(/^origin\//, '') || undefined }
+  const baseRef = defaultRef || 'origin/main'
+  const hasCommits = await runCommand(ctx, `git rev-list --count ${shellQuote(baseRef)}..${shellQuote(branchRef)}`, {
+    workdir: repoPath, timeoutMs: 3000, sandboxPolicy: policy,
+  }).then((count) => Number(count) > 0).catch(() => false)
+  return { branchExists: true, hasCommits, defaultBranch: defaultRef.replace(/^origin\//, '') || undefined }
+}
+
+/** Enrich every stored workflow concurrently; one unreachable GitHub call costs at most one 5s window. */
+export async function enrichWorkflowStates(
+  ctx: Context,
+  workflows: IssueWorkflow[],
+  configOverride?: ClickVibeConfig,
+): Promise<Array<IssueWorkflow & { derived: WorkflowDerived }>> {
+  const config = configOverride ?? await loadConfig()
+  return Promise.all(workflows.map(async (workflow) => {
+    const [prLookup, branchFacts] = await Promise.all([
+      fetchGithubPrFact(ctx, workflow.repoKey, workflow.branch, workflow.prNumber),
+      readConfiguredBranchFacts(ctx, config, workflow),
+    ])
+    return deriveWorkflowState(ctx, workflow, {
+      pr: prLookup.pr,
+      prStatusKnown: workflow.prNumber ? prLookup.known && prLookup.pr !== null : prLookup.known,
+      ...branchFacts,
+    })
+  }))
 }
 
 interface RepositoryIssueItem {
@@ -771,6 +826,31 @@ interface RepositoryIssueItem {
   updatedAt?: string
   labels?: { name: string; color?: string }[]
   milestone?: { title: string; number?: number } | null
+}
+
+interface RepositoryIssueRest {
+  number: number
+  title: string
+  state: string
+  body: string | null
+  html_url: string
+  updated_at?: string
+  labels?: { name: string; color?: string }[]
+  milestone?: { title: string; number?: number } | null
+  pull_request?: unknown
+}
+
+interface RepositoryPrRest {
+  number: number
+  state: string
+  merged_at: string | null
+  html_url: string
+  head?: { ref?: string }
+}
+
+function flattenGithubPages<T>(value: unknown): T[] {
+  if (!Array.isArray(value)) throw new Error('GitHub 分页返回格式无效')
+  return value.flatMap((page) => Array.isArray(page) ? page as T[] : [page as T])
 }
 
 export async function fetchRepositoryIssues(
@@ -786,17 +866,34 @@ export async function fetchRepositoryIssues(
   const configuredPath = config.repos[repoKey]
   if (!configuredPath) return { ok: false, error: `未配置项目 ${repoKey}` }
 
-  const issueCommand = `gh issue list --repo ${shellQuote(repoKey)} --state all --limit 1000 --json number,title,state,body,url,updatedAt,labels,milestone`
-  const prCommand = `gh pr list --repo ${shellQuote(repoKey)} --state all --limit 1000 --json number,state,mergedAt,headRefName,url,reviewDecision`
+  const issueCommand = `gh api --paginate --slurp ${shellQuote(`repos/${repoKey}/issues?state=all&per_page=100`)}`
+  const prCommand = `gh api --paginate --slurp ${shellQuote(`repos/${repoKey}/pulls?state=all&per_page=100`)}`
   try {
     const [issueOutput, prOutput, allWorkflows] = await Promise.all([
       runCommand(ctx, issueCommand, { timeoutMs: 30000 }),
       runCommand(ctx, prCommand, { timeoutMs: 30000 }),
       overrides.workflows ? Promise.resolve(overrides.workflows) : loadAllWorkflows(),
     ])
-    const allIssues = JSON.parse(issueOutput) as RepositoryIssueItem[]
-    const prs = JSON.parse(prOutput) as (Omit<GithubPrFact, 'number'> & { number: number | string })[]
-    if (!Array.isArray(allIssues) || !Array.isArray(prs)) throw new Error('GitHub 返回格式无效')
+    const allIssues = flattenGithubPages<RepositoryIssueRest>(JSON.parse(issueOutput))
+      .filter((issue) => issue.pull_request === undefined)
+      .map<RepositoryIssueItem>((issue) => ({
+        number: issue.number,
+        title: issue.title,
+        state: issue.state.toUpperCase(),
+        body: issue.body ?? '',
+        url: issue.html_url,
+        updatedAt: issue.updated_at,
+        labels: issue.labels,
+        milestone: issue.milestone,
+      }))
+    const prs = flattenGithubPages<RepositoryPrRest>(JSON.parse(prOutput)).map<GithubPrFact>((pr) => ({
+      number: String(pr.number),
+      state: pr.merged_at ? 'MERGED' : pr.state.toUpperCase() === 'CLOSED' ? 'CLOSED' : 'OPEN',
+      mergedAt: pr.merged_at,
+      headRefName: String(pr.head?.ref ?? ''),
+      url: pr.html_url,
+      reviewDecision: null,
+    }))
 
     const issueByNumber = new Map(allIssues.map((issue) => [issue.number, issue]))
     const workflowByNumber = new Map(
@@ -813,13 +910,19 @@ export async function fetchRepositoryIssues(
     const repoPath = expandHome(configuredPath)
     const project = basename(repoPath)
     let refs = new Set<string>()
+    let defaultBranch = 'main'
     if (existsSync(repoPath)) {
-      const refOutput = await runCommand(
-        ctx,
-        "git for-each-ref --format='%(refname:short)' refs/heads refs/remotes/origin",
-        { workdir: repoPath, timeoutMs: 15000, sandboxPolicy: { mode: 'read-only', workspaceRoot: repoPath } },
-      ).catch(() => '')
+      const policy = { mode: 'read-only' as const, workspaceRoot: repoPath }
+      const [refOutput, defaultRef] = await Promise.all([
+        runCommand(ctx, "git for-each-ref --format='%(refname:short)' refs/heads refs/remotes/origin", {
+          workdir: repoPath, timeoutMs: 5000, sandboxPolicy: policy,
+        }).catch(() => ''),
+        runCommand(ctx, 'git symbolic-ref --quiet --short refs/remotes/origin/HEAD', {
+          workdir: repoPath, timeoutMs: 3000, sandboxPolicy: policy,
+        }).catch(() => ''),
+      ])
       refs = new Set(refOutput.split('\n').filter(Boolean))
+      defaultBranch = defaultRef.replace(/^origin\//, '') || defaultBranch
     }
 
     const openIssues = allIssues.filter((issue) => String(issue.state).toUpperCase() === 'OPEN')
@@ -828,10 +931,19 @@ export async function fetchRepositoryIssues(
       const branch = existing?.branch ?? `${project}-issue-${issue.number}`
       const worktree = existing?.worktree ?? join(config.worktreeRoot, project, branch)
       const branchExists = refs.has(branch) || refs.has(`origin/${branch}`)
-      const pr = prByBranch.get(branch) ?? null
+      let pr: GithubPrFact | null
+      let prStatusKnown: boolean
+      if (existing?.prNumber) {
+        const lookup = await fetchGithubPrFact(ctx, repoKey, branch, existing.prNumber)
+        pr = lookup.pr
+        prStatusKnown = lookup.known && lookup.pr !== null
+      } else {
+        pr = prByBranch.get(branch) ?? null
+        prStatusKnown = true
+      }
       let hasCommits = false
       if (branchExists && existsSync(repoPath)) {
-        hasCommits = await runCommand(ctx, `git rev-list --count origin/main..${shellQuote(branch)}`, {
+        hasCommits = await runCommand(ctx, `git rev-list --count ${shellQuote(`origin/${defaultBranch}`)}..${shellQuote(branch)}`, {
           workdir: repoPath,
           timeoutMs: 10000,
           sandboxPolicy: { mode: 'read-only', workspaceRoot: repoPath },
@@ -861,7 +973,9 @@ export async function fetchRepositoryIssues(
       workflow.worktree = worktree
       workflow.branch = branch
       workflow.issueState = 'OPEN'
-      const derived = await deriveWorkflowState(ctx, workflow, { pr, branchExists, hasCommits })
+      const derived = await deriveWorkflowState(ctx, workflow, {
+        pr, prStatusKnown, branchExists, hasCommits, defaultBranch,
+      })
       const blockedBy = parseDependencies(issue.body).map((number) => {
         const dependency = issueByNumber.get(number)
         return { number, title: dependency?.title ?? '', state: String(dependency?.state ?? 'UNKNOWN').toUpperCase() }

--- a/src/state-view.ts
+++ b/src/state-view.ts
@@ -24,6 +24,23 @@ export interface NextAction {
   hint: string
 }
 
+/** Resolve the PR base from the frozen workflow baseline, then the live repo default. */
+export function workflowBaseBranch(baseRef: string | null | undefined, defaultBranch = 'main'): string {
+  const ref = String(baseRef ?? '').split(/\s+@\s+/, 1)[0].trim()
+  const branch = ref.replace(/^refs\/remotes\/origin\//, '').replace(/^origin\//, '')
+  return branch !== '' && branch !== 'HEAD' ? branch : defaultBranch
+}
+
+export function githubCompareUrl(
+  repoKey: string,
+  branch: string,
+  baseRef: string | null | undefined,
+  defaultBranch = 'main',
+): string {
+  const base = workflowBaseBranch(baseRef, defaultBranch)
+  return `https://github.com/${repoKey}/compare/${encodeURIComponent(base)}...${encodeURIComponent(branch)}?expand=1`
+}
+
 export type WorkflowStageInput = 'idle' | 'developing' | 'review-ready' | 'reviewing' | 'passed'
 
 export interface WorkflowFacts {

--- a/src/state-view.ts
+++ b/src/state-view.ts
@@ -10,6 +10,7 @@ export type NextActionKind =
   | 'develop'
   | 'resume'
   | 'sync'
+  | 'create-pr'
   | 'review'
   | 'rework'
   | 'merge'
@@ -30,6 +31,10 @@ export interface WorkflowFacts {
   issueOpen: boolean
   /** A linked PR has been merged: terminal state. */
   prMerged: boolean
+  /** Current GitHub PR state, queried live. */
+  prState?: 'OPEN' | 'MERGED' | 'CLOSED' | null
+  /** False means a linked PR exists in cache but its live GitHub state could not be read. */
+  prStatusKnown?: boolean
   prNumber: string | null
   /** Persisted workflow stage. */
   stage: WorkflowStageInput
@@ -47,6 +52,13 @@ export interface WorkflowFacts {
   hasNewCommits: boolean
   /** Worktree is behind its base / remote branch and should be synced. */
   needsSync: boolean
+  /** Hard git facts used when the workflow cache is absent. */
+  branchExists?: boolean
+  worktreeExists?: boolean
+  worktreeValid?: boolean
+  hasUncommittedChanges?: boolean
+  hasCommits?: boolean
+  hasResumeSession?: boolean
 }
 
 function action(kind: NextActionKind, label: string, hint: string): NextAction {
@@ -69,6 +81,37 @@ export function deriveNextAction(facts: WorkflowFacts): NextAction {
   if (!facts.issueOpen) return action('none', '无', 'issue 已关闭,无待办动作')
   if (facts.prMerged) return action('none', '无', 'PR 已合并,交付完成')
   if (facts.taskRunning) return action('none', '任务进行中', '开发/review 正在运行,等待完成')
+  if (facts.prNumber && facts.prStatusKnown === false) {
+    return action('none', '刷新 PR 状态', 'GitHub PR 实时状态查询失败,为避免误合并已暂停动作')
+  }
+
+  // P2 结构恢复。统一走 develop,由 ensureWorktree 按硬事实幂等恢复。
+  if (facts.worktreeExists && facts.worktreeValid === false) {
+    return action('develop', '修复 worktree', 'worktree 未附着到约定分支,修复后继续开发')
+  }
+  if (facts.branchExists && facts.worktreeExists === false && (facts.hasCommits || facts.stage !== 'idle')) {
+    return action('develop', '恢复 worktree 继续开发', '分支仍存在,重建 worktree 后继续开发')
+  }
+
+  // worktree 落后远端基线 → 先同步(唯一动作)。
+  if (facts.needsSync) {
+    return action('sync', '同步 worktree', 'worktree 落后远端基线,先同步再继续')
+  }
+
+  // GitHub 上 closed-but-unmerged 是异常终态,必须显式交还给人处理。
+  if (facts.prState === 'CLOSED') {
+    return action('develop', '查看原因 / 重新开发', 'PR 已关闭但未合并,检查原因后重新开发')
+  }
+
+  // 没有 workflow 缓存时,从 git 内容与 PR 硬事实恢复生命周期。
+  if (!facts.prNumber && facts.hasUncommittedChanges) {
+    return facts.hasResumeSession
+      ? action('resume', '恢复开发', 'worktree 有未提交改动,续上次 agent 会话')
+      : action('develop', '重新开发', 'worktree 有未提交改动但无可恢复会话,启动新会话')
+  }
+  if (!facts.prNumber && facts.hasCommits) {
+    return action('create-pr', '创建 PR', '开发分支已有提交,推送并创建 PR 后 Review')
+  }
 
   // 中断恢复:开发中但没有存活任务(Host 重启 / 用户停止 / agent 失败)→ 恢复会话。
   // taskRunning 已在上方排除,这里 stage==='developing' 即意味着任务已失联。
@@ -84,14 +127,9 @@ export function deriveNextAction(facts: WorkflowFacts): NextAction {
     return action('review', '重新 Review', '上次 review 中断,重新审查当前代码')
   }
 
-  // worktree 缺失(非 idle):无法继续,需要人工修复。
+  // worktree 缺失(非 idle,且分支也无法确认):无法继续,需要人工检查。
   if (facts.stage !== 'idle' && facts.head === null) {
     return action('none', '无', 'worktree 缺失,请检查本地配置')
-  }
-
-  // worktree 落后远端基线 → 先同步(唯一动作)。
-  if (facts.needsSync) {
-    return action('sync', '同步 worktree', 'worktree 落后远端基线,先同步再继续')
   }
 
   // developing / reviewing 已被上面的早退处理(中断恢复/重新 review)

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { createServer, request, type RequestListener } from 'node:http'
 import test from 'node:test'
-import { apply } from '../src/index.ts'
+import { apply, fetchRepositoryIssues } from '../src/index.ts'
 
 function createHandler(run?: (spec: { command: string }) => Promise<unknown>): RequestListener {
   let handler: RequestListener | null = null
@@ -180,4 +180,45 @@ test('/fetch on an issue without a 依赖 section yields no blockedBy (and no bl
   assert.ok(deps)
   assert.deepEqual(deps.blockedBy, [])
   assert.deepEqual(deps.blocking.map((d) => (d as { number: number }).number), [7])
+})
+
+test('repo issue aggregation includes open issues without workflows and honors live merged PR state', async () => {
+  const allIssues = [
+    { number: 5, title: 'dependency', state: 'CLOSED', body: '', url: 'https://github.com/o/r/issues/5', milestone: null },
+    { number: 7, title: 'delivered but still open', state: 'OPEN', body: '## 依赖\nBlocked by #5', url: 'https://github.com/o/r/issues/7', milestone: { title: 'M1' } },
+    { number: 8, title: 'never developed', state: 'OPEN', body: '## 依赖\n无', url: 'https://github.com/o/r/issues/8', milestone: null },
+  ]
+  const prs = [
+    { number: 19, state: 'MERGED', mergedAt: '2026-08-22T00:00:00Z', headRefName: 'r-issue-7', url: 'https://github.com/o/r/pull/19', reviewDecision: 'APPROVED' },
+  ]
+  const ctx = {
+    shell: {
+      resolve(spec: unknown) { return spec },
+      async run(spec: { command: string }) {
+        if (spec.command.startsWith('gh issue list')) return { exitCode: 0, stdout: { text: JSON.stringify(allIssues) }, stderr: { text: '' } }
+        if (spec.command.startsWith('gh pr list')) return { exitCode: 0, stdout: { text: JSON.stringify(prs) }, stderr: { text: '' } }
+        throw new Error(`unexpected command: ${spec.command}`)
+      },
+    },
+  }
+  const result = await fetchRepositoryIssues(ctx as never, { repoKey: 'o/r' }, {
+    config: { repos: { 'o/r': '/remote/r' }, worktreeRoot: '/remote/worktrees' },
+    workflows: [],
+  })
+  assert.equal(result.ok, true)
+  if (!result.ok) return
+  const issues = result.issues as Array<{
+    number: number
+    milestone: { title: string } | null
+    blockedBy: { number: number; state: string }[]
+    workflow: { prNumber: string | null; derived: { status: string; nextAction: { kind: string; label: string } } }
+  }>
+  assert.deepEqual(issues.map((issue) => issue.number), [7, 8])
+  assert.deepEqual(issues[0].blockedBy, [{ number: 5, title: 'dependency', state: 'CLOSED' }])
+  assert.equal(issues[0].milestone?.title, 'M1')
+  assert.equal(issues[0].workflow.prNumber, '19')
+  assert.equal(issues[0].workflow.derived.status, 'passed')
+  assert.equal(issues[0].workflow.derived.nextAction.kind, 'none')
+  assert.equal(issues[1].workflow.derived.status, 'idle')
+  assert.equal(issues[1].workflow.derived.nextAction.label, '开始开发')
 })

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -125,6 +125,12 @@ test('/sync rejects worktree mutation without the same-origin privileged headers
   assert.match(result.body.error ?? '', /授权请求头/)
 })
 
+test('/projects route returns the configured-project envelope without invoking shell', async () => {
+  const result = await post(createHandler(), '/clickvibe/api/projects', {})
+  assert.equal(result.status, 200)
+  assert.equal(Array.isArray((result.body as { projects?: unknown[] }).projects), true)
+})
+
 
 
 test('/fetch resolves blockedBy from the body and blocking from a repo scan', async () => {
@@ -184,19 +190,19 @@ test('/fetch on an issue without a 依赖 section yields no blockedBy (and no bl
 
 test('repo issue aggregation includes open issues without workflows and honors live merged PR state', async () => {
   const allIssues = [
-    { number: 5, title: 'dependency', state: 'CLOSED', body: '', url: 'https://github.com/o/r/issues/5', milestone: null },
-    { number: 7, title: 'delivered but still open', state: 'OPEN', body: '## 依赖\nBlocked by #5', url: 'https://github.com/o/r/issues/7', milestone: { title: 'M1' } },
-    { number: 8, title: 'never developed', state: 'OPEN', body: '## 依赖\n无', url: 'https://github.com/o/r/issues/8', milestone: null },
+    { number: 5, title: 'dependency', state: 'closed', body: '', html_url: 'https://github.com/o/r/issues/5', milestone: null },
+    { number: 7, title: 'delivered but still open', state: 'open', body: '## 依赖\nBlocked by #5', html_url: 'https://github.com/o/r/issues/7', milestone: { title: 'M1' } },
+    { number: 8, title: 'never developed', state: 'open', body: '## 依赖\n无', html_url: 'https://github.com/o/r/issues/8', milestone: null },
   ]
   const prs = [
-    { number: 19, state: 'MERGED', mergedAt: '2026-08-22T00:00:00Z', headRefName: 'r-issue-7', url: 'https://github.com/o/r/pull/19', reviewDecision: 'APPROVED' },
+    { number: 19, state: 'closed', merged_at: '2026-08-22T00:00:00Z', head: { ref: 'r-issue-7' }, html_url: 'https://github.com/o/r/pull/19' },
   ]
   const ctx = {
     shell: {
       resolve(spec: unknown) { return spec },
       async run(spec: { command: string }) {
-        if (spec.command.startsWith('gh issue list')) return { exitCode: 0, stdout: { text: JSON.stringify(allIssues) }, stderr: { text: '' } }
-        if (spec.command.startsWith('gh pr list')) return { exitCode: 0, stdout: { text: JSON.stringify(prs) }, stderr: { text: '' } }
+        if (spec.command.includes('/issues?')) return { exitCode: 0, stdout: { text: JSON.stringify([allIssues]) }, stderr: { text: '' } }
+        if (spec.command.includes('/pulls?')) return { exitCode: 0, stdout: { text: JSON.stringify([prs]) }, stderr: { text: '' } }
         throw new Error(`unexpected command: ${spec.command}`)
       },
     },
@@ -221,4 +227,99 @@ test('repo issue aggregation includes open issues without workflows and honors l
   assert.equal(issues[0].workflow.derived.nextAction.kind, 'none')
   assert.equal(issues[1].workflow.derived.status, 'idle')
   assert.equal(issues[1].workflow.derived.nextAction.label, '开始开发')
+})
+
+test('repo issue aggregation fails closed when a stored PR cannot be refreshed by number', async () => {
+  const issue = { number: 7, title: 'issue 7', state: 'open', body: '', html_url: 'https://github.com/o/r/issues/7', milestone: null }
+  const workflow = {
+    key: 'o-r-7', url: issue.html_url, repoKey: 'o/r', worktree: '/remote/worktrees/r/r-issue-7', branch: 'renamed-branch',
+    stage: 'passed', devAgent: 'codex', devTaskId: null, devSessionId: null, devInterrupted: false,
+    reviewAgent: 'codex', reviewTaskId: null, reviewSessionId: null,
+    reviewResult: { passed: true, issues: [] }, prNumber: 99, issueState: 'OPEN',
+    baseRef: 'origin/main @ abc', updatedAt: 1, events: [],
+  }
+  const ctx = {
+    shell: {
+      resolve(spec: unknown) { return spec },
+      async run(spec: { command: string }) {
+        if (spec.command.includes('/issues?')) return { exitCode: 0, stdout: { text: JSON.stringify([[issue]]) }, stderr: { text: '' } }
+        if (spec.command.includes('/pulls?')) return { exitCode: 0, stdout: { text: '[[]]' }, stderr: { text: '' } }
+        if (spec.command.startsWith('gh pr view')) return { exitCode: 1, stdout: { text: '' }, stderr: { text: 'offline' } }
+        throw new Error(`unexpected command: ${spec.command}`)
+      },
+    },
+  }
+  const result = await fetchRepositoryIssues(ctx as never, { repoKey: 'o/r' }, {
+    config: { repos: { 'o/r': '/remote/r' }, worktreeRoot: '/remote/worktrees' },
+    workflows: [workflow as never],
+  })
+  assert.equal(result.ok, true)
+  if (!result.ok) return
+  const item = result.issues[0] as { workflow: { prNumber: string; derived: { nextAction: { kind: string; label: string } } } }
+  assert.equal(item.workflow.prNumber, '99')
+  assert.deepEqual(item.workflow.derived.nextAction, {
+    kind: 'none', label: '刷新 PR 状态', hint: 'GitHub PR 实时状态查询失败,为避免误合并已暂停动作',
+  })
+})
+
+test('repo issue aggregation refreshes stored PR by number when its head no longer matches', async () => {
+  const issue = { number: 7, title: 'issue 7', state: 'open', body: '', html_url: 'https://github.com/o/r/issues/7', milestone: null }
+  const workflow = {
+    key: 'o-r-7', url: issue.html_url, repoKey: 'o/r', worktree: '/remote/worktrees/r/r-issue-7', branch: 'old-branch-name',
+    stage: 'passed', devAgent: 'codex', devTaskId: null, devSessionId: null, devInterrupted: false,
+    reviewAgent: 'codex', reviewTaskId: null, reviewSessionId: null,
+    reviewResult: { passed: true, issues: [] }, prNumber: 99, issueState: 'OPEN',
+    baseRef: 'origin/main @ abc', updatedAt: 1, events: [],
+  }
+  const ctx = {
+    shell: {
+      resolve(spec: unknown) { return spec },
+      async run(spec: { command: string }) {
+        if (spec.command.includes('/issues?')) return { exitCode: 0, stdout: { text: JSON.stringify([[issue]]) }, stderr: { text: '' } }
+        if (spec.command.includes('/pulls?')) return { exitCode: 0, stdout: { text: '[[]]' }, stderr: { text: '' } }
+        if (spec.command.startsWith("gh pr view '99'")) return {
+          exitCode: 0,
+          stdout: { text: JSON.stringify({ number: 99, state: 'MERGED', mergedAt: '2026-08-22T00:00:00Z', headRefName: 'new-branch-name', url: 'https://github.com/o/r/pull/99', reviewDecision: 'APPROVED' }) },
+          stderr: { text: '' },
+        }
+        throw new Error(`unexpected command: ${spec.command}`)
+      },
+    },
+  }
+  const result = await fetchRepositoryIssues(ctx as never, { repoKey: 'o/r' }, {
+    config: { repos: { 'o/r': '/remote/r' }, worktreeRoot: '/remote/worktrees' },
+    workflows: [workflow as never],
+  })
+  assert.equal(result.ok, true)
+  if (!result.ok) return
+  const item = result.issues[0] as { workflow: { prNumber: string; derived: { status: string; nextAction: { kind: string } } } }
+  assert.equal(item.workflow.prNumber, '99')
+  assert.equal(item.workflow.derived.status, 'passed')
+  assert.equal(item.workflow.derived.nextAction.kind, 'none')
+})
+
+test('repo issue aggregation uses unbounded pagination and keeps issues beyond 1000', async () => {
+  const allIssues = Array.from({ length: 1001 }, (_, index) => ({
+    number: index + 1, title: `issue ${index + 1}`, state: 'open', body: '',
+    html_url: `https://github.com/o/r/issues/${index + 1}`, milestone: null,
+  }))
+  const commands: string[] = []
+  const ctx = {
+    shell: {
+      resolve(spec: unknown) { return spec },
+      async run(spec: { command: string }) {
+        commands.push(spec.command)
+        if (spec.command.includes('/issues?')) return { exitCode: 0, stdout: { text: JSON.stringify([allIssues.slice(0, 1000), allIssues.slice(1000)]) }, stderr: { text: '' } }
+        if (spec.command.includes('/pulls?')) return { exitCode: 0, stdout: { text: '[[]]' }, stderr: { text: '' } }
+        throw new Error(`unexpected command: ${spec.command}`)
+      },
+    },
+  }
+  const result = await fetchRepositoryIssues(ctx as never, { repoKey: 'o/r' }, {
+    config: { repos: { 'o/r': '/remote/r' }, worktreeRoot: '/remote/worktrees' }, workflows: [],
+  })
+  assert.equal(result.ok, true)
+  if (!result.ok) return
+  assert.equal(result.issues.length, 1001)
+  assert.equal(commands.filter((command) => command.includes('--paginate --slurp')).length, 2)
 })

--- a/tests/state-view-integration.test.ts
+++ b/tests/state-view-integration.test.ts
@@ -82,7 +82,7 @@ test('state view derives worktree/main/remote hashes, ahead-behind and sync need
     assert.equal(derived.behindBase, 0)
     assert.equal(derived.aheadOfBase, 1)
     assert.equal(derived.needsSync, false)
-    assert.equal(derived.nextAction.kind, 'review') // review-ready 无结论 → review
+    assert.equal(derived.nextAction.kind, 'create-pr') // 有提交但无 PR → 先创建 PR
 
     // 并行开发:main 前进到 B,worktree 落后 → 需要同步
     await git('switch', 'main')
@@ -103,7 +103,7 @@ test('state view derives worktree/main/remote hashes, ahead-behind and sync need
     const synced = (await deriveWorkflowState(ctx, workflow({ worktree }))).derived
     assert.equal(synced.behindBase, 0)
     assert.equal(synced.needsSync, false)
-    assert.equal(synced.nextAction.kind, 'review')
+    assert.equal(synced.nextAction.kind, 'create-pr')
   } finally {
     await rm(root, { recursive: true, force: true })
   }

--- a/tests/state-view-integration.test.ts
+++ b/tests/state-view-integration.test.ts
@@ -1,11 +1,11 @@
 import assert from 'node:assert/strict'
 import { execFile } from 'node:child_process'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
 import test from 'node:test'
-import { deriveWorkflowState, type IssueWorkflow } from '../src/index.ts'
+import { deriveWorkflowState, enrichWorkflowStates, type IssueWorkflow } from '../src/index.ts'
 
 const execFileAsync = promisify(execFile)
 
@@ -134,6 +134,53 @@ test('review verdict binds to the reviewed HEAD and goes stale when the head mov
     assert.equal(stale.head === headC, false)
     assert.equal(stale.verdictCurrent, false)
     assert.equal(stale.nextAction.kind, 'review')
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('/state enrichment checks configured branches and runs GitHub lookups concurrently', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'clickvibe-state-enrich-'))
+  const repo = join(root, 'repo')
+  await mkdir(repo)
+  let activeGithub = 0
+  let maxGithub = 0
+  const githubTimeouts: number[] = []
+  const fakeCtx = {
+    shell: {
+      resolve(spec: unknown) { return spec },
+      async run(spec: { command: string; timeoutMs?: number }) {
+        if (spec.command.startsWith('gh pr list')) {
+          githubTimeouts.push(spec.timeoutMs ?? 0)
+          activeGithub += 1
+          maxGithub = Math.max(maxGithub, activeGithub)
+          await new Promise((resolve) => setTimeout(resolve, 40))
+          activeGithub -= 1
+          return { exitCode: 0, stdout: { text: '{}' }, stderr: { text: '' } }
+        }
+        if (spec.command.startsWith('if git show-ref')) {
+          const branch = spec.command.includes('issue-6') ? 'clickvibe-issue-6' : 'clickvibe-issue-5'
+          return { exitCode: 0, stdout: { text: branch }, stderr: { text: '' } }
+        }
+        if (spec.command.startsWith('git symbolic-ref')) return { exitCode: 0, stdout: { text: 'origin/main' }, stderr: { text: '' } }
+        if (spec.command.startsWith('git rev-list')) return { exitCode: 0, stdout: { text: '1' }, stderr: { text: '' } }
+        throw new Error(`unexpected command: ${spec.command}`)
+      },
+    },
+  }
+  try {
+    const workflows = [
+      workflow({ worktree: join(root, 'missing-5'), branch: 'clickvibe-issue-5' }),
+      workflow({ key: 'repo-6', url: 'https://github.com/o/r/issues/6', worktree: join(root, 'missing-6'), branch: 'clickvibe-issue-6' }),
+    ]
+    const enriched = await enrichWorkflowStates(fakeCtx as never, workflows, {
+      repos: { 'o/r': repo }, worktreeRoot: root,
+    })
+    assert.equal(maxGithub, 2)
+    assert.deepEqual(githubTimeouts, [5000, 5000])
+    assert.deepEqual(enriched.map((item) => item.derived.nextAction.label), [
+      '恢复 worktree 继续开发', '恢复 worktree 继续开发',
+    ])
   } finally {
     await rm(root, { recursive: true, force: true })
   }

--- a/tests/state-view.test.ts
+++ b/tests/state-view.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { deriveNextAction, type WorkflowFacts } from '../src/state-view.ts'
+import { deriveNextAction, githubCompareUrl, workflowBaseBranch, type WorkflowFacts } from '../src/state-view.ts'
 
 function facts(overrides: Partial<WorkflowFacts> = {}): WorkflowFacts {
   return {
@@ -27,6 +27,20 @@ test('closed issue has no next action', () => {
 test('merged PR is terminal', () => {
   const next = deriveNextAction(facts({ prMerged: true, stage: 'passed', prNumber: '9' }))
   assert.equal(next.kind, 'none')
+})
+
+test('closed unmerged PR offers the explicit recovery action', () => {
+  const next = deriveNextAction(facts({ prNumber: '9', prState: 'CLOSED', prStatusKnown: true }))
+  assert.equal(next.kind, 'develop')
+  assert.equal(next.label, '查看原因 / 重新开发')
+})
+
+test('compare URL uses the frozen non-main workflow base', () => {
+  assert.equal(workflowBaseBranch('origin/trunk @ abc123', 'main'), 'trunk')
+  assert.equal(
+    githubCompareUrl('o/r', 'feature/7', 'origin/trunk @ abc123', 'main'),
+    'https://github.com/o/r/compare/trunk...feature%2F7?expand=1',
+  )
 })
 
 test('a linked PR with an unavailable live state fails closed', () => {

--- a/tests/state-view.test.ts
+++ b/tests/state-view.test.ts
@@ -29,6 +29,14 @@ test('merged PR is terminal', () => {
   assert.equal(next.kind, 'none')
 })
 
+test('a linked PR with an unavailable live state fails closed', () => {
+  const next = deriveNextAction(facts({
+    prNumber: '9', prStatusKnown: false, stage: 'passed', reviewPassed: true, reviewedHash: 'a1b2c3d',
+  }))
+  assert.equal(next.kind, 'none')
+  assert.equal(next.label, '刷新 PR 状态')
+})
+
 test('a running task has no next action until it settles', () => {
   const next = deriveNextAction(facts({ stage: 'developing', taskRunning: true }))
   assert.equal(next.kind, 'none')
@@ -56,6 +64,34 @@ test('aborted review re-reviews instead of blocking', () => {
 test('idle issue starts development', () => {
   const next = deriveNextAction(facts({ stage: 'idle' }))
   assert.equal(next.kind, 'develop')
+})
+
+test('a branch with content but without its worktree is recoverable without workflow cache', () => {
+  const next = deriveNextAction(facts({ branchExists: true, worktreeExists: false, hasCommits: true, head: null }))
+  assert.equal(next.kind, 'develop')
+  assert.equal(next.label, '恢复 worktree 继续开发')
+})
+
+test('an empty branch without a worktree still starts development', () => {
+  const next = deriveNextAction(facts({ branchExists: true, worktreeExists: false, hasCommits: false, head: null }))
+  assert.equal(next.kind, 'develop')
+  assert.equal(next.label, '开始开发')
+})
+
+test('uncommitted work without a resumable session starts a fresh development session', () => {
+  const next = deriveNextAction(facts({
+    stage: 'idle', branchExists: true, worktreeExists: true,
+    hasUncommittedChanges: true, hasResumeSession: false,
+  }))
+  assert.equal(next.kind, 'develop')
+  assert.equal(next.label, '重新开发')
+})
+
+test('commits without a PR offer PR creation', () => {
+  const next = deriveNextAction(facts({
+    stage: 'idle', branchExists: true, worktreeExists: true, hasCommits: true,
+  }))
+  assert.equal(next.kind, 'create-pr')
 })
 
 test('review-ready without a verdict reviews', () => {


### PR DESCRIPTION
## 变更

- 面板入口改为配置 repo 选择器，展示全部 open issue
- 支持按依赖状态过滤、按依赖或里程碑分组
- 每行展示状态、约定分支、落后提示、blockedBy、milestone 与唯一动作
- 无 workflow 时从 git/GitHub 硬事实重建状态；实时查询 PR merged/review 状态
- PR 状态查询失败时 fail-closed，不显示旧的合并动作

## 验证

- `pnpm typecheck`
- `pnpm test`（43 tests）
- `pnpm build`
- 真实 `ai-daming/clickvibe` 只读烟测：枚举 13 个 open issue，#7 依赖/分支/落后/动作推导正确

Closes #7