### PR TITLE
fix: review 结论改为文件物化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ pnpm-debug.log*
 .DS_Store
 .idea/
 .vscode/
+
+# ClickVibe agent artifacts (not source changes)
+.clickvibe/review-result.json

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ ClickVibe 启动 agent 的命令行**按次显式传参**,不读取也不假设�
 - [#17](https://github.com/ai-daming/clickvibe/issues/17) 超时/中断后会话恢复(会话 id 捕获 + resume 命令形式)
 - [#18](https://github.com/ai-daming/clickvibe/issues/18) 任务超时上限可配置,支持小时级长任务
 - [#20](https://github.com/ai-daming/clickvibe/issues/20) 提示词统一:各阶段自带需求快照
-- [#22](https://github.com/ai-daming/clickvibe/issues/22) review 结论解析器支持 JSON 格式
+- [#22](https://github.com/ai-daming/clickvibe/issues/22) review 结论物化为 worktree 内 JSON 文件
 - [#23](https://github.com/ai-daming/clickvibe/issues/23) 合并后清理(worktree/分支/issue/workflow)
 
 ## 开发
@@ -139,5 +139,11 @@ curl -X POST http://127.0.0.1:3080/clickvibe/api/develop/poll \
 ```
 
 任务状态只保存在当前 Host 进程内,重启后旧 `taskId` 失效。真实 Agent 必须从面板发起:面板先把当前显示的完整 Issue 快照交给服务端比对,再展示 Agent、更新时间、评论数和快照摘要供确认；确认后的授权只能使用一次且会过期。`dryrun` 不需要高权限授权、不启动 Agent,适合用 curl 验证配置、worktree 恢复和增量轮询。
+
+### Review 结论与历史恢复
+
+Review agent 会把结构化结论写到 worktree 的 `.clickvibe/review-result.json`。完成回调优先读取并严格校验这个文件；文件缺失、过大、不是普通文件、JSON 损坏或 schema 不符时，会在 `~/.clickvibe/state/<issue-key>/review.log` 记录原因，再依次回退 stdout JSON 和表情结论。该文件已被 git 忽略，且每次 review 启动前都会删除，避免上一次结论污染新一轮 review；因此不要手工预置它。
+
+对 #19/#12 这类旧版本已截断的结论，先从 `~/.clickvibe/state/<issue-key>.json` 读取 `reviewAgent` 与 `reviewSessionId`，必要时用该 id 在 Claude 的 `~/.claude/projects/**/*.jsonl` 或 Codex 的 `~/.codex/sessions/**/*.jsonl` 中定位原会话。不要直接篡改 workflow JSON：旧结论必须绑定它实际审查的 commit。将 worktree 恢复到需要审查的 HEAD 后，在面板使用同一 reviewer 执行「重新 Review」；ClickVibe 会续接精确 session、要求 agent 从原会话上下文复核问题并物化新结论，新的 review 事件会记录本次实际 HEAD。若原 session 已不存在，只能发起一次全新 review，不能把无法验证 commit 的旧文本冒充当前结论。
 
 不要把 ClickVibe 暴露到局域网或公网。服务端会拒绝非回环来源的 Agent 操作,但同一操作系统账号下的恶意进程本来就可能读取代码、配置和开发凭据,本工具不把同账号进程隔离当作安全边界。

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -133,7 +133,7 @@ export function parseClaudeEvent(line: string): StatusLine[] {
     case 'assistant': {
       for (const block of event.message?.content ?? []) {
         if (block.type === 'text' && block.text) {
-          out.push({ kind: 'message', text: `💬 ${oneLine(block.text)}` })
+          out.push({ kind: 'message', text: `💬 ${oneLine(block.text, 4000)}` })
         } else if (block.type === 'tool_use' && block.name) {
           const args = block.input ? oneLine(JSON.stringify(block.input), 80) : ''
           out.push({ kind: 'tool', text: toolLabel(block.name, args) })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1920,6 +1920,11 @@ async function startReview(
   if (!existsSync(workflow.worktree)) {
     return { ok: false, error: `worktree 不存在: ${workflow.worktree}` }
   }
+  // 已有 review 在跑:复用同一任务,而不是再开一个并发 review——
+  // 并发任务共用同一个 .clickvibe/review-result.json,会互删/互读结论导致 verdict 错绑。
+  if (workflow.reviewTaskId && liveTasks.has(workflow.reviewTaskId) && !liveTasks.get(workflow.reviewTaskId)!.closed) {
+    return { ok: true, taskId: workflow.reviewTaskId }
+  }
   // 记录关联 PR(若 review 的是 PR 且未记录)
   if (parsed.kind === 'pr' && !workflow.prNumber) {
     workflow.prNumber = parsed.number

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ import {
   loadReviewResult,
   REVIEW_RESULT_RELATIVE_PATH,
 } from './review-result.ts'
+import { ExclusiveTaskGate } from './task-gate.ts'
 
 declare module '@deepseek-ai/cordis' {
   interface Context {
@@ -136,6 +137,7 @@ interface LiveTask {
 }
 
 const liveTasks = new Map<string, LiveTask>()
+const reviewTaskGate = new ExclusiveTaskGate<LiveTask>()
 const liveWaiters = new Map<string, Set<() => void>>()
 const authorizations = new AuthorizationStore()
 const TASK_LOG_LINES = 2000
@@ -1493,6 +1495,7 @@ function finishTask(
   task.closed = true
   task.status = status
   task.exitCode = exitCode
+  if (task.kind === 'review') reviewTaskGate.release(task.workflowKey, task)
   if (task.timeout) clearTimeout(task.timeout)
   notifyTask(task.taskId)
   scheduleTaskCleanup(task)
@@ -1920,11 +1923,20 @@ async function startReview(
   if (!existsSync(workflow.worktree)) {
     return { ok: false, error: `worktree 不存在: ${workflow.worktree}` }
   }
-  // 已有 review 在跑:复用同一任务,而不是再开一个并发 review——
-  // 并发任务共用同一个 .clickvibe/review-result.json,会互删/互读结论导致 verdict 错绑。
-  if (workflow.reviewTaskId && liveTasks.has(workflow.reviewTaskId) && !liveTasks.get(workflow.reviewTaskId)!.closed) {
-    return { ok: true, taskId: workflow.reviewTaskId }
+  // 必须在第一个 await 之前同步占位。只检查持久化 reviewTaskId 会有 TOCTOU:
+  // 两个请求可同时读到旧 workflow,再在清理结果文件时交错并双开 review。
+  let reservation: { task: LiveTask; created: boolean }
+  try {
+    reservation = reviewTaskGate.reserve(workflow.key, () => {
+      const id = taskId('review')
+      return createLiveTask(id, workflow.key, 'review', agent, workflow.reviewSessionId)
+    })
+  } catch (error) {
+    return { ok: false, error: String(error instanceof Error ? error.message : error) }
   }
+  if (!reservation.created) return { ok: true, taskId: reservation.task.taskId }
+  const live = reservation.task
+
   // 记录关联 PR(若 review 的是 PR 且未记录)
   if (parsed.kind === 'pr' && !workflow.prNumber) {
     workflow.prNumber = parsed.number
@@ -1937,18 +1949,12 @@ async function startReview(
   } catch (error) {
     const message = String(error instanceof Error ? error.message : error)
     await appendLog(workflow.key, 'review', `[clickvibe] 无法清除旧 review 结论文件: ${message}`)
+    finishTask(live, 'failed', 1)
     return { ok: false, error: `无法清除旧 review 结论文件: ${message}` }
   }
 
-  const taskIdValue = taskId('review')
-  let live: LiveTask
-  try {
-    live = createLiveTask(taskIdValue, workflow.key, 'review', agent, workflow.reviewSessionId)
-  } catch (error) {
-    return { ok: false, error: String(error instanceof Error ? error.message : error) }
-  }
   workflow.reviewAgent = agent
-  workflow.reviewTaskId = taskIdValue
+  workflow.reviewTaskId = live.taskId
   workflow.stage = 'reviewing'
   await saveWorkflow(workflow)
 
@@ -2017,7 +2023,7 @@ async function startReview(
     }
   })
 
-  return { ok: true, taskId: taskIdValue }
+  return { ok: true, taskId: live.taskId }
 }
 
 /** Post the review result to the issue's GitHub comments. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,11 @@ import {
   type IssueWorkflow,
 } from './state.ts'
 import { parseAgentChunk, type AgentKind } from './agent-stream.ts'
+import {
+  clearReviewResultFile,
+  loadReviewResult,
+  REVIEW_RESULT_RELATIVE_PATH,
+} from './review-result.ts'
 
 declare module '@deepseek-ai/cordis' {
   interface Context {
@@ -1207,10 +1212,11 @@ async function buildReviewPrompt(ctx: Context, workflow: IssueWorkflow): Promise
     `0. 先执行 git fetch origin 同步远端最新状态(并行开发时 base 可能已变化)`,
     `1. 再执行 git diff ${base}...HEAD 查看完整改动(在 worktree 内)`,
     '2. 检查:需求是否完整实现、是否有 bug/安全隐患、测试是否覆盖',
-    '3. 不要修改任何文件,只做只读 review',
-    '4. 最后一行必须输出一个 JSON 对象(单独一行,不要包裹在代码块里),格式:',
+    `3. 除 ${REVIEW_RESULT_RELATIVE_PATH} 外不要修改任何文件,只做只读 review`,
+    `4. 必须使用写文件工具把最终结论写入 worktree 内 ${REVIEW_RESULT_RELATIVE_PATH},格式:`,
     '{"passed": true|false, "issues": ["问题1(含文件/位置/原因)", "问题2", ...]}',
     '   passed=true 表示无问题;有任意问题则 passed=false 并列出全部。',
+    '5. 同时在最后一行输出同一个 JSON 对象(单独一行,不要包裹在代码块里),仅作为兼容兜底。',
   ].join('\n')
 }
 
@@ -1244,26 +1250,6 @@ async function fetchPrHeadBranch(ctx: Context, owner: string, repo: string, prNu
   } catch {
     return null
   }
-}
-
-/** Extract the final JSON verdict object from review log lines. */
-function extractReviewJson(lines: string[]): { passed: boolean; issues: string[] } | null {
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const line = lines[i]
-    const match = line.match(/\{.*"passed".*\}/)
-    if (!match) continue
-    try {
-      const obj = JSON.parse(match[0]) as { passed?: unknown; issues?: unknown }
-      if (typeof obj.passed !== 'boolean') continue
-      const issues = Array.isArray(obj.issues)
-        ? obj.issues.filter((x): x is string => typeof x === 'string')
-        : []
-      return { passed: obj.passed, issues }
-    } catch {
-      // 不是合法 JSON,继续找前一行
-    }
-  }
-  return null
 }
 
 /** Create (or reuse) the workflow record and the worktree+branch. */
@@ -1940,6 +1926,15 @@ async function startReview(
     await saveWorkflow(workflow)
   }
 
+  // A prior run's file must never become the next run's verdict.
+  try {
+    await clearReviewResultFile(workflow.worktree)
+  } catch (error) {
+    const message = String(error instanceof Error ? error.message : error)
+    await appendLog(workflow.key, 'review', `[clickvibe] 无法清除旧 review 结论文件: ${message}`)
+    return { ok: false, error: `无法清除旧 review 结论文件: ${message}` }
+  }
+
   const taskIdValue = taskId('review')
   let live: LiveTask
   try {
@@ -1966,7 +1961,7 @@ async function startReview(
       : 'codex exec -c approval_policy=never -s danger-full-access --json -'
   }
   const prompt = sessionId
-    ? '请继续 review。代码已更新,请先确认之前发现的问题是否已解决,再审查新改动,最后输出同样的 JSON 结论。'
+    ? `请继续 review。代码已更新,请先确认之前发现的问题是否已解决,再审查新改动。除 ${REVIEW_RESULT_RELATIVE_PATH} 外不要修改任何文件;必须使用写文件工具把最终结论写入该路径,格式为 {"passed":true|false,"issues":[...]};最后一行再输出同一个 JSON 作为兼容兜底。`
     : await buildReviewPrompt(ctx, workflow)
 
   await appendLog(workflow.key, 'review', `[clickvibe] 启动 ${agent} review${sessionId ? `(续会话 ${sessionId})` : ''}…`)
@@ -1980,12 +1975,18 @@ async function startReview(
       }
       return
     }
-    // 优先用 agent 输出的 JSON 结论(完整、不受截断/分块影响);
-    // JSON 缺失时回退到 ❌/✅ 文本判定。
     const lines = await readLogTail(workflow.key, 'review', 200)
-    const json = extractReviewJson(lines)
-    const passed = json ? json.passed : reviewVerdict(lines).passed
-    const issues = passed ? [] : (json?.issues ?? extractIssues(lines))
+    const resolved = await loadReviewResult(workflow.worktree, lines)
+    if (resolved.source === 'file') {
+      await appendLog(workflow.key, 'review', `[clickvibe] review 结论来源: ${REVIEW_RESULT_RELATIVE_PATH}`)
+    } else {
+      await appendLog(
+        workflow.key,
+        'review',
+        `[clickvibe] review 结论文件不可用(${resolved.fileError ?? '原因未知'}),回退 ${resolved.source === 'stdout-json' ? 'stdout JSON' : 'stdout 表情行'}判定`,
+      )
+    }
+    const { passed, issues } = resolved.result
     const reloaded = await loadWorkflow(workflow.key)
     if (reloaded) {
       reloaded.reviewResult = { passed, issues }
@@ -2012,50 +2013,6 @@ async function startReview(
   })
 
   return { ok: true, taskId: taskIdValue }
-}
-
-/** Decide the review verdict from the log: ❌ wins over ✅; neither → fail closed. */
-function reviewVerdict(lines: string[]): { passed: boolean } {
-  let sawFail = false
-  let sawPass = false
-  for (const line of lines) {
-    const t = line.trim()
-    // 结论可能带 emoji/状态前缀(💬/🔧/⚠️…),用 includes 判断更稳
-    if (t.includes('❌') && /发现|存在|问题|Review/.test(t)) sawFail = true
-    if (t.includes('✅') && !/本轮完成|会话结束/.test(t)) sawPass = true
-    if (/Review\s*通过|未发现问题|无问题/.test(t)) sawPass = true
-  }
-  return { passed: !sawFail && sawPass }
-}
-
-/** Extract issue lines from a review result (lines after a ❌ header). */
-/** Extract issue lines from review log lines (lines after a ❌ verdict). */
-function extractIssues(lines: string[]): string[] {
-  const out: string[] = []
-  // 只取最后一个包含 ❌ 的行(agent 的最终结论;前面可能有中间自查的 ❌)
-  let verdictIndex = -1
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].includes('❌')) verdictIndex = i
-  }
-  if (verdictIndex === -1) return []
-  const verdict = lines[verdictIndex]
-  const rest = verdict.slice(verdict.indexOf('❌') + 1)
-  // 按 "N. " 编号切分条目;若无编号条目则走下面的行收集
-  const parts = rest.split(/(?=\d+\.\s)/).filter((s) => /^\d+\./.test(s.trim()))
-  if (parts.length > 0) {
-    for (const p of parts) {
-      const item = p.replace(/^\d+\.\s*/, '').trim()
-      if (item !== '') out.push(item)
-    }
-  } else {
-    // 无编号条目:收集结论行之后非状态、非 clickvibe 的行
-    for (let i = verdictIndex + 1; i < lines.length; i++) {
-      const t = lines[i].trim()
-      if (t === '' || /^✅|^⚠️|^🚀|^💭|^🔧|^\[clickvibe\]|本轮完成|会话结束/.test(t)) break
-      out.push(t)
-    }
-  }
-  return out.slice(0, 20)
 }
 
 /** Post the review result to the issue's GitHub comments. */

--- a/src/review-result.ts
+++ b/src/review-result.ts
@@ -1,0 +1,132 @@
+import { lstat, readFile, unlink } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export const REVIEW_RESULT_RELATIVE_PATH = '.clickvibe/review-result.json'
+const MAX_REVIEW_RESULT_BYTES = 2 * 1024 * 1024
+
+export interface ReviewResult {
+  passed: boolean
+  issues: string[]
+}
+
+export interface ResolvedReviewResult {
+  result: ReviewResult
+  source: 'file' | 'stdout-json' | 'stdout-verdict'
+  fileError?: string
+}
+
+function parseMaterializedResult(raw: string): ReviewResult | null {
+  let value: unknown
+  try {
+    value = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  if (typeof record.passed !== 'boolean') return null
+  if (!Array.isArray(record.issues) || !record.issues.every((issue) => typeof issue === 'string')) return null
+  if (record.passed && record.issues.length > 0) return null
+  return { passed: record.passed, issues: record.issues }
+}
+
+/** Remove the prior run's verdict before starting another review. */
+export async function clearReviewResultFile(worktree: string): Promise<void> {
+  try {
+    await unlink(join(worktree, REVIEW_RESULT_RELATIVE_PATH))
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+}
+
+async function readMaterializedResult(worktree: string): Promise<
+  | { result: ReviewResult; error?: never }
+  | { result: null; error: string }
+> {
+  const path = join(worktree, REVIEW_RESULT_RELATIVE_PATH)
+  try {
+    const info = await lstat(path)
+    if (!info.isFile()) return { result: null, error: '不是普通文件' }
+    if (info.size > MAX_REVIEW_RESULT_BYTES) {
+      return { result: null, error: `文件超过 ${MAX_REVIEW_RESULT_BYTES} 字节上限` }
+    }
+    const result = parseMaterializedResult(await readFile(path, 'utf8'))
+    if (!result) return { result: null, error: 'JSON 损坏或 schema 非 {passed:boolean,issues:string[]}' }
+    return { result }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { result: null, error: '文件不存在' }
+    return { result: null, error: `读取失败: ${String(error instanceof Error ? error.message : error)}` }
+  }
+}
+
+/** Extract the final JSON verdict object from review display lines. */
+export function extractReviewJson(lines: string[]): ReviewResult | null {
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const match = lines[i].match(/\{.*"passed".*\}/)
+    if (!match) continue
+    try {
+      const obj = JSON.parse(match[0]) as { passed?: unknown; issues?: unknown }
+      if (typeof obj.passed !== 'boolean') continue
+      const issues = Array.isArray(obj.issues)
+        ? obj.issues.filter((issue): issue is string => typeof issue === 'string')
+        : []
+      return { passed: obj.passed, issues }
+    } catch {
+      // Keep searching older lines to preserve the existing stdout fallback.
+    }
+  }
+  return null
+}
+
+function reviewVerdict(lines: string[]): { passed: boolean } {
+  let sawFail = false
+  let sawPass = false
+  for (const line of lines) {
+    const text = line.trim()
+    if (text.includes('❌') && /发现|存在|问题|Review/.test(text)) sawFail = true
+    if (text.includes('✅') && !/本轮完成|会话结束/.test(text)) sawPass = true
+    if (/Review\s*通过|未发现问题|无问题/.test(text)) sawPass = true
+  }
+  return { passed: !sawFail && sawPass }
+}
+
+function extractIssues(lines: string[]): string[] {
+  const issues: string[] = []
+  let verdictIndex = -1
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes('❌')) verdictIndex = i
+  }
+  if (verdictIndex === -1) return []
+  const verdict = lines[verdictIndex]
+  const rest = verdict.slice(verdict.indexOf('❌') + 1)
+  const parts = rest.split(/(?=\d+\.\s)/).filter((part) => /^\d+\./.test(part.trim()))
+  if (parts.length > 0) {
+    for (const part of parts) {
+      const issue = part.replace(/^\d+\.\s*/, '').trim()
+      if (issue !== '') issues.push(issue)
+    }
+  } else {
+    for (let i = verdictIndex + 1; i < lines.length; i++) {
+      const text = lines[i].trim()
+      if (text === '' || /^✅|^⚠️|^🚀|^💭|^🔧|^\[clickvibe\]|本轮完成|会话结束/.test(text)) break
+      issues.push(text)
+    }
+  }
+  return issues.slice(0, 20)
+}
+
+/** Resolve a verdict from the durable file first, then preserve both stdout fallbacks. */
+export async function loadReviewResult(worktree: string, lines: string[]): Promise<ResolvedReviewResult> {
+  const materialized = await readMaterializedResult(worktree)
+  if (materialized.result) return { result: materialized.result, source: 'file' }
+
+  const json = extractReviewJson(lines)
+  if (json) return { result: json, source: 'stdout-json', fileError: materialized.error }
+
+  const passed = reviewVerdict(lines).passed
+  return {
+    result: { passed, issues: passed ? [] : extractIssues(lines) },
+    source: 'stdout-verdict',
+    fileError: materialized.error,
+  }
+}

--- a/src/review-result.ts
+++ b/src/review-result.ts
@@ -1,5 +1,5 @@
-import { lstat, readFile, unlink } from 'node:fs/promises'
-import { join } from 'node:path'
+import { lstat, mkdir, readFile, unlink } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
 
 export const REVIEW_RESULT_RELATIVE_PATH = '.clickvibe/review-result.json'
 const MAX_REVIEW_RESULT_BYTES = 2 * 1024 * 1024
@@ -30,10 +30,16 @@ function parseMaterializedResult(raw: string): ReviewResult | null {
   return { passed: record.passed, issues: record.issues }
 }
 
-/** Remove the prior run's verdict before starting another review. */
+/** Remove the prior run's verdict before starting another review.
+ *  Also creates the `.clickvibe` parent directory: brand-new worktrees have no
+ *  such dir, and the review agent's write-tool often refuses to create parent
+ *  directories itself — without this, materialization silently falls back to
+ *  stdout parsing. The dir must exist before the agent starts. */
 export async function clearReviewResultFile(worktree: string): Promise<void> {
+  const dir = join(worktree, dirname(REVIEW_RESULT_RELATIVE_PATH))
+  await mkdir(dir, { recursive: true })
   try {
-    await unlink(join(worktree, REVIEW_RESULT_RELATIVE_PATH))
+    await unlink(join(dir, 'review-result.json'))
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
   }

--- a/src/task-gate.ts
+++ b/src/task-gate.ts
@@ -1,0 +1,21 @@
+/**
+ * Synchronous per-key reservation for tasks that must not overlap.
+ * JavaScript runs reserve() without an await boundary, so a second request
+ * either observes the first reservation or replaces an already-closed task.
+ */
+export class ExclusiveTaskGate<T extends { closed: boolean }> {
+  private readonly active = new Map<string, T>()
+
+  reserve(key: string, create: () => T): { task: T; created: boolean } {
+    const existing = this.active.get(key)
+    if (existing && !existing.closed) return { task: existing, created: false }
+
+    const task = create()
+    this.active.set(key, task)
+    return { task, created: true }
+  }
+
+  release(key: string, task: T): void {
+    if (this.active.get(key) === task) this.active.delete(key)
+  }
+}

--- a/tests/agent-stream.test.ts
+++ b/tests/agent-stream.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { parseClaudeEvent, parseCodexEvent } from '../src/agent-stream.ts'
+
+const longMessage = 'x'.repeat(5000)
+
+test('codex and claude use the same 4000-character display limit for messages', () => {
+  const codex = parseCodexEvent(JSON.stringify({
+    type: 'item.completed', item: { type: 'agent_message', text: longMessage },
+  }))
+  const claude = parseClaudeEvent(JSON.stringify({
+    type: 'assistant', message: { content: [{ type: 'text', text: longMessage }] },
+  }))
+  assert.equal(codex[0].text, claude[0].text)
+  assert.equal(codex[0].text, `💬 ${'x'.repeat(4000)}…`)
+})

--- a/tests/review-result.test.ts
+++ b/tests/review-result.test.ts
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { parseAgentChunk, type AgentKind } from '../src/agent-stream.ts'
+import {
+  clearReviewResultFile,
+  loadReviewResult,
+  REVIEW_RESULT_RELATIVE_PATH,
+} from '../src/review-result.ts'
+
+function agentOutput(agent: AgentKind, text: string): string {
+  return agent === 'codex'
+    ? JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text } })
+    : JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text }] } })
+}
+
+async function withWorktree(run: (worktree: string) => Promise<void>): Promise<void> {
+  const worktree = await mkdtemp(join(tmpdir(), 'clickvibe-review-result-'))
+  try {
+    await run(worktree)
+  } finally {
+    await rm(worktree, { recursive: true, force: true })
+  }
+}
+
+for (const agent of ['codex', 'claude'] as const) {
+  test(`${agent}: materialized JSON wins even when the displayed conclusion is truncated`, async () => {
+    await withWorktree(async (worktree) => {
+      const issues = Array.from({ length: 12 }, (_, index) => `问题 ${index + 1}: ${'长描述'.repeat(220)}`)
+      await mkdir(join(worktree, '.clickvibe'))
+      await writeFile(
+        join(worktree, REVIEW_RESULT_RELATIVE_PATH),
+        JSON.stringify({ passed: false, issues }),
+      )
+      const parsed = parseAgentChunk(agent, agentOutput(agent, `${'分析'.repeat(2500)}${JSON.stringify({ passed: true, issues: [] })}`))
+      assert.match(parsed.lines[0].text, /…$/)
+
+      const resolved = await loadReviewResult(worktree, parsed.lines.map((line) => line.text))
+      assert.equal(resolved.source, 'file')
+      assert.deepEqual(resolved.result, { passed: false, issues })
+    })
+  })
+
+  test(`${agent}: stdout JSON remains the first fallback`, async () => {
+    await withWorktree(async (worktree) => {
+      const expected = { passed: false, issues: ['src/a.ts:10 存在竞态'] }
+      const parsed = parseAgentChunk(agent, agentOutput(agent, JSON.stringify(expected)))
+      const resolved = await loadReviewResult(worktree, parsed.lines.map((line) => line.text))
+      assert.equal(resolved.source, 'stdout-json')
+      assert.match(resolved.fileError ?? '', /不存在/)
+      assert.deepEqual(resolved.result, expected)
+    })
+  })
+
+  test(`${agent}: emoji verdict remains the final fallback`, async () => {
+    await withWorktree(async (worktree) => {
+      const parsed = parseAgentChunk(agent, agentOutput(agent, '✅ Review 通过'))
+      const resolved = await loadReviewResult(worktree, parsed.lines.map((line) => line.text))
+      assert.equal(resolved.source, 'stdout-verdict')
+      assert.deepEqual(resolved.result, { passed: true, issues: [] })
+    })
+  })
+}
+
+test('invalid materialized JSON logs a reason and falls back without accepting a partial schema', async () => {
+  await withWorktree(async (worktree) => {
+    await mkdir(join(worktree, '.clickvibe'))
+    await writeFile(join(worktree, REVIEW_RESULT_RELATIVE_PATH), '{"passed":false,"issues":[1]}')
+    const resolved = await loadReviewResult(worktree, ['💬 {"passed":true,"issues":[]}'])
+    assert.equal(resolved.source, 'stdout-json')
+    assert.match(resolved.fileError ?? '', /issues/)
+    assert.deepEqual(resolved.result, { passed: true, issues: [] })
+  })
+})
+
+test('a passing materialized verdict cannot carry contradictory issues', async () => {
+  await withWorktree(async (worktree) => {
+    await mkdir(join(worktree, '.clickvibe'))
+    await writeFile(join(worktree, REVIEW_RESULT_RELATIVE_PATH), '{"passed":true,"issues":["still broken"]}')
+    const resolved = await loadReviewResult(worktree, ['💬 ❌ Review 发现问题'])
+    assert.equal(resolved.source, 'stdout-verdict')
+    assert.match(resolved.fileError ?? '', /schema/)
+    assert.deepEqual(resolved.result, { passed: false, issues: [] })
+  })
+})
+
+test('clearing the materialized result prevents a stale review from being reused', async () => {
+  await withWorktree(async (worktree) => {
+    await mkdir(join(worktree, '.clickvibe'))
+    const path = join(worktree, REVIEW_RESULT_RELATIVE_PATH)
+    await writeFile(path, '{"passed":true,"issues":[]}')
+    await clearReviewResultFile(worktree)
+    const resolved = await loadReviewResult(worktree, ['💬 ❌ Review 发现问题'])
+    assert.equal(resolved.source, 'stdout-verdict')
+    assert.deepEqual(resolved.result, { passed: false, issues: [] })
+  })
+})

--- a/tests/review-result.test.ts
+++ b/tests/review-result.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { lstat, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
@@ -95,5 +95,16 @@ test('clearing the materialized result prevents a stale review from being reused
     const resolved = await loadReviewResult(worktree, ['💬 ❌ Review 发现问题'])
     assert.equal(resolved.source, 'stdout-verdict')
     assert.deepEqual(resolved.result, { passed: false, issues: [] })
+  })
+})
+
+test('clearing creates the .clickvibe parent directory on a brand-new worktree', async () => {
+  await withWorktree(async (worktree) => {
+    // 真实启动链路:新 worktree 里没有 .clickvibe,Host 必须先建目录,
+    // review agent 的写文件工具才有落点(多数写工具不自动创建父目录)。
+    await clearReviewResultFile(worktree)
+    await assert.rejects(lstat(join(worktree, '.clickvibe/review-result.json')), { code: 'ENOENT' })
+    const info = await lstat(join(worktree, '.clickvibe'))
+    assert.equal(info.isDirectory(), true)
   })
 })

--- a/tests/task-gate.test.ts
+++ b/tests/task-gate.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { ExclusiveTaskGate } from '../src/task-gate.ts'
+
+interface TestTask {
+  id: string
+  closed: boolean
+}
+
+test('exclusive task gate synchronously reuses an active task for the same workflow', () => {
+  const gate = new ExclusiveTaskGate<TestTask>()
+  let creates = 0
+  const create = (): TestTask => ({ id: `review-${++creates}`, closed: false })
+
+  const first = gate.reserve('owner-repo-22', create)
+  const concurrent = gate.reserve('owner-repo-22', create)
+
+  assert.equal(first.created, true)
+  assert.equal(concurrent.created, false)
+  assert.equal(concurrent.task, first.task)
+  assert.equal(creates, 1)
+})
+
+test('releasing an old task cannot remove its newer replacement', () => {
+  const gate = new ExclusiveTaskGate<TestTask>()
+  const old = gate.reserve('owner-repo-22', () => ({ id: 'old', closed: false })).task
+  old.closed = true
+  const current = gate.reserve('owner-repo-22', () => ({ id: 'current', closed: false })).task
+
+  gate.release('owner-repo-22', old)
+  const reused = gate.reserve('owner-repo-22', () => ({ id: 'unexpected', closed: false }))
+
+  assert.equal(reused.created, false)
+  assert.equal(reused.task, current)
+})


### PR DESCRIPTION
## 变更

- review prompt 要求 Codex/Claude 写入 `.clickvibe/review-result.json`
- 完成回调严格校验并优先采用文件结论，缺失或损坏时记录原因并回退 stdout JSON/表情判定
- 每轮 review 前清理旧文件，避免残留结论污染；Claude 展示上限与 Codex 对齐为 4000
- 增加双 agent 三路径、长结论、损坏 schema 和旧文件清理回归测试
- 补充 #19/#12 基于精确 session 与 HEAD 绑定的历史恢复说明

## 验证

- `pnpm test`（60/60）
- `pnpm run typecheck`
- `pnpm run build`

Closes #22