### PR TITLE
fix: 同步 Issue 列表与详情工作流状态

### DIFF
--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -1105,6 +1105,10 @@ interface RepositoryIssue extends GhIssue {
   workflow: Workflow
 }
 
+type WorkflowStateResponse =
+  | { ok: true; workflows: Workflow[] }
+  | { ok: false; error: string }
+
 function PanelContent() {
   const [projects, setProjects] = React.useState<ProjectOption[]>([])
   const [repoKey, setRepoKey] = React.useState('')
@@ -1133,8 +1137,13 @@ function PanelContent() {
 
   const refreshWorkflowStates = React.useCallback(async () => {
     if (!repoKey) return
-    const response = await apiCall<{ ok: true; workflows: Workflow[] }>('state', { repoKey })
-    if (response.ok) mergeWorkflowStates(response.workflows)
+    try {
+      const response = await apiCall<WorkflowStateResponse>('state', { repoKey })
+      if (response.ok) mergeWorkflowStates(response.workflows)
+    } catch {
+      // Polling is best-effort. Keep the last usable snapshot when the panel
+      // host disconnects; a later tick or explicit refresh will recover it.
+    }
   }, [mergeWorkflowStates, repoKey])
 
   const loadRepo = async (selected: string) => {
@@ -1186,14 +1195,17 @@ function PanelContent() {
       const url = String(issue.url ?? '')
       const [response, stateResponse] = await Promise.all([
         fetchIssue(url),
-        apiCall<{ ok: true; workflows: Workflow[] }>('state', { url }),
+        apiCall<WorkflowStateResponse>('state', { url }).catch(() => null),
       ])
-      mergeWorkflowStates(stateResponse.workflows)
+      if (stateResponse?.ok) mergeWorkflowStates(stateResponse.workflows)
       if (!response.ok) setError(response.error)
       else {
         // Workflows are persisted only after development starts; keep the
-        // authoritative repo snapshot solely for never-started synthetic rows.
-        setWorkflow(stateResponse.workflows.find((item) => item.url === url) ?? issue.workflow)
+        // repo snapshot for never-started rows and as a graceful fallback when
+        // /state is temporarily unavailable.
+        setWorkflow(stateResponse?.ok
+          ? stateResponse.workflows.find((item) => item.url === url) ?? issue.workflow
+          : issue.workflow)
         setResult(response.data as { kind: 'issue' | 'pr'; item: GhIssue; timeline?: TimelineEvent[]; dependencies?: Dependencies })
         setAutoAction(triggerAction)
       }

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -17,7 +17,7 @@ import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'
 // merges the slot names.
 import type { LayoutController } from '@deepseek-ai/dsh-client-ui-layout/client'
 import type { SidebarFooterActionOwnerProps } from '@deepseek-ai/dsh-client-ui-sidebar/client'
-import { githubCompareUrl } from '../state-view.ts'
+import { githubCompareUrl, workflowStatusLabel } from '../state-view.ts'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _SlotLoaders = [typeof LayoutController, SidebarFooterActionOwnerProps]
 
@@ -678,17 +678,11 @@ function fmtTime(iso: string): string {
 }
 
 function stageLabel(stage: Workflow['stage'], workflow: Workflow | null): string {
-  switch (stage) {
-    case 'idle': return '未开发'
-    case 'developing': return '开发中'
-    case 'review-ready':
-      // 已有 review 结果:未通过 → "Review 未通过";否则 → "待 review"
-      return workflow?.reviewResult
-        ? (workflow.reviewResult.passed ? 'Review 通过' : 'Review 未通过')
-        : '待 review'
-    case 'reviewing': return 'review 中'
-    case 'passed': return '✅ 已通过'
-  }
+  return workflowStatusLabel(
+    stage,
+    workflow?.reviewResult?.passed ?? null,
+    workflow?.derived?.verdictCurrent,
+  )
 }
 
 function DevSection({ url, issue, workflow, onWorkflow, autoAction, onAutoActionHandled }: {
@@ -762,7 +756,7 @@ function DevSection({ url, issue, workflow, onWorkflow, autoAction, onAutoAction
   }, [workflow?.reviewAgent, workflow?.devAgent])
 
   const refresh = async () => {
-    const res = await apiCall<{ ok: true; workflows: Workflow[] }>('state', {})
+    const res = await apiCall<{ ok: true; workflows: Workflow[] }>('state', { url })
     if (res.ok) {
       onWorkflow(res.workflows.find((w) => w.url === url) ?? null)
     }
@@ -1121,6 +1115,26 @@ function PanelContent() {
   const [workflow, setWorkflow] = React.useState<Workflow | null>(null)
   const [autoAction, setAutoAction] = React.useState(false)
 
+  const mergeWorkflowStates = React.useCallback((workflows: Workflow[]) => {
+    const byUrl = new Map(workflows.map((item) => [item.url, item]))
+    setIssues((previous) => previous.map((issue) => {
+      const current = byUrl.get(String(issue.url ?? ''))
+      return current ? { ...issue, workflow: current } : issue
+    }))
+    setWorkflow((previous) => previous ? byUrl.get(previous.url) ?? previous : previous)
+  }, [])
+
+  const updateWorkflow = React.useCallback((next: Workflow | null) => {
+    setWorkflow(next)
+    if (next) mergeWorkflowStates([next])
+  }, [mergeWorkflowStates])
+
+  const refreshWorkflowStates = React.useCallback(async () => {
+    if (!repoKey) return
+    const response = await apiCall<{ ok: true; workflows: Workflow[] }>('state', { repoKey })
+    if (response.ok) mergeWorkflowStates(response.workflows)
+  }, [mergeWorkflowStates, repoKey])
+
   const loadRepo = async (selected: string) => {
     if (!selected) return
     setLoading(true)
@@ -1155,15 +1169,29 @@ function PanelContent() {
     return () => { cancelled = true }
   }, [])
 
+  // Keep list badges bound to the same live /state facts as the detail view.
+  React.useEffect(() => {
+    if (!repoKey) return
+    const timer = window.setInterval(() => { void refreshWorkflowStates() }, 5000)
+    return () => window.clearInterval(timer)
+  }, [refreshWorkflowStates, repoKey])
+
   const openIssue = async (issue: RepositoryIssue, triggerAction = false) => {
     setLoading(true)
     setError(null)
     setAutoAction(false)
     try {
-      const response = await fetchIssue(String(issue.url ?? ''))
+      const url = String(issue.url ?? '')
+      const [response, stateResponse] = await Promise.all([
+        fetchIssue(url),
+        apiCall<{ ok: true; workflows: Workflow[] }>('state', { url }),
+      ])
+      mergeWorkflowStates(stateResponse.workflows)
       if (!response.ok) setError(response.error)
       else {
-        setWorkflow(issue.workflow)
+        // Workflows are persisted only after development starts; keep the
+        // authoritative repo snapshot solely for never-started synthetic rows.
+        setWorkflow(stateResponse.workflows.find((item) => item.url === url) ?? issue.workflow)
         setResult(response.data as { kind: 'issue' | 'pr'; item: GhIssue; timeline?: TimelineEvent[]; dependencies?: Dependencies })
         setAutoAction(triggerAction)
       }
@@ -1207,7 +1235,7 @@ function PanelContent() {
   return (
     <div className="cv-panel">
       <div className="cv-panel-header">
-        <span>{result ? <button className="cv-back" onClick={() => { setResult(null); setAutoAction(false) }}>← 项目 Issues</button> : 'ClickVibe · 项目'}</span>
+        <span>{result ? <button className="cv-back" onClick={() => { setResult(null); setAutoAction(false); void refreshWorkflowStates() }}>← 项目 Issues</button> : 'ClickVibe · 项目'}</span>
         <button className="cv-close" onClick={() => setPanelOpen(false)}>✕</button>
       </div>
       {result ? (
@@ -1215,7 +1243,7 @@ function PanelContent() {
           issue={result.item}
           kind={result.kind}
           workflow={workflow}
-          onWorkflow={setWorkflow}
+          onWorkflow={updateWorkflow}
           timeline={result.timeline}
           dependencies={result.dependencies}
           autoAction={autoAction}

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ import {
   type DevelopAgent,
   type IssuePromptSnapshot,
 } from './develop.ts'
-import { deriveNextAction, workflowBaseBranch, type NextAction, type WorkflowFacts } from './state-view.ts'
+import { deriveNextAction, deriveWorkflowStatus, workflowBaseBranch, type NextAction, type WorkflowFacts } from './state-view.ts'
 import {
   appendEvent,
   appendLog,
@@ -529,15 +529,7 @@ export async function deriveWorkflowState(
   }
   const nextAction = deriveNextAction(facts)
   const baseBranch = workflowBaseBranch(workflow.baseRef, options.defaultBranch ?? 'main')
-  const status: WorkflowDerived['status'] = facts.prMerged || reviewPassed === true
-    ? 'passed'
-    : taskRunning && workflow.stage === 'reviewing'
-      ? 'reviewing'
-      : facts.prNumber
-        ? 'review-ready'
-        : taskRunning || hasUncommittedChanges || facts.hasCommits
-          ? 'developing'
-          : 'idle'
+  const status = deriveWorkflowStatus(facts)
 
   return {
     ...workflow,
@@ -627,7 +619,12 @@ export function apply(ctx: Context): void {
         return
       }
       if (method === 'state') {
-        const workflows = await loadAllWorkflows()
+        const filter = payload as { url?: unknown; repoKey?: unknown } | undefined
+        const url = String(filter?.url ?? '')
+        const repoKey = String(filter?.repoKey ?? '')
+        const workflows = (await loadAllWorkflows()).filter((workflow) =>
+          (url === '' || workflow.url === url) && (repoKey === '' || workflow.repoKey === repoKey),
+        )
         const enriched = await enrichWorkflowStates(ctx, workflows)
         writeJson(res, 200, { ok: true, workflows: enriched })
         return

--- a/src/state-view.ts
+++ b/src/state-view.ts
@@ -42,6 +42,7 @@ export function githubCompareUrl(
 }
 
 export type WorkflowStageInput = 'idle' | 'developing' | 'review-ready' | 'reviewing' | 'passed'
+export type WorkflowStatus = WorkflowStageInput
 
 export interface WorkflowFacts {
   /** The issue itself is still open (closed issues have no next action). */
@@ -80,6 +81,41 @@ export interface WorkflowFacts {
 
 function action(kind: NextActionKind, label: string, hint: string): NextAction {
   return { kind, label, hint }
+}
+
+/** Derive the badge/detail status from the same live facts as the next action. */
+export function deriveWorkflowStatus(facts: WorkflowFacts): WorkflowStatus {
+  const verdictCurrent = facts.reviewPassed !== null
+    && facts.head !== null
+    && facts.reviewedHash !== null
+    && facts.head === facts.reviewedHash
+
+  if (facts.prMerged) return 'passed'
+  // A live task outranks the linked PR and any verdict bound to an older HEAD.
+  if (facts.taskRunning) return facts.stage === 'reviewing' ? 'reviewing' : 'developing'
+  if (facts.reviewPassed === true && verdictCurrent) return 'passed'
+  if (facts.reviewPassed !== null || facts.prNumber || facts.stage === 'review-ready') return 'review-ready'
+  if (facts.hasUncommittedChanges || facts.hasCommits) return 'developing'
+  return 'idle'
+}
+
+/** Human label shared by the issue list and detail header. */
+export function workflowStatusLabel(
+  status: WorkflowStatus,
+  reviewPassed: boolean | null,
+  verdictCurrent: boolean | undefined,
+): string {
+  switch (status) {
+    case 'idle': return '未开发'
+    case 'developing': return '开发中'
+    case 'review-ready':
+      if (reviewPassed !== null && verdictCurrent === false) return '待重新 Review'
+      if (reviewPassed === true) return 'Review 通过'
+      if (reviewPassed === false) return 'Review 未通过'
+      return '待 review'
+    case 'reviewing': return 'review 中'
+    case 'passed': return '✅ 已通过'
+  }
 }
 
 /**

--- a/src/state-view.ts
+++ b/src/state-view.ts
@@ -93,7 +93,12 @@ export function deriveWorkflowStatus(facts: WorkflowFacts): WorkflowStatus {
   if (facts.prMerged) return 'passed'
   // A live task outranks the linked PR and any verdict bound to an older HEAD.
   if (facts.taskRunning) return facts.stage === 'reviewing' ? 'reviewing' : 'developing'
-  if (facts.reviewPassed === true && verdictCurrent) return 'passed'
+  // When the worktree cannot be inspected, preserve a known passing verdict
+  // unless there is positive evidence of a newer commit. This matches the
+  // pre-derived-state behavior without treating a known changed HEAD as current.
+  const passedWithoutContradictingHead = facts.reviewPassed === true
+    && (verdictCurrent || (facts.head === null && !facts.hasNewCommits))
+  if (passedWithoutContradictingHead) return 'passed'
   if (facts.reviewPassed !== null || facts.prNumber || facts.stage === 'review-ready') return 'review-ready'
   if (facts.hasUncommittedChanges || facts.hasCommits) return 'developing'
   return 'idle'

--- a/tests/state-view.test.ts
+++ b/tests/state-view.test.ts
@@ -1,6 +1,13 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { deriveNextAction, githubCompareUrl, workflowBaseBranch, type WorkflowFacts } from '../src/state-view.ts'
+import {
+  deriveNextAction,
+  deriveWorkflowStatus,
+  githubCompareUrl,
+  workflowBaseBranch,
+  workflowStatusLabel,
+  type WorkflowFacts,
+} from '../src/state-view.ts'
 
 function facts(overrides: Partial<WorkflowFacts> = {}): WorkflowFacts {
   return {
@@ -56,6 +63,46 @@ test('a running task has no next action until it settles', () => {
   assert.equal(next.kind, 'none')
   const reviewing = deriveNextAction(facts({ stage: 'reviewing', taskRunning: true }))
   assert.equal(reviewing.kind, 'none')
+})
+
+test('a running development task stays developing even when a PR and old verdict exist', () => {
+  const runningRework = facts({
+    stage: 'developing', taskRunning: true, prNumber: '9', reviewPassed: false,
+    reviewedHash: 'a1b2c3d', head: 'e5f6g7', hasCommits: true,
+  })
+  assert.equal(deriveWorkflowStatus(runningRework), 'developing')
+
+  const runningDevWithPr = facts({
+    stage: 'developing', taskRunning: true, prNumber: '9', reviewPassed: null, hasCommits: true,
+  })
+  assert.equal(deriveWorkflowStatus(runningDevWithPr), 'developing')
+})
+
+test('a running review task stays reviewing even when a PR exists', () => {
+  assert.equal(deriveWorkflowStatus(facts({
+    stage: 'reviewing', taskRunning: true, prNumber: '9', hasCommits: true,
+  })), 'reviewing')
+})
+
+test('only a current passed verdict produces passed status', () => {
+  assert.equal(deriveWorkflowStatus(facts({
+    stage: 'review-ready', prNumber: '9', reviewPassed: true,
+    reviewedHash: 'a1b2c3d', head: 'a1b2c3d',
+  })), 'passed')
+  assert.equal(deriveWorkflowStatus(facts({
+    stage: 'review-ready', prNumber: '9', reviewPassed: true,
+    reviewedHash: 'a1b2c3d', head: 'e5f6g7',
+  })), 'review-ready')
+  assert.equal(deriveWorkflowStatus(facts({
+    stage: 'review-ready', prNumber: null, reviewPassed: false,
+    reviewedHash: 'a1b2c3d', head: 'e5f6g7', hasCommits: true,
+  })), 'review-ready')
+})
+
+test('a stale review verdict is labelled as awaiting re-review', () => {
+  assert.equal(workflowStatusLabel('review-ready', false, false), '待重新 Review')
+  assert.equal(workflowStatusLabel('review-ready', true, false), '待重新 Review')
+  assert.equal(workflowStatusLabel('review-ready', false, true), 'Review 未通过')
 })
 
 test('interrupted development resumes the agent session', () => {

--- a/tests/state-view.test.ts
+++ b/tests/state-view.test.ts
@@ -84,7 +84,7 @@ test('a running review task stays reviewing even when a PR exists', () => {
   })), 'reviewing')
 })
 
-test('only a current passed verdict produces passed status', () => {
+test('a current passed verdict passes while a known changed head requires review', () => {
   assert.equal(deriveWorkflowStatus(facts({
     stage: 'review-ready', prNumber: '9', reviewPassed: true,
     reviewedHash: 'a1b2c3d', head: 'a1b2c3d',
@@ -97,6 +97,13 @@ test('only a current passed verdict produces passed status', () => {
     stage: 'review-ready', prNumber: null, reviewPassed: false,
     reviewedHash: 'a1b2c3d', head: 'e5f6g7', hasCommits: true,
   })), 'review-ready')
+})
+
+test('an unavailable worktree preserves a passed verdict without evidence of new commits', () => {
+  assert.equal(deriveWorkflowStatus(facts({
+    stage: 'review-ready', prNumber: '9', reviewPassed: true,
+    reviewedHash: 'a1b2c3d', head: null, hasNewCommits: false,
+  })), 'passed')
 })
 
 test('a stale review verdict is labelled as awaiting re-review', () => {


### PR DESCRIPTION
## 修改内容

- 抽取共享状态决策，运行中的 dev/rework 优先显示「开发中」，review 任务显示「review 中」
- 仅当前 HEAD 的通过结论可进入 passed；过期结论统一显示「待重新 Review」
- 详情状态更新同步回写列表，并按仓库每 5 秒轮询权威 `/state`
- 重进详情时按 URL 强制拉取 `/state`；接口失败时降级到列表快照
- 轮询网络异常被安全吸收，不再产生 unhandled promise rejection
- worktree HEAD 暂不可读且无新提交证据时，保守保留 Review 通过状态
- 为运行任务、已有 PR、当前/过期 verdict、HEAD 不可读等组合补充状态映射测试

## 验证

- `pnpm typecheck`
- `pnpm test`（82/82）
- `pnpm build`
- `git diff --check`

Blocked by #31
Closes #28