### PR TITLE
fix: GitHub 读取改 REST 并按更新缓存

### DIFF
--- a/docs/plans/2026-08-22-github-rest-cache-design.md
+++ b/docs/plans/2026-08-22-github-rest-cache-design.md
@@ -1,0 +1,19 @@
+# GitHub REST 读取与缓存设计
+
+## 范围
+
+只替换 ClickVibe 的 GitHub 读取层。Issue/PR 列表、详情、评论、review、timeline、依赖扫描、Issue 状态和 PR 状态均通过 `gh api` REST 获取；评论、关闭 Issue、合并 PR 等写操作保持原命令与门禁。
+
+## 数据与缓存
+
+REST 响应在服务端映射回现有面板字段。PR `reviewDecision` 按 reviewer 聚合最新有效 review：任一最新决定为 `CHANGES_REQUESTED` 时返回该状态，否则存在批准则为 `APPROVED`。
+
+仓库 issues/pulls 聚合使用与现有刷新配置一致的短 TTL，并合并并发请求。单 Issue/PR 详情按资源缓存；仓库聚合提供的 `updated_at` 与缓存版本一致时直接复用完整详情，不再访问 GitHub。尚无版本提示时使用短 TTL。手动刷新、开发/Review 阶段启动和合并契约校验可绕过缓存。评论、PR 合并和 Issue 关闭成功后主动失效相关详情与仓库聚合，避免写后读旧状态。
+
+## 限流与失败
+
+所有 REST 响应读取 HTTP headers。遇到 `403/429`、`X-RateLimit-Remaining: 0` 或 secondary rate limit 时，优先使用 `Retry-After`，否则使用 `X-RateLimit-Reset` 建立进程内熔断。恢复前所有后续读取零请求失败，并统一返回 `GitHub 额度已用完,约 HH:MM 恢复`；面板直接显示该文案并保留已有数据。
+
+## 验证
+
+测试覆盖 REST 字段等效、latest review 推导、详情与聚合缓存命中、强制刷新、限流恢复时间、跨路由熔断、分页、spill 输出及最新 main 的 Review 契约/合并门禁。

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -1289,14 +1289,14 @@ type FetchIssueResponse =
   | { ok: true; data: { kind: 'issue' | 'pr'; item: unknown; timeline?: TimelineEvent[]; dependencies?: Dependencies }; dependencyError?: string }
   | { ok: false; error: string }
 
-async function fetchIssue(url: string, timeoutMs?: number): Promise<FetchIssueResponse> {
+async function fetchIssue(url: string, timeoutMs?: number, forceRefresh = false): Promise<FetchIssueResponse> {
   const controller = timeoutMs === undefined ? null : new AbortController()
   const timeout = controller ? window.setTimeout(() => controller.abort(), timeoutMs) : null
   try {
     const response = await fetch('/clickvibe/api/fetch', {
       method: 'POST',
       headers: { 'content-type': 'application/json', 'x-clickvibe-request': '1' },
-      body: JSON.stringify({ url }),
+      body: JSON.stringify({ url, forceRefresh }),
       ...(controller ? { signal: controller.signal } : {}),
     })
     return response.json() as Promise<FetchIssueResponse>
@@ -1398,6 +1398,8 @@ function PanelContent() {
             setDependencyRefreshError(`GitHub 依赖刷新失败: ${String(reason)}`)
           }
         }
+      } else {
+        setStateRefreshError(response.error)
       }
     } catch (reason) {
       // Polling is best-effort. Keep the last usable snapshot when the panel
@@ -1473,6 +1475,8 @@ function PanelContent() {
       if (stateResponse?.ok) {
         setFreshness(stateResponse.freshness)
         setStateRefreshError(null)
+      } else if (stateResponse && !stateResponse.ok) {
+        setStateRefreshError(stateResponse.error)
       }
       if (!response.ok) setError(response.error)
       else {
@@ -1500,7 +1504,7 @@ function PanelContent() {
     setError(null)
     try {
       const [issueResponse, stateResponse] = await Promise.all([
-        fetchIssue(url),
+        fetchIssue(url, undefined, true),
         apiCall<WorkflowStateResponse>('state', { url, forceRefresh: true }),
       ])
       if (!issueResponse.ok) setError(issueResponse.error)
@@ -1516,6 +1520,8 @@ function PanelContent() {
         setWorkflow(stateResponse.workflows.find((item) => item.url === url) ?? workflow)
         setFreshness(stateResponse.freshness)
         setStateRefreshError(null)
+      } else {
+        setStateRefreshError(stateResponse.error)
       }
     } catch (reason) {
       setError(`Issue 刷新失败: ${String(reason)}`)
@@ -1566,8 +1572,8 @@ function PanelContent() {
             : '⚠ 状态可能过期 · 远端同步失败，当前使用本地 refs'}
         </div>
       ) : null}
-      {stateRefreshError ? <div className="cv-stale" title={stateRefreshError}>⚠ 状态可能过期 · 自动刷新失败，当前保留上次结果</div> : null}
-      {dependencyRefreshError ? <div className="cv-stale" title={dependencyRefreshError}>⚠ 依赖状态可能过期 · GitHub 刷新失败，当前保留上次结果</div> : null}
+      {stateRefreshError ? <div className="cv-stale" title={stateRefreshError}>{stateRefreshError.startsWith('GitHub 额度已用完,约 ') ? stateRefreshError : '⚠ 状态可能过期 · 自动刷新失败，当前保留上次结果'}</div> : null}
+      {dependencyRefreshError ? <div className="cv-stale" title={dependencyRefreshError}>{dependencyRefreshError.startsWith('GitHub 额度已用完,约 ') ? dependencyRefreshError : '⚠ 依赖状态可能过期 · GitHub 刷新失败，当前保留上次结果'}</div> : null}
       {result ? (
         <IssueView
           issue={result.item}

--- a/src/github-rest.ts
+++ b/src/github-rest.ts
@@ -1,0 +1,283 @@
+import { readFile } from 'node:fs/promises'
+
+interface ShellContext {
+  shell: {
+    resolve(spec: { command: string; timeoutMs?: number }): unknown
+    run(spec: unknown): Promise<{
+      exitCode: number | null
+      stdout: { text: string; truncated?: boolean; spillPath?: string }
+      stderr?: { text?: string }
+    }>
+  }
+}
+
+interface CachedValue<T> {
+  value: T
+  version: string | null
+  expiresAt: number
+}
+
+interface GithubReviewRest {
+  id?: number
+  user?: { login?: string } | null
+  state?: string
+  submitted_at?: string | null
+}
+
+interface IncludedResponse {
+  status: number
+  headers: Map<string, string>
+  body: string
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+function parseIncludedResponse(output: string): IncludedResponse {
+  const normalized = output.replace(/\r\n/g, '\n')
+  const separator = normalized.indexOf('\n\n')
+  const headerText = separator >= 0 ? normalized.slice(0, separator) : normalized
+  const body = separator >= 0 ? normalized.slice(separator + 2) : ''
+  const lines = headerText.split('\n')
+  const statusMatch = lines.shift()?.match(/^HTTP\/\S+\s+(\d{3})/i)
+  if (!statusMatch) throw new Error('GitHub REST 响应缺少 HTTP 状态行')
+  const headers = new Map<string, string>()
+  for (const line of lines) {
+    const colon = line.indexOf(':')
+    if (colon <= 0) continue
+    headers.set(line.slice(0, colon).trim().toLowerCase(), line.slice(colon + 1).trim())
+  }
+  return { status: Number(statusMatch[1]), headers, body }
+}
+
+function resetFrom(headers: Map<string, string>, now: number): number {
+  const retryAfter = Number(headers.get('retry-after'))
+  if (Number.isFinite(retryAfter) && retryAfter >= 0) return now + retryAfter * 1000
+  const resetSeconds = Number(headers.get('x-ratelimit-reset'))
+  if (Number.isFinite(resetSeconds) && resetSeconds > 0) return resetSeconds * 1000
+  return now + 60 * 60_000
+}
+
+function isRateLimited(response: IncludedResponse, detail: string): boolean {
+  if (response.status === 429) return true
+  if (response.headers.get('x-ratelimit-remaining') === '0') return true
+  return response.status === 403 && /(?:rate limit|secondary rate)/i.test(detail)
+}
+
+function recoveryLabel(resetAt: number): string {
+  return new Date(resetAt).toLocaleTimeString('zh-CN', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+}
+
+export class GithubRateLimitError extends Error {
+  readonly resetAt: number
+
+  constructor(resetAt: number) {
+    super(`GitHub 额度已用完,约 ${recoveryLabel(resetAt)} 恢复`)
+    this.name = 'GithubRateLimitError'
+    this.resetAt = resetAt
+  }
+}
+
+/**
+ * Derive GraphQL's coarse reviewDecision from REST reviews. Only each actor's
+ * latest decisive review counts; later approval clears that actor's old change
+ * request, while comments do not replace a decisive review.
+ */
+export function deriveReviewDecision(reviews: GithubReviewRest[]): 'APPROVED' | 'CHANGES_REQUESTED' | null {
+  const latest = new Map<string, GithubReviewRest>()
+  const sorted = [...reviews].sort((left, right) => {
+    const time = String(left.submitted_at ?? '').localeCompare(String(right.submitted_at ?? ''))
+    return time || Number(left.id ?? 0) - Number(right.id ?? 0)
+  })
+  for (const review of sorted) {
+    const login = String(review.user?.login ?? '')
+    const state = String(review.state ?? '').toUpperCase()
+    if (!login || !['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'].includes(state)) continue
+    if (state === 'DISMISSED') latest.delete(login)
+    else latest.set(login, review)
+  }
+  if ([...latest.values()].some((review) => String(review.state).toUpperCase() === 'CHANGES_REQUESTED')) {
+    return 'CHANGES_REQUESTED'
+  }
+  return [...latest.values()].some((review) => String(review.state).toUpperCase() === 'APPROVED')
+    ? 'APPROVED'
+    : null
+}
+
+/** One ctx-scoped REST reader: rate-limit circuit, request parsing and read caches. */
+export class GithubRestReader {
+  private readonly ctx: ShellContext
+  private readonly resources = new Map<string, CachedValue<unknown>>()
+  private readonly aggregates = new Map<string, CachedValue<unknown>>()
+  private readonly inFlight = new Map<string, Promise<unknown>>()
+  private readonly versions = new Map<string, string>()
+  private circuitUntil = 0
+
+  constructor(ctx: ShellContext) {
+    this.ctx = ctx
+  }
+
+  rateLimitError(now = Date.now()): GithubRateLimitError | null {
+    return this.circuitUntil > now ? new GithubRateLimitError(this.circuitUntil) : null
+  }
+
+  rememberVersion(key: string, version: string | null | undefined): void {
+    if (version) this.versions.set(key, version)
+  }
+
+  resourceVersion(key: string): string | null {
+    return this.versions.get(key) ?? null
+  }
+
+  invalidate(prefix: string): void {
+    for (const key of this.resources.keys()) {
+      if (key === prefix || key.startsWith(`${prefix}/`)) this.resources.delete(key)
+    }
+    for (const key of this.aggregates.keys()) {
+      if (key === prefix || key.startsWith(`${prefix}/`)) this.aggregates.delete(key)
+    }
+    this.versions.delete(prefix)
+  }
+
+  private assertCircuitOpen(): void {
+    const error = this.rateLimitError()
+    if (error) throw error
+  }
+
+  private async output(result: Awaited<ReturnType<ShellContext['shell']['run']>>): Promise<string> {
+    const stdout = result.stdout
+    if (stdout.truncated) {
+      if (!stdout.spillPath) throw new Error('GitHub REST 输出超过上限且无 spill 文件')
+      return readFile(stdout.spillPath, 'utf8')
+    }
+    return stdout.text
+  }
+
+  private async request(path: string, accept?: string, timeoutMs = 30_000): Promise<IncludedResponse> {
+    this.assertCircuitOpen()
+    const command = [
+      'gh api --include',
+      shellQuote(path),
+      accept ? `-H ${shellQuote(`Accept: ${accept}`)}` : '',
+    ].filter(Boolean).join(' ')
+    const spec = this.ctx.shell.resolve({ command, timeoutMs })
+    const result = await this.ctx.shell.run(spec)
+    const stdout = await this.output(result)
+    let response: IncludedResponse
+    try {
+      response = parseIncludedResponse(stdout)
+    } catch (parseError) {
+      const detail = [result.stderr?.text, stdout].filter(Boolean).join('\n').trim()
+      if (result.exitCode !== 0 && /(?:rate limit|secondary rate)/i.test(detail)) {
+        this.circuitUntil = Date.now() + 60 * 60_000
+        throw new GithubRateLimitError(this.circuitUntil)
+      }
+      if (result.exitCode !== 0) throw new Error(detail || `gh api 执行失败(exit ${result.exitCode})`)
+      throw parseError
+    }
+    const detail = [result.stderr?.text, response.body].filter(Boolean).join('\n')
+    if (isRateLimited(response, detail)) {
+      this.circuitUntil = resetFrom(response.headers, Date.now())
+      throw new GithubRateLimitError(this.circuitUntil)
+    }
+    if (result.exitCode !== 0 || response.status < 200 || response.status >= 300) {
+      let message = response.body.trim()
+      try {
+        const parsed = JSON.parse(response.body) as { message?: unknown }
+        message = String(parsed.message ?? message)
+      } catch { /* retain raw response body */ }
+      throw new Error(`GitHub REST ${response.status}: ${message || result.stderr?.text || '请求失败'}`)
+    }
+    return response
+  }
+
+  async json<T = unknown>(path: string, accept?: string, timeoutMs?: number): Promise<T> {
+    const response = await this.request(path, accept, timeoutMs)
+    try {
+      return JSON.parse(response.body || 'null') as T
+    } catch {
+      throw new Error(`GitHub REST 返回了无效 JSON: ${path}`)
+    }
+  }
+
+  async paginate<T>(path: string, accept?: string, timeoutMs?: number): Promise<T[]> {
+    const values: T[] = []
+    for (let page = 1; ; page++) {
+      const separator = path.includes('?') ? '&' : '?'
+      const batch = await this.json<T[]>(`${path}${separator}per_page=100&page=${page}`, accept, timeoutMs)
+      if (!Array.isArray(batch)) throw new Error('GitHub REST 分页返回格式无效')
+      values.push(...batch)
+      if (batch.length < 100) return values
+    }
+  }
+
+  async cachedResource<T>(
+    key: string,
+    version: string | null | undefined,
+    loader: () => Promise<T>,
+    options: { ttlMs?: number; force?: boolean; versionOf?: (value: T) => string | null | undefined } = {},
+  ): Promise<T> {
+    this.assertCircuitOpen()
+    const knownVersion = version || null
+    const cached = this.resources.get(key) as CachedValue<T> | undefined
+    const now = Date.now()
+    if (!options.force && cached && (
+      (knownVersion !== null && cached.version === knownVersion)
+      || (knownVersion === null && cached.expiresAt > now)
+    )) return cached.value
+    return this.deduplicate(`resource:${key}`, async () => {
+      const value = await loader()
+      const loadedVersion = options.versionOf?.(value) || knownVersion
+      this.resources.set(key, {
+        value,
+        version: loadedVersion,
+        expiresAt: Date.now() + (options.ttlMs ?? 30_000),
+      })
+      if (loadedVersion) this.versions.set(key, loadedVersion)
+      return value
+    })
+  }
+
+  async cachedAggregate<T>(key: string, ttlMs: number, force: boolean, loader: () => Promise<T>): Promise<T> {
+    this.assertCircuitOpen()
+    const cached = this.aggregates.get(key) as CachedValue<T> | undefined
+    if (!force && cached && cached.expiresAt > Date.now()) return cached.value
+    return this.deduplicate(`aggregate:${key}`, async () => {
+      const value = await loader()
+      this.aggregates.set(key, { value, version: null, expiresAt: Date.now() + ttlMs })
+      return value
+    })
+  }
+
+  private async deduplicate<T>(key: string, loader: () => Promise<T>): Promise<T> {
+    const pending = this.inFlight.get(key) as Promise<T> | undefined
+    if (pending) return pending
+    const created = loader().finally(() => this.inFlight.delete(key))
+    this.inFlight.set(key, created)
+    return created
+  }
+}
+
+const readers = new WeakMap<object, GithubRestReader>()
+
+export function githubRest(ctx: ShellContext): GithubRestReader {
+  const key = ctx as object
+  const existing = readers.get(key)
+  if (existing) return existing
+  const created = new GithubRestReader(ctx)
+  readers.set(key, created)
+  return created
+}
+
+export function githubErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export function isGithubRateLimitError(error: unknown): error is GithubRateLimitError {
+  return error instanceof GithubRateLimitError
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,12 @@ import {
   aggregateRepositoryFreshness,
   type RepositoryFreshness,
 } from './repo-freshness.ts'
+import {
+  deriveReviewDecision,
+  githubErrorMessage,
+  githubRest,
+  isGithubRateLimitError,
+} from './github-rest.ts'
 
 declare module '@deepseek-ai/cordis' {
   interface Context {
@@ -134,22 +140,6 @@ const ROUTE = '/clickvibe/api'
 
 /** Body size bound of one JSON request. */
 const MAX_BODY_BYTES = 64 * 1024
-
-/** Fields the issue fetch requests from gh (verified against rc.8). */
-const ISSUE_FIELDS = [
-  'number', 'title', 'state', 'stateReason', 'author', 'createdAt',
-  'updatedAt', 'closedAt', 'body', 'url', 'labels', 'assignees',
-  'milestone', 'comments', 'reactionGroups', 'isPinned',
-].join(',')
-
-/** Fields the PR fetch requests from gh (verified against rc.8). */
-const PR_FIELDS = [
-  'number', 'title', 'state', 'author', 'createdAt', 'updatedAt',
-  'closedAt', 'mergedAt', 'body', 'url', 'labels', 'assignees',
-  'milestone', 'additions', 'deletions', 'changedFiles', 'commits',
-  'isDraft', 'mergeable', 'mergeStateStatus', 'baseRefName',
-  'headRefName', 'reviews', 'reviewRequests', 'comments',
-].join(',')
 
 interface ClickVibeConfig {
   repos: Record<string, string>
@@ -300,6 +290,11 @@ function writeJson(res: ServerResponse, status: number, value: unknown): void {
   res.end(body)
 }
 
+function githubAwareStatus(result: { ok: boolean; error?: string }, success = 200, failure = 400): number {
+  if (result.ok) return success
+  return result.error?.startsWith('GitHub 额度已用完,约 ') ? 429 : failure
+}
+
 /** Run one foreground command; returns trimmed stdout or throws on non-zero. */
 async function runCommand(
   ctx: Context,
@@ -384,14 +379,11 @@ async function readWorktreeHead(ctx: Context, worktree: string): Promise<string 
  */
 async function detectLinkedPr(ctx: Context, repoKey: string, branch: string): Promise<string | null> {
   try {
-    const spec = ctx.shell.resolve({
-      command: `gh pr list --repo ${repoKey} --head ${shellQuote(branch)} --state open --json number --jq '.[0].number // ""'`,
-      timeoutMs: 15000,
-    })
-    const result = await ctx.shell.run(spec)
-    if (result.exitCode !== 0) return null
-    const num = result.stdout.text.trim()
-    return num === '' ? null : num
+    const owner = repoKey.split('/')[0]
+    const prs = await githubRest(ctx).json<Array<{ number?: number }>>(
+      `repos/${repoKey}/pulls?state=open&head=${encodeURIComponent(`${owner}:${branch}`)}&per_page=1`,
+    )
+    return prs[0]?.number === undefined ? null : String(prs[0].number)
   } catch {
     return null
   }
@@ -445,6 +437,140 @@ interface GithubPrFact {
   reviewDecision: string | null
   headRefOid?: string
   baseRefName?: string
+}
+
+interface GithubUserRest { login?: string }
+interface GithubLabelRest { name?: string; color?: string }
+interface GithubMilestoneRest { title?: string; number?: number }
+interface GithubCommentRest {
+  user?: GithubUserRest | null
+  body?: string | null
+  created_at?: string
+  updated_at?: string
+}
+interface GithubReviewRest {
+  id?: number
+  user?: GithubUserRest | null
+  body?: string | null
+  state?: string
+  submitted_at?: string | null
+}
+interface GithubIssueDetailRest {
+  number: number
+  title: string
+  state: string
+  state_reason?: string | null
+  user?: GithubUserRest | null
+  created_at?: string
+  updated_at?: string
+  closed_at?: string | null
+  body?: string | null
+  html_url: string
+  labels?: GithubLabelRest[]
+  assignees?: GithubUserRest[]
+  milestone?: GithubMilestoneRest | null
+}
+interface GithubPrDetailRest extends GithubIssueDetailRest {
+  merged_at?: string | null
+  additions?: number
+  deletions?: number
+  changed_files?: number
+  commits?: number
+  draft?: boolean
+  mergeable?: boolean | null
+  mergeable_state?: string
+  base?: { ref?: string; sha?: string }
+  head?: { ref?: string; sha?: string }
+}
+
+function mapComments(comments: GithubCommentRest[]): Array<{ author: { login: string }; createdAt: string; updatedAt: string; body: string }> {
+  return comments.map((comment) => ({
+    author: { login: String(comment.user?.login ?? 'unknown') },
+    createdAt: String(comment.created_at ?? ''),
+    updatedAt: String(comment.updated_at ?? ''),
+    body: String(comment.body ?? ''),
+  }))
+}
+
+function mapIssueDetail(issue: GithubIssueDetailRest, comments: GithubCommentRest[]): Record<string, unknown> {
+  return {
+    number: issue.number,
+    title: issue.title,
+    state: String(issue.state).toUpperCase(),
+    stateReason: issue.state_reason ?? null,
+    author: { login: String(issue.user?.login ?? 'unknown') },
+    createdAt: issue.created_at ?? '',
+    updatedAt: issue.updated_at ?? '',
+    closedAt: issue.closed_at ?? null,
+    body: issue.body ?? '',
+    url: issue.html_url,
+    labels: (issue.labels ?? []).map((label) => ({ name: String(label.name ?? ''), color: label.color })),
+    assignees: (issue.assignees ?? []).map((user) => ({ login: String(user.login ?? '') })),
+    milestone: issue.milestone ? { title: String(issue.milestone.title ?? ''), number: issue.milestone.number } : null,
+    comments: mapComments(comments),
+    reactionGroups: [],
+    isPinned: false,
+  }
+}
+
+function mapPrDetail(
+  pr: GithubPrDetailRest,
+  comments: GithubCommentRest[],
+  reviews: GithubReviewRest[],
+  requested: { users?: GithubUserRest[]; teams?: Array<{ name?: string; slug?: string }> },
+): Record<string, unknown> {
+  return {
+    ...mapIssueDetail(pr, comments),
+    state: pr.merged_at ? 'MERGED' : String(pr.state).toUpperCase(),
+    mergedAt: pr.merged_at ?? null,
+    additions: pr.additions ?? 0,
+    deletions: pr.deletions ?? 0,
+    changedFiles: pr.changed_files ?? 0,
+    commits: Array.from({ length: Math.max(0, pr.commits ?? 0) }, () => ({})),
+    isDraft: pr.draft ?? false,
+    mergeable: pr.mergeable === null || pr.mergeable === undefined ? 'UNKNOWN' : pr.mergeable ? 'MERGEABLE' : 'CONFLICTING',
+    mergeStateStatus: String(pr.mergeable_state ?? 'unknown').toUpperCase(),
+    baseRefName: String(pr.base?.ref ?? ''),
+    headRefName: String(pr.head?.ref ?? ''),
+    reviews: reviews.map((review) => ({
+      author: { login: String(review.user?.login ?? 'unknown') },
+      body: String(review.body ?? ''),
+      state: String(review.state ?? '').toUpperCase(),
+      submittedAt: review.submitted_at ?? null,
+    })),
+    reviewRequests: [
+      ...(requested.users ?? []).map((user) => ({ login: String(user.login ?? '') })),
+      ...(requested.teams ?? []).map((team) => ({ name: String(team.name ?? team.slug ?? '') })),
+    ],
+    reviewDecision: deriveReviewDecision(reviews),
+  }
+}
+
+async function fetchPrRestDetail(ctx: Context, repoKey: string, number: string | number, force = false, timeoutMs?: number): Promise<GithubPrDetailRest> {
+  const rest = githubRest(ctx)
+  const key = `${repoKey}/pulls/${number}`
+  return rest.cachedResource(key, rest.resourceVersion(key), () =>
+    rest.json<GithubPrDetailRest>(`repos/${repoKey}/pulls/${number}`, undefined, timeoutMs), {
+      force,
+      versionOf: (pr) => pr.updated_at,
+    })
+}
+
+async function fetchPrRestReviews(ctx: Context, repoKey: string, number: string | number, timeoutMs?: number): Promise<GithubReviewRest[]> {
+  const rest = githubRest(ctx)
+  const resourceKey = `${repoKey}/pulls/${number}`
+  return rest.cachedResource(`${resourceKey}/reviews`, rest.resourceVersion(resourceKey), () =>
+    rest.paginate<GithubReviewRest>(`repos/${repoKey}/pulls/${number}/reviews`, undefined, timeoutMs))
+}
+
+async function fetchIssueRestDetail(ctx: Context, repoKey: string, number: string | number, force = false, timeoutMs?: number): Promise<GithubIssueDetailRest> {
+  const rest = githubRest(ctx)
+  const key = `${repoKey}/issues/${number}`
+  return rest.cachedResource(key, rest.resourceVersion(key), () =>
+    rest.json<GithubIssueDetailRest>(`repos/${repoKey}/issues/${number}`, undefined, timeoutMs), {
+      force,
+      versionOf: (issue) => issue.updated_at,
+    })
 }
 
 interface DeriveOptions {
@@ -782,7 +908,7 @@ export function apply(ctx: Context): void {
 
       if (method === 'fetch') {
         const result = await fetchIssue(ctx, payload)
-        writeJson(res, result.ok ? 200 : 400, result)
+        writeJson(res, githubAwareStatus(result), result)
         return
       }
       if (method === 'projects') {
@@ -792,7 +918,7 @@ export function apply(ctx: Context): void {
       }
       if (method === 'repo/issues') {
         const result = await fetchRepositoryIssues(ctx, payload)
-        writeJson(res, result.ok ? 200 : 400, result)
+        writeJson(res, githubAwareStatus(result), result)
         return
       }
       if (method === 'state') {
@@ -811,15 +937,24 @@ export function apply(ctx: Context): void {
             : parsedRepo ? [`${parsedRepo.owner}/${parsedRepo.repo}`]
               : workflows.map((workflow) => workflow.repoKey),
         )
-        const freshnesses = (await Promise.all([...repoKeys].map((key) =>
-          ensureConfiguredRepoFresh(ctx, config, key, filter?.forceRefresh === true),
-        ))).filter((value): value is RepositoryFreshness => value !== null)
-        const dependenciesRefreshDue = [...repoKeys]
-          .map((key) => dependencyRefreshClock.take(key, fetchTtlMs(config), filter?.forceRefresh === true))
-          .some(Boolean)
-        const enriched = await enrichWorkflowStates(ctx, workflows, config)
-        const freshness = aggregateRepositoryFreshness(freshnesses)
-        writeJson(res, 200, { ok: true, workflows: enriched, freshness, dependenciesRefreshDue })
+        try {
+          for (const key of repoKeys) {
+            const circuitError = githubRest(ctx).rateLimitError()
+            if (circuitError) throw circuitError
+          }
+          const freshnesses = (await Promise.all([...repoKeys].map((key) =>
+            ensureConfiguredRepoFresh(ctx, config, key, filter?.forceRefresh === true),
+          ))).filter((value): value is RepositoryFreshness => value !== null)
+          const dependenciesRefreshDue = [...repoKeys]
+            .map((key) => dependencyRefreshClock.take(key, fetchTtlMs(config), filter?.forceRefresh === true))
+            .some(Boolean)
+          const enriched = await enrichWorkflowStates(ctx, workflows, config)
+          const freshness = aggregateRepositoryFreshness(freshnesses)
+          writeJson(res, 200, { ok: true, workflows: enriched, freshness, dependenciesRefreshDue })
+        } catch (error) {
+          const message = isGithubRateLimitError(error) ? error.message : `状态刷新失败: ${githubErrorMessage(error)}`
+          writeJson(res, isGithubRateLimitError(error) ? 429 : 400, { ok: false, error: message })
+        }
         return
       }
       if (method === 'authorize') {
@@ -971,28 +1106,38 @@ async function fetchGithubPrFact(
   prNumber: string | number | null,
 ): Promise<GithubPrLookup> {
   const hasPrNumber = prNumber !== null && prNumber !== undefined
-  const selector = hasPrNumber ? shellQuote(String(prNumber)) : `--head ${shellQuote(branch)} --state all --limit 1`
-  const command = hasPrNumber
-    ? `gh pr view ${selector} --repo ${shellQuote(repoKey)} --json number,state,mergedAt,headRefName,headRefOid,baseRefName,url,reviewDecision`
-    : `gh pr list --repo ${shellQuote(repoKey)} ${selector} --json number,state,mergedAt,headRefName,headRefOid,baseRefName,url,reviewDecision --jq '.[0] // {}'`
   try {
-    const output = await runCommand(ctx, command, { timeoutMs: 5000 })
-    const raw = JSON.parse(output || '{}') as Partial<GithubPrFact> & { number?: number | string }
-    if (raw.number === undefined) return { known: true, pr: null }
+    const rest = githubRest(ctx)
+    let raw: GithubPrDetailRest | undefined
+    if (hasPrNumber) {
+      raw = await fetchPrRestDetail(ctx, repoKey, String(prNumber), false, 5_000)
+    } else {
+      const owner = repoKey.split('/')[0]
+      raw = await rest.cachedResource(`${repoKey}/pulls/head/${branch}`, null, async () =>
+        (await rest.json<GithubPrDetailRest[]>(
+          `repos/${repoKey}/pulls?state=all&head=${encodeURIComponent(`${owner}:${branch}`)}&per_page=1`,
+          undefined,
+          5_000,
+        ))[0])
+    }
+    if (!raw) return { known: true, pr: null }
+    rest.rememberVersion(`${repoKey}/pulls/${raw.number}`, raw.updated_at)
+    const reviews = await fetchPrRestReviews(ctx, repoKey, raw.number, 5_000)
     return {
       known: true,
       pr: {
         number: String(raw.number),
-        state: raw.state === 'MERGED' ? 'MERGED' : raw.state === 'CLOSED' ? 'CLOSED' : 'OPEN',
-        mergedAt: raw.mergedAt ?? null,
-        headRefName: String(raw.headRefName ?? branch),
-        url: String(raw.url ?? `https://github.com/${repoKey}/pull/${raw.number}`),
-        reviewDecision: raw.reviewDecision ?? null,
-        headRefOid: raw.headRefOid ? String(raw.headRefOid) : undefined,
-        baseRefName: raw.baseRefName ? String(raw.baseRefName) : undefined,
+        state: raw.merged_at ? 'MERGED' : String(raw.state).toUpperCase() === 'CLOSED' ? 'CLOSED' : 'OPEN',
+        mergedAt: raw.merged_at ?? null,
+        headRefName: String(raw.head?.ref ?? branch),
+        url: String(raw.html_url ?? `https://github.com/${repoKey}/pull/${raw.number}`),
+        reviewDecision: deriveReviewDecision(reviews),
+        headRefOid: raw.head?.sha ? String(raw.head.sha) : undefined,
+        baseRefName: raw.base?.ref ? String(raw.base.ref) : undefined,
       },
     }
-  } catch {
+  } catch (error) {
+    if (isGithubRateLimitError(error)) throw error
     return { known: false, pr: null }
   }
 }
@@ -1002,13 +1147,12 @@ async function fetchGithubIssueState(
   url: string,
 ): Promise<'OPEN' | 'CLOSED' | null> {
   try {
-    const output = await runCommand(
-      ctx,
-      `gh issue view ${shellQuote(url)} --json state --jq '.state'`,
-      { timeoutMs: 5_000 },
-    )
-    return output.trim().toUpperCase() === 'CLOSED' ? 'CLOSED' : 'OPEN'
-  } catch {
+    const parsed = parseUrl(url)
+    if (!parsed || parsed.kind !== 'issue') return null
+    const issue = await fetchIssueRestDetail(ctx, `${parsed.owner}/${parsed.repo}`, parsed.number, false, 5_000)
+    return String(issue.state).toUpperCase() === 'CLOSED' ? 'CLOSED' : 'OPEN'
+  } catch (error) {
+    if (isGithubRateLimitError(error)) throw error
     return null
   }
 }
@@ -1094,13 +1238,30 @@ interface RepositoryPrRest {
   number: number
   state: string
   merged_at: string | null
+  updated_at?: string
   html_url: string
   head?: { ref?: string }
 }
 
-function flattenGithubPages<T>(value: unknown): T[] {
-  if (!Array.isArray(value)) throw new Error('GitHub 分页返回格式无效')
-  return value.flatMap((page) => Array.isArray(page) ? page as T[] : [page as T])
+interface RepositoryGithubSnapshot {
+  issues: RepositoryIssueRest[]
+  pulls: RepositoryPrRest[]
+}
+
+async function fetchGithubRepoSnapshot(
+  ctx: Context,
+  repoKey: string,
+  ttlMs: number,
+  force: boolean,
+): Promise<RepositoryGithubSnapshot> {
+  const rest = githubRest(ctx)
+  return rest.cachedAggregate(`repo:${repoKey}`, ttlMs, force, async () => {
+    const [issues, pulls] = await Promise.all([
+      rest.paginate<RepositoryIssueRest>(`repos/${repoKey}/issues?state=all`),
+      rest.paginate<RepositoryPrRest>(`repos/${repoKey}/pulls?state=all`),
+    ])
+    return { issues, pulls }
+  })
 }
 
 export async function fetchRepositoryIssues(
@@ -1118,15 +1279,13 @@ export async function fetchRepositoryIssues(
   const forceRefresh = (payload as { forceRefresh?: unknown } | undefined)?.forceRefresh === true
   const freshness = await ensureConfiguredRepoFresh(ctx, config, repoKey, forceRefresh)
 
-  const issueCommand = `gh api --paginate --slurp ${shellQuote(`repos/${repoKey}/issues?state=all&per_page=100`)}`
-  const prCommand = `gh api --paginate --slurp ${shellQuote(`repos/${repoKey}/pulls?state=all&per_page=100`)}`
   try {
-    const [issueOutput, prOutput, allWorkflows] = await Promise.all([
-      runCommand(ctx, issueCommand, { timeoutMs: 30000 }),
-      runCommand(ctx, prCommand, { timeoutMs: 30000 }),
+    const rest = githubRest(ctx)
+    const [githubSnapshot, allWorkflows] = await Promise.all([
+      fetchGithubRepoSnapshot(ctx, repoKey, fetchTtlMs(config), forceRefresh),
       overrides.workflows ? Promise.resolve(overrides.workflows) : loadAllWorkflows(),
     ])
-    const allIssues = flattenGithubPages<RepositoryIssueRest>(JSON.parse(issueOutput))
+    const allIssues = githubSnapshot.issues
       .filter((issue) => issue.pull_request === undefined)
       .map<RepositoryIssueItem>((issue) => ({
         number: issue.number,
@@ -1138,7 +1297,7 @@ export async function fetchRepositoryIssues(
         labels: issue.labels,
         milestone: issue.milestone,
       }))
-    const prs = flattenGithubPages<RepositoryPrRest>(JSON.parse(prOutput)).map<GithubPrFact>((pr) => ({
+    const prs = githubSnapshot.pulls.map<GithubPrFact>((pr) => ({
       number: String(pr.number),
       state: pr.merged_at ? 'MERGED' : pr.state.toUpperCase() === 'CLOSED' ? 'CLOSED' : 'OPEN',
       mergedAt: pr.merged_at,
@@ -1146,6 +1305,8 @@ export async function fetchRepositoryIssues(
       url: pr.html_url,
       reviewDecision: null,
     }))
+    for (const issue of allIssues) rest.rememberVersion(`${repoKey}/issues/${issue.number}`, issue.updatedAt)
+    for (const pr of githubSnapshot.pulls) rest.rememberVersion(`${repoKey}/pulls/${pr.number}`, pr.updated_at)
 
     const issueByNumber = new Map(allIssues.map((issue) => [issue.number, issue]))
     const workflowByNumber = new Map(
@@ -1251,7 +1412,7 @@ export async function fetchRepositoryIssues(
     dependencyRefreshClock.mark(repoKey)
     return { ok: true, repoKey, issues, freshness }
   } catch (error) {
-    return { ok: false, error: `项目 issue 抓取失败: ${String(error instanceof Error ? error.message : error)}` }
+    return { ok: false, error: isGithubRateLimitError(error) ? error.message : `项目 issue 抓取失败: ${githubErrorMessage(error)}` }
   }
 }
 
@@ -1269,17 +1430,44 @@ async function fetchIssue(
     return { ok: false, error: '请输入形如 https://github.com/owner/repo/issues/123 或 /pull/123 的链接' }
   }
   const isPR = parsed.kind === 'pr'
-  const command = `${isPR ? 'gh pr view' : 'gh issue view'} ${url} --json ${isPR ? PR_FIELDS : ISSUE_FIELDS}`
   try {
-    const parsedJson = JSON.parse(await runCommand(ctx, command, { timeoutMs: 20000 })) as unknown
-    const data: { kind: 'issue' | 'pr'; item: unknown; timeline?: unknown; dependencies?: { blockedBy: IssueDependency[]; blocking: IssueDependency[] } } = { kind: parsed.kind, item: parsedJson }
+    const repoKey = `${parsed.owner}/${parsed.repo}`
+    const rest = githubRest(ctx)
+    const resourceKey = `${repoKey}/${isPR ? 'pulls' : 'issues'}/${parsed.number}`
+    const panelCacheKey = `${resourceKey}/panel`
+    const forceRefresh = (payload as { forceRefresh?: unknown } | undefined)?.forceRefresh === true
+    const detail = await rest.cachedResource(panelCacheKey, rest.resourceVersion(resourceKey), async () => {
+      if (isPR) {
+        const pr = await fetchPrRestDetail(ctx, repoKey, parsed.number, forceRefresh, 20_000)
+        const [comments, reviews, requested] = await Promise.all([
+          rest.paginate<GithubCommentRest>(`repos/${repoKey}/issues/${parsed.number}/comments`, undefined, 20_000),
+          fetchPrRestReviews(ctx, repoKey, parsed.number, 20_000),
+          rest.json<{ users?: GithubUserRest[]; teams?: Array<{ name?: string; slug?: string }> }>(`repos/${repoKey}/pulls/${parsed.number}/requested_reviewers`, undefined, 20_000),
+        ])
+        return { item: mapPrDetail(pr, comments, reviews, requested), updatedAt: pr.updated_at ?? '' }
+      }
+      const issue = await fetchIssueRestDetail(ctx, repoKey, parsed.number, forceRefresh, 20_000)
+      const [comments, timeline] = await Promise.all([
+        rest.paginate<GithubCommentRest>(`repos/${repoKey}/issues/${parsed.number}/comments`, undefined, 20_000),
+        fetchTimeline(ctx, parsed.owner, parsed.repo, parsed.number),
+      ])
+      return { item: mapIssueDetail(issue, comments), timeline, updatedAt: issue.updated_at ?? '' }
+    }, {
+      force: forceRefresh,
+      ttlMs: fetchTtlMs(await loadConfig()),
+      versionOf: (value) => value.updatedAt,
+    })
+    const data: { kind: 'issue' | 'pr'; item: unknown; timeline?: unknown; dependencies?: { blockedBy: IssueDependency[]; blocking: IssueDependency[] } } = {
+      kind: parsed.kind,
+      item: detail.item,
+      ...(detail.timeline ? { timeline: detail.timeline } : {}),
+    }
     let dependencyError: string | undefined
     // issue 额外拉 timeline,提取关联事件(linked PR/commit)——GitHub UI 的
     // "linked a pull request" 就来自 cross-referenced 事件
     if (!isPR) {
-      data.timeline = await fetchTimeline(ctx, parsed.owner, parsed.repo, parsed.number)
       // 依赖图:blockedBy 来自本 issue 正文,blocking 扫描 repo 内其它 issue
-      const dependencyResult = await fetchDependencies(ctx, parsed, parsedJson as { body?: unknown })
+      const dependencyResult = await fetchDependencies(ctx, parsed, detail.item as { body?: unknown }, forceRefresh)
       if (dependencyResult.ok) {
         data.dependencies = dependencyResult.dependencies
         dependencyRefreshClock.mark(`${parsed.owner}/${parsed.repo}`)
@@ -1289,7 +1477,7 @@ async function fetchIssue(
     }
     return { ok: true, data, ...(dependencyError ? { dependencyError } : {}) }
   } catch (error) {
-    return { ok: false, error: `抓取异常: ${String(error instanceof Error ? error.message : error)}` }
+    return { ok: false, error: isGithubRateLimitError(error) ? error.message : `抓取异常: ${githubErrorMessage(error)}` }
   }
 }
 
@@ -1320,15 +1508,10 @@ interface ReviewIssueContract {
 }
 
 /** Read the exact Issue contract that one review run evaluates. */
-async function fetchIssueContract(ctx: Context, url: string): Promise<ReviewIssueContract> {
+async function fetchIssueContract(ctx: Context, url: string, force = false): Promise<ReviewIssueContract> {
   const parsed = parseUrl(url)
   if (!parsed || parsed.kind !== 'issue') throw new Error('review workflow 缺少有效 Issue URL')
-  const output = await runCommand(
-    ctx,
-    `gh issue view ${shellQuote(url)} --json title,body,state,updatedAt`,
-    { timeoutMs: 5_000 },
-  )
-  const item = JSON.parse(output) as Record<string, unknown>
+  const item = await fetchIssueRestDetail(ctx, `${parsed.owner}/${parsed.repo}`, parsed.number, force, 5_000)
   const body = String(item.body ?? '')
   return {
     title: String(item.title ?? ''),
@@ -1336,7 +1519,7 @@ async function fetchIssueContract(ctx: Context, url: string): Promise<ReviewIssu
     state: String(item.state ?? '').toUpperCase(),
     contract: {
       bodyHash: issueBodyHash(body),
-      updatedAt: String(item.updatedAt ?? ''),
+      updatedAt: String(item.updated_at ?? ''),
     },
   }
 }
@@ -1366,7 +1549,7 @@ async function assertReviewContractCurrent(ctx: Context, workflow: IssueWorkflow
   }
   let current: ReviewIssueContract
   try {
-    current = await fetchIssueContract(ctx, workflow.url)
+    current = await fetchIssueContract(ctx, workflow.url, true)
   } catch (error) {
     throw new Error(`合并门禁拒绝:无法读取当前验收契约: ${String(error instanceof Error ? error.message : error)}`)
   }
@@ -1533,6 +1716,8 @@ async function mergeAndCleanupUnlocked(ctx: Context, payload: unknown): Promise<
       ].join(' ')
       try {
         await runCommand(ctx, command, { timeoutMs: 120_000 })
+        githubRest(ctx).invalidate(`${repoKey}/pulls/${pr.number}`)
+        githubRest(ctx).invalidate(`repo:${repoKey}`)
       } catch (error) {
         return { ok: false, error: `PR 合并失败: ${String(error instanceof Error ? error.message : error)}` }
       }
@@ -1636,6 +1821,8 @@ async function mergeAndCleanupUnlocked(ctx: Context, payload: unknown): Promise<
           `gh issue close ${shellQuote(parsed.number)} --repo ${shellQuote(repoKey)} --comment ${shellQuote(`由 PR #${pr.number} 以 merge commit 合并交付。`)}`,
           { timeoutMs: 30_000 },
         )
+        githubRest(ctx).invalidate(`${repoKey}/issues/${parsed.number}`)
+        githubRest(ctx).invalidate(`repo:${repoKey}`)
       }
       workflow.issueState = 'CLOSED'
       delivery.cleanup.issue = true
@@ -1672,18 +1859,26 @@ async function fetchDependencies(
   ctx: Context,
   target: { owner: string; repo: string; number: string },
   item: { body?: unknown },
+  forceRefresh = false,
 ): Promise<
   | { ok: true; dependencies: { blockedBy: IssueDependency[]; blocking: IssueDependency[] } }
   | { ok: false; error: string }
 > {
-  const command = `gh issue list --repo ${target.owner}/${target.repo} --state all --limit 100 --json number,title,state,body`
   let issues: { number: number; title: string; state: string; body: string }[] = []
   try {
-    const parsed = JSON.parse(await runCommand(ctx, command, { timeoutMs: 20000 })) as unknown
-    if (!Array.isArray(parsed)) throw new Error('GitHub 依赖列表格式无效')
-    issues = parsed as { number: number; title: string; state: string; body: string }[]
+    const config = await loadConfig()
+    const repoKey = `${target.owner}/${target.repo}`
+    const snapshot = await fetchGithubRepoSnapshot(ctx, repoKey, fetchTtlMs(config), forceRefresh)
+    issues = snapshot.issues
+      .filter((issue) => issue.pull_request === undefined)
+      .map((issue) => ({
+        number: issue.number,
+        title: issue.title,
+        state: String(issue.state).toUpperCase(),
+        body: issue.body ?? '',
+      }))
   } catch (error) {
-    return { ok: false, error: `GitHub 依赖刷新失败: ${String(error instanceof Error ? error.message : error)}` }
+    return { ok: false, error: isGithubRateLimitError(error) ? error.message : `GitHub 依赖刷新失败: ${githubErrorMessage(error)}` }
   }
 
   const current = Number(target.number)
@@ -1710,13 +1905,34 @@ async function fetchDependencies(
 
 /** Fetch the issue timeline and keep only the events worth showing. */
 async function fetchTimeline(ctx: Context, owner: string, repo: string, number: string): Promise<unknown[]> {
-  const command = `gh api repos/${owner}/${repo}/issues/${number}/timeline -H "Accept: application/vnd.github+json" --jq '[.[] | select(.event == "cross-referenced" or .event == "referenced" or .event == "connected" or .event == "closed" or .event == "reopened") | {event, created_at, actor: .actor.login, commit_id, source: (if .source then {number: .source.issue.number, title: .source.issue.title, html_url: .source.issue.html_url, state: .source.issue.state, is_pr: (.source.issue.pull_request != null), pr_merged: (.source.issue.pull_request.merged_at != null)} else null end)}]'`
   try {
-    const spec = ctx.shell.resolve({ command, timeoutMs: 15000 })
-    const result = await ctx.shell.run(spec)
-    if (result.exitCode !== 0) return []
-    return JSON.parse(result.stdout.text) as unknown[]
-  } catch {
+    const events = await githubRest(ctx).paginate<{
+      event?: string
+      created_at?: string
+      actor?: GithubUserRest | null
+      commit_id?: string | null
+      source?: { issue?: { number?: number; title?: string; html_url?: string; state?: string; pull_request?: { merged_at?: string | null } | null } } | null
+    }>(`repos/${owner}/${repo}/issues/${number}/timeline`, 'application/vnd.github+json', 15_000)
+    const visible = new Set(['cross-referenced', 'referenced', 'connected', 'closed', 'reopened'])
+    return events.filter((event) => visible.has(String(event.event ?? ''))).map((event) => {
+      const source = event.source?.issue
+      return {
+        event: event.event,
+        created_at: event.created_at,
+        actor: String(event.actor?.login ?? ''),
+        commit_id: event.commit_id ?? null,
+        source: source ? {
+          number: source.number,
+          title: source.title,
+          html_url: source.html_url,
+          state: source.state,
+          is_pr: source.pull_request != null,
+          pr_merged: source.pull_request?.merged_at != null,
+        } : null,
+      }
+    })
+  } catch (error) {
+    if (isGithubRateLimitError(error)) throw error
     return []
   }
 }
@@ -1733,19 +1949,16 @@ async function fetchPrPromptComments(
 ): Promise<{ author: string; body: string }[] | null> {
   if (!workflow.prNumber) return []
   try {
-    const spec = ctx.shell.resolve({
-      command: `gh pr view ${workflow.prNumber} --repo ${workflow.repoKey} --json comments`,
-      timeoutMs: 20000,
-    })
-    const result = await ctx.shell.run(spec)
-    if (result.exitCode !== 0) return null
-    const parsed = JSON.parse(result.stdout.text) as { comments?: unknown }
-    if (!Array.isArray(parsed.comments)) return null
-    return (parsed.comments as { author?: { login?: string } | null; body?: unknown }[]).map((comment) => ({
-      author: String(comment.author?.login ?? 'unknown'),
+    const rest = githubRest(ctx)
+    const key = `${workflow.repoKey}/pulls/${workflow.prNumber}`
+    const comments = await rest.cachedResource(`${key}/comments`, rest.resourceVersion(key), () =>
+      rest.paginate<GithubCommentRest>(`repos/${workflow.repoKey}/issues/${workflow.prNumber}/comments`))
+    return comments.map((comment) => ({
+      author: String(comment.user?.login ?? 'unknown'),
       body: String(comment.body ?? ''),
     }))
-  } catch {
+  } catch (error) {
+    if (isGithubRateLimitError(error)) throw error
     return null
   }
 }
@@ -1755,7 +1968,9 @@ async function resolvePromptSnapshot(
   ctx: Context,
   workflow: IssueWorkflow,
 ): Promise<ResolvedPromptSnapshot | { error: string }> {
-  const fetched = await fetchIssue(ctx, { url: workflow.url })
+  // A privileged stage start must revalidate the frozen authorization snapshot;
+  // this security boundary intentionally bypasses the display cache.
+  const fetched = await fetchIssue(ctx, { url: workflow.url, forceRefresh: true })
   if (fetched.ok) {
     const snapshot = issueSnapshot(fetched.data.item as Record<string, unknown>)
     const prComments = await fetchPrPromptComments(ctx, workflow)
@@ -1896,15 +2111,11 @@ async function buildResumePrompt(
 /** Fetch a PR's base ref name via gh. */
 async function fetchPrBase(ctx: Context, repoKey: string, prNumber: string): Promise<string | null> {
   try {
-    const spec = ctx.shell.resolve({
-      command: `gh pr view ${prNumber} --repo ${repoKey} --json baseRefName --jq '.baseRefName // ""'`,
-      timeoutMs: 15000,
-    })
-    const result = await ctx.shell.run(spec)
-    if (result.exitCode !== 0) return null
-    const name = result.stdout.text.trim()
+    const pr = await fetchPrRestDetail(ctx, repoKey, prNumber)
+    const name = String(pr.base?.ref ?? '').trim()
     return name === '' ? null : name
-  } catch {
+  } catch (error) {
+    if (isGithubRateLimitError(error)) throw error
     return null
   }
 }
@@ -1912,15 +2123,11 @@ async function fetchPrBase(ctx: Context, repoKey: string, prNumber: string): Pro
 /** Fetch a PR's head branch name via gh (to locate its worktree). */
 async function fetchPrHeadBranch(ctx: Context, owner: string, repo: string, prNumber: string): Promise<string | null> {
   try {
-    const spec = ctx.shell.resolve({
-      command: `gh pr view ${prNumber} --repo ${owner}/${repo} --json headRefName --jq '.headRefName // ""'`,
-      timeoutMs: 15000,
-    })
-    const result = await ctx.shell.run(spec)
-    if (result.exitCode !== 0) return null
-    const name = result.stdout.text.trim()
+    const pr = await fetchPrRestDetail(ctx, `${owner}/${repo}`, prNumber)
+    const name = String(pr.head?.ref ?? '').trim()
     return name === '' ? null : name
-  } catch {
+  } catch (error) {
+    if (isGithubRateLimitError(error)) throw error
     return null
   }
 }
@@ -2330,14 +2537,14 @@ async function startDevelop(
 
   let launchSnapshot: ResolvedPromptSnapshot | null = null
   if (agent === 'dryrun') {
-    const fetched = await fetchIssue(ctx, { url })
+    const fetched = await fetchIssue(ctx, { url, forceRefresh: true })
     if (!fetched.ok) return fetched
     const snapshot = issueSnapshot(fetched.data.item as Record<string, unknown>)
     if (snapshot.state !== 'OPEN') return { ok: false, error: '只有 OPEN Issue 可以执行 dryrun' }
   } else if (!authorizedSnapshot || authorizedSnapshot.url !== url || authorizedSnapshot.state !== 'OPEN') {
     return { ok: false, error: '缺少与该 OPEN Issue 绑定的服务端确认快照' }
   } else {
-    const fetched = await fetchIssue(ctx, { url })
+    const fetched = await fetchIssue(ctx, { url, forceRefresh: true })
     if (fetched.ok) {
       const current = issueSnapshot(fetched.data.item as Record<string, unknown>)
       if (!sameSnapshot(current, authorizedSnapshot)) {
@@ -2955,6 +3162,9 @@ async function publishDeliveryComment(
       status: 'posted',
       ...(commentUrl ? { url: commentUrl } : {}),
     }
+    const number = workflow.prNumber ?? parseUrl(workflow.url)?.number
+    if (number) githubRest(ctx).invalidate(`${workflow.repoKey}/${target === 'pr' ? 'pulls' : 'issues'}/${number}`)
+    githubRest(ctx).invalidate(`repo:${workflow.repoKey}`)
     await appendLog(workflow.key, event.kind === 'review' ? 'review' : 'dev', `[clickvibe] 已发布 GitHub ${target === 'pr' ? 'PR' : 'Issue'} 评论${event.publication.url ? `: ${event.publication.url}` : ''}`)
   } catch (error) {
     const message = String(error instanceof Error ? error.message : error).slice(0, 500)

--- a/tests/github-rest.test.ts
+++ b/tests/github-rest.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  GithubRateLimitError,
+  GithubRestReader,
+  deriveReviewDecision,
+} from '../src/github-rest.ts'
+
+function shellWith(responses: Array<{ exitCode: number; stdout: string; stderr?: string }>) {
+  const commands: string[] = []
+  return {
+    commands,
+    shell: {
+      resolve(spec: unknown) { return spec },
+      async run(spec: { command: string }) {
+        commands.push(spec.command)
+        const response = responses.shift()
+        if (!response) throw new Error(`unexpected command: ${spec.command}`)
+        return {
+          exitCode: response.exitCode,
+          stdout: { text: response.stdout },
+          stderr: { text: response.stderr ?? '' },
+        }
+      },
+    },
+  }
+}
+
+function included(body: unknown, headers: Record<string, string> = {}): string {
+  return [
+    'HTTP/2.0 200 OK',
+    ...Object.entries(headers).map(([name, value]) => `${name}: ${value}`),
+    '',
+    JSON.stringify(body),
+  ].join('\n')
+}
+
+test('REST reader only invokes gh api and reuses a resource while its known version is unchanged', async () => {
+  const fake = shellWith([{ exitCode: 0, stdout: included({ updated_at: 'v1', title: 'first' }, { etag: '"one"' }) }])
+  const reader = new GithubRestReader(fake as never)
+
+  const first = await reader.cachedResource('o/r/issues/1', 'v1', async () =>
+    reader.json<{ title: string }>('repos/o/r/issues/1'))
+  const second = await reader.cachedResource('o/r/issues/1', 'v1', async () =>
+    reader.json<{ title: string }>('repos/o/r/issues/1'))
+
+  assert.equal(first.title, 'first')
+  assert.equal(second, first)
+  assert.equal(fake.commands.length, 1)
+  assert.match(fake.commands[0], /^gh api /)
+})
+
+test('REST reader opens a circuit after rate limiting and reports the reset time without another request', async () => {
+  const resetAt = 1_800_000_000
+  const fake = shellWith([{
+    exitCode: 1,
+    stdout: [
+      'HTTP/2.0 403 Forbidden',
+      'x-ratelimit-remaining: 0',
+      `x-ratelimit-reset: ${resetAt}`,
+      '',
+      JSON.stringify({ message: 'API rate limit exceeded' }),
+    ].join('\n'),
+  }])
+  const reader = new GithubRestReader(fake as never)
+
+  await assert.rejects(() => reader.json('repos/o/r/issues/1'), GithubRateLimitError)
+  await assert.rejects(() => reader.json('repos/o/r/issues/2'), (error: unknown) => {
+    assert.ok(error instanceof GithubRateLimitError)
+    assert.equal(error.resetAt, resetAt * 1000)
+    assert.match(error.message, /^GitHub 额度已用完,约 \d{2}:\d{2} 恢复$/)
+    return true
+  })
+  assert.equal(fake.commands.length, 1)
+})
+
+test('review decision uses each reviewer latest decisive review', () => {
+  assert.equal(deriveReviewDecision([
+    { id: 1, user: { login: 'alice' }, state: 'CHANGES_REQUESTED', submitted_at: '2026-08-22T01:00:00Z' },
+    { id: 2, user: { login: 'alice' }, state: 'APPROVED', submitted_at: '2026-08-22T02:00:00Z' },
+    { id: 3, user: { login: 'bob' }, state: 'COMMENTED', submitted_at: '2026-08-22T03:00:00Z' },
+  ]), 'APPROVED')
+  assert.equal(deriveReviewDecision([
+    { id: 4, user: { login: 'alice' }, state: 'APPROVED', submitted_at: '2026-08-22T01:00:00Z' },
+    { id: 5, user: { login: 'bob' }, state: 'CHANGES_REQUESTED', submitted_at: '2026-08-22T02:00:00Z' },
+  ]), 'CHANGES_REQUESTED')
+  assert.equal(deriveReviewDecision([]), null)
+})

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -15,6 +15,84 @@ import {
   type IssueWorkflow,
 } from '../src/state.ts'
 
+function included(body: unknown, status = 200, headers: Record<string, string> = {}): string {
+  return [
+    `HTTP/2.0 ${status} ${status === 200 ? 'OK' : 'Error'}`,
+    ...Object.entries(headers).map(([name, value]) => `${name}: ${value}`),
+    '',
+    JSON.stringify(body),
+  ].join('\n')
+}
+
+function restIssue(item: Record<string, unknown>): Record<string, unknown> {
+  const url = String(item.url ?? item.html_url ?? '')
+  const number = Number(item.number ?? url.match(/\/(?:issues|pull)\/(\d+)/)?.[1] ?? 0)
+  return {
+    ...item,
+    number,
+    html_url: url,
+    url: undefined,
+    state: String(item.state ?? 'open').toLowerCase(),
+    user: item.author ?? item.user ?? { login: 'owner' },
+    created_at: item.createdAt ?? item.created_at ?? '',
+    updated_at: item.updatedAt ?? item.updated_at ?? '',
+    closed_at: item.closedAt ?? item.closed_at ?? null,
+  }
+}
+
+function restComment(comment: Record<string, unknown>): Record<string, unknown> {
+  return {
+    user: comment.author ?? comment.user ?? { login: 'unknown' },
+    body: comment.body ?? '',
+    created_at: comment.createdAt ?? comment.created_at ?? '',
+    updated_at: comment.updatedAt ?? comment.updated_at ?? '',
+  }
+}
+
+function githubApi(
+  command: string,
+  options: {
+    item?: Record<string, unknown>
+    issues?: Array<Record<string, unknown>>
+    pulls?: Array<Record<string, unknown>>
+    pr?: Record<string, unknown>
+    prComments?: Array<Record<string, unknown>>
+    reviews?: Array<Record<string, unknown>>
+    failRepoIssues?: string
+  } = {},
+): { exitCode: number; stdout: { text: string }; stderr: { text: string } } | null {
+  if (!command.startsWith('gh api ')) return null
+  let body: unknown = []
+  let exitCode = 0
+  let stderr = ''
+  if (/\/issues\?state=all/.test(command)) {
+    if (options.failRepoIssues) {
+      return { exitCode: 1, stdout: { text: included({ message: options.failRepoIssues }, 500) }, stderr: { text: options.failRepoIssues } }
+    }
+    body = (options.issues ?? []).map(restIssue)
+  } else if (/\/pulls\?state=all/.test(command)) {
+    body = options.pulls ?? []
+  } else if (/\/issues\/\d+\/comments/.test(command)) {
+    const commandNumber = command.match(/\/issues\/(\d+)\/comments/)?.[1]
+    const itemNumber = String(options.item?.number ?? String(options.item?.url ?? '').match(/\/issues\/(\d+)/)?.[1] ?? '')
+    const comments = commandNumber === itemNumber
+      ? (Array.isArray(options.item?.comments) ? options.item.comments as Array<Record<string, unknown>> : [])
+      : (options.prComments ?? [])
+    body = comments.map(restComment)
+  } else if (/\/issues\/\d+\/timeline/.test(command)) {
+    body = []
+  } else if (/\/pulls\/\d+\/reviews/.test(command)) {
+    body = options.reviews ?? []
+  } else if (/\/pulls\/\d+\/requested_reviewers/.test(command)) {
+    body = { users: [], teams: [] }
+  } else if (/\/pulls\/\d+/.test(command)) {
+    body = options.pr ?? {}
+  } else if (/\/issues\/\d+/.test(command)) {
+    body = restIssue(options.item ?? {})
+  }
+  return { exitCode, stdout: { text: included(body) }, stderr: { text: stderr } }
+}
+
 function createHandler(
   run?: (spec: { command: string; workdir?: string; stdin?: string; timeoutMs?: number }) => Promise<unknown>,
   start?: (spec: { command: string; workdir?: string; stdin?: string }) => unknown,
@@ -124,10 +202,8 @@ test('authorization route freezes the displayed snapshot and consumes tampered c
     title: 'snapshot title', body: 'snapshot body', state: 'OPEN',
     updatedAt: '2026-08-21T00:00:00Z', comments: [{ author: { login: 'owner' }, body: 'review note' }],
   }
-  const handler = createHandler(async (spec) => ({
-    exitCode: 0,
-    stdout: { text: spec.command.startsWith('gh issue view') ? JSON.stringify(item) : '[]' },
-    stderr: { text: '' },
+  const handler = createHandler(async (spec) => githubApi(spec.command, { item }) ?? ({
+    exitCode: 0, stdout: { text: '' }, stderr: { text: '' },
   }))
   const expectedSnapshot = {
     url: item.url, title: item.title, body: item.body, state: item.state,
@@ -164,13 +240,14 @@ test('development rejects a confirmed snapshot when the issue changes before sta
   }
   let issueReads = 0
   const handler = createHandler(async (spec) => {
-    if (spec.command.startsWith('gh issue view')) {
+    if (/gh api .*\/issues\/20'/.test(spec.command)) {
       issueReads += 1
-      return { exitCode: 0, stdout: { text: JSON.stringify(issueReads === 1 ? oldItem : {
+      const current = issueReads === 1 ? oldItem : {
         ...oldItem, body: 'new acceptance', updatedAt: '2026-08-22T06:00:00Z',
-      }) }, stderr: { text: '' } }
+      }
+      return githubApi(spec.command, { item: current })
     }
-    return { exitCode: 0, stdout: { text: '[]' }, stderr: { text: '' } }
+    return githubApi(spec.command, { item: oldItem }) ?? { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
   })
   const headers = { origin: 'same-origin', 'x-clickvibe-request': '1' }
   const authorized = await post(handler, '/clickvibe/api/authorize', {
@@ -222,14 +299,19 @@ test('/merge requires one-use authorization, exact reviewed HEAD, merge commit, 
     const commands: string[] = []
     const handler = createHandler(async (spec) => {
       commands.push(spec.command)
-      if (spec.command.startsWith('gh pr view')) return {
-        exitCode: 0,
-        stdout: { text: JSON.stringify({
-          number: 29, state: merged ? 'MERGED' : 'OPEN', mergedAt: merged ? '2026-08-22T01:00:00Z' : null,
-          headRefName: workflow.branch, headRefOid: 'abcdef1234567890', baseRefName: 'main',
-          url: 'https://github.com/o/r/pull/29', reviewDecision: 'APPROVED',
-        }) }, stderr: { text: '' },
-      }
+      const api = githubApi(spec.command, {
+        item: {
+          url: workflow.url, number: 23, title: 'merge issue', body: reviewedBody,
+          state: issueClosed ? 'CLOSED' : 'OPEN', updatedAt: '2026-08-22T00:00:00Z',
+        },
+        pr: {
+          number: 29, state: merged ? 'closed' : 'open', merged_at: merged ? '2026-08-22T01:00:00Z' : null,
+          head: { ref: workflow.branch, sha: 'abcdef1234567890' }, base: { ref: 'main' },
+          html_url: 'https://github.com/o/r/pull/29',
+        },
+        reviews: [{ id: 1, user: { login: 'reviewer' }, state: 'APPROVED', submitted_at: '2026-08-22T00:00:00Z' }],
+      })
+      if (api) return api
       if (spec.command.startsWith('gh pr merge')) {
         merged = true
         return { exitCode: 0, stdout: { text: 'merged' }, stderr: { text: '' } }
@@ -237,12 +319,6 @@ test('/merge requires one-use authorization, exact reviewed HEAD, merge commit, 
       if (spec.command === 'git worktree list --porcelain') return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
       if (spec.command.startsWith('if git show-ref')) return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
       if (spec.command.startsWith('if git ls-remote')) return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
-      if (spec.command.startsWith('gh issue view') && spec.command.includes('--json title,body,state,updatedAt')) {
-        return { exitCode: 0, stdout: { text: JSON.stringify({
-          title: 'merge issue', body: reviewedBody, state: issueClosed ? 'CLOSED' : 'OPEN', updatedAt: '2026-08-22T00:00:00Z',
-        }) }, stderr: { text: '' } }
-      }
-      if (spec.command.startsWith('gh issue view')) return { exitCode: 0, stdout: { text: issueClosed ? 'CLOSED' : 'OPEN' }, stderr: { text: '' } }
       if (spec.command.startsWith('gh issue close')) {
         issueClosed = true
         return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
@@ -326,13 +402,15 @@ test('/merge rejects a stale review hash before invoking gh pr merge', async () 
     const commands: string[] = []
     const handler = createHandler(async (spec) => {
       commands.push(spec.command)
-      if (spec.command.startsWith('gh pr view')) return {
-        exitCode: 0,
-        stdout: { text: JSON.stringify({
-          number: 29, state: 'OPEN', mergedAt: null, headRefName: workflow.branch,
-          headRefOid: '2222222222222222', baseRefName: 'main', url: 'https://github.com/o/r/pull/29', reviewDecision: 'APPROVED',
-        }) }, stderr: { text: '' },
-      }
+      const api = githubApi(spec.command, {
+        pr: {
+          number: 29, state: 'open', merged_at: null,
+          head: { ref: workflow.branch, sha: '2222222222222222' }, base: { ref: 'main' },
+          html_url: 'https://github.com/o/r/pull/29',
+        },
+        reviews: [{ id: 1, user: { login: 'reviewer' }, state: 'APPROVED', submitted_at: '2026-08-22T00:00:00Z' }],
+      })
+      if (api) return api
       throw new Error(`unexpected command: ${spec.command}`)
     })
     const headers = { origin: 'same-origin', 'x-clickvibe-request': '1' }
@@ -368,19 +446,19 @@ test('/merge authorization rejects a changed acceptance contract with the same P
     const commands: string[] = []
     const handler = createHandler(async (spec) => {
       commands.push(spec.command)
-      if (spec.command.startsWith('gh pr view')) return {
-        exitCode: 0,
-        stdout: { text: JSON.stringify({
-          number: 29, state: 'OPEN', mergedAt: null, headRefName: workflow.branch,
-          headRefOid: 'abcdef1234567890', baseRefName: 'main', url: 'https://github.com/o/r/pull/29', reviewDecision: 'APPROVED',
-        }) }, stderr: { text: '' },
-      }
-      if (spec.command.startsWith('gh issue view')) return {
-        exitCode: 0,
-        stdout: { text: JSON.stringify({
-          title: 'changed issue', body: '## 验收标准\n- changed contract', state: 'OPEN', updatedAt: '2026-08-22T01:00:00Z',
-        }) }, stderr: { text: '' },
-      }
+      const api = githubApi(spec.command, {
+        item: {
+          url: workflow.url, number: 23, title: 'changed issue', body: '## 验收标准\n- changed contract',
+          state: 'OPEN', updatedAt: '2026-08-22T01:00:00Z',
+        },
+        pr: {
+          number: 29, state: 'open', merged_at: null,
+          head: { ref: workflow.branch, sha: 'abcdef1234567890' }, base: { ref: 'main' },
+          html_url: 'https://github.com/o/r/pull/29',
+        },
+        reviews: [{ id: 1, user: { login: 'reviewer' }, state: 'APPROVED', submitted_at: '2026-08-22T00:00:00Z' }],
+      })
+      if (api) return api
       throw new Error(`unexpected command: ${spec.command}`)
     })
     const result = await post(handler, '/clickvibe/api/authorize', {
@@ -423,14 +501,19 @@ test('cleanup failure keeps merged terminal state and retries without merging ag
     const commands: string[] = []
     const handler = createHandler(async (spec) => {
       commands.push(spec.command)
-      if (spec.command.startsWith('gh pr view')) return {
-        exitCode: 0,
-        stdout: { text: JSON.stringify({
-          number: 29, state: merged ? 'MERGED' : 'OPEN', mergedAt: merged ? '2026-08-22T01:00:00Z' : null,
-          headRefName: workflow.branch, headRefOid: 'abcdef1234567890', baseRefName: 'main',
-          url: 'https://github.com/o/r/pull/29', reviewDecision: 'APPROVED',
-        }) }, stderr: { text: '' },
-      }
+      const api = githubApi(spec.command, {
+        item: {
+          url: workflow.url, number: 23, title: 'merge issue', body: reviewedBody,
+          state: 'CLOSED', updatedAt: '2026-08-22T00:00:00Z',
+        },
+        pr: {
+          number: 29, state: merged ? 'closed' : 'open', merged_at: merged ? '2026-08-22T01:00:00Z' : null,
+          head: { ref: workflow.branch, sha: 'abcdef1234567890' }, base: { ref: 'main' },
+          html_url: 'https://github.com/o/r/pull/29',
+        },
+        reviews: [{ id: 1, user: { login: 'reviewer' }, state: 'APPROVED', submitted_at: '2026-08-22T00:00:00Z' }],
+      })
+      if (api) return api
       if (spec.command.startsWith('gh pr merge')) {
         merged = true
         return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
@@ -445,12 +528,6 @@ test('cleanup failure keeps merged terminal state and retries without merging ag
       if (spec.command.startsWith('if git show-ref') || spec.command.startsWith('if git ls-remote')) {
         return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
       }
-      if (spec.command.startsWith('gh issue view') && spec.command.includes('--json title,body,state,updatedAt')) {
-        return { exitCode: 0, stdout: { text: JSON.stringify({
-          title: 'merge issue', body: reviewedBody, state: 'OPEN', updatedAt: '2026-08-22T00:00:00Z',
-        }) }, stderr: { text: '' } }
-      }
-      if (spec.command.startsWith('gh issue view')) return { exitCode: 0, stdout: { text: 'CLOSED' }, stderr: { text: '' } }
       throw new Error(`unexpected command: ${spec.command}`)
     })
     const headers = { origin: 'same-origin', 'x-clickvibe-request': '1' }
@@ -497,14 +574,15 @@ test('/state uses the live GitHub issue state instead of the stored issueState',
     workflow.issueState = 'OPEN'
     await saveWorkflow(workflow)
     const handler = createHandler(async (spec) => {
-      if (spec.command.startsWith('gh pr view')) return {
-        exitCode: 0,
-        stdout: { text: JSON.stringify({
-          number: 29, state: 'OPEN', mergedAt: null, headRefName: workflow.branch,
-          headRefOid: 'abcdef1234567890', baseRefName: 'main', url: 'https://github.com/o/r/pull/29', reviewDecision: null,
-        }) }, stderr: { text: '' },
-      }
-      if (spec.command.startsWith('gh issue view')) return { exitCode: 0, stdout: { text: 'CLOSED' }, stderr: { text: '' } }
+      const api = githubApi(spec.command, {
+        item: { url: workflow.url, number: 23, state: 'CLOSED' },
+        pr: {
+          number: 29, state: 'open', merged_at: null,
+          head: { ref: workflow.branch, sha: 'abcdef1234567890' }, base: { ref: 'main' },
+          html_url: 'https://github.com/o/r/pull/29',
+        },
+      })
+      if (api) return api
       throw new Error(`unexpected command: ${spec.command}`)
     })
     const response = await post(handler, '/clickvibe/api/state', { url: workflow.url }) as {
@@ -546,8 +624,8 @@ test('/state and repo/issues share one repository fetch TTL while manual refresh
         fetches++
         return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
       }
-      if (command.includes('/issues?') || command.includes('/pulls?')) {
-        return { exitCode: 0, stdout: { text: '[[]]' }, stderr: { text: '' } }
+      if (command.startsWith('gh api ')) {
+        return githubApi(command)
       }
       if (command.startsWith('git for-each-ref') || command.startsWith('git symbolic-ref')) {
         return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
@@ -688,8 +766,8 @@ test('a rejected dry-run worktree attempt preserves the previous durable dev his
       state: 'OPEN', updatedAt: 'now', comments: [],
     }
     const handler = createHandler(async ({ command }) => {
-      if (command.startsWith('gh issue view')) return { exitCode: 0, stdout: { text: JSON.stringify(issue) }, stderr: { text: '' } }
-      if (command.startsWith('gh api') || command.startsWith('gh issue list')) return { exitCode: 0, stdout: { text: '[]' }, stderr: { text: '' } }
+      const api = githubApi(command, { item: issue })
+      if (api) return api
       if (command === 'git fetch origin --prune') return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
       if (command === 'git symbolic-ref --quiet --short refs/remotes/origin/HEAD') return { exitCode: 0, stdout: { text: 'origin/main' }, stderr: { text: '' } }
       if (command === "git rev-parse --short 'origin/main'") return { exitCode: 0, stdout: { text: 'abc123' }, stderr: { text: '' } }
@@ -807,17 +885,14 @@ test('invalid exact dev session falls back once to a fresh session on the same t
     await appendLog(workflow.key, 'dev', 'prior run must be rotated')
     const starts: Array<{ command: string; workdir?: string; prompt: string }> = []
     const comments: Array<{ command: string; body: string }> = []
+    const currentIssue = {
+      url: workflow.url, title: 'resume issue', body: '## 验收标准\n- fallback', state: 'OPEN', updatedAt: 'now',
+      comments: [],
+    }
+    const reviewComments = [{ author: { login: 'review-bot' }, body: '== Review Meta ==\n- event: review\n- passed: false\n\n- 修复竞态\n- 补充失败测试' }]
     const handler = createHandler(async (spec) => {
-      if (spec.command.startsWith('gh issue view')) return { exitCode: 0, stdout: { text: JSON.stringify({
-        url: workflow.url, title: 'resume issue', body: '## 验收标准\n- fallback', state: 'OPEN', updatedAt: 'now',
-        comments: [],
-      }) }, stderr: { text: '' } }
-      if (spec.command === 'gh pr view 29 --repo o/r --json comments') return { exitCode: 0, stdout: { text: JSON.stringify({
-        comments: [{ author: { login: 'review-bot' }, body: '== Review Meta ==\n- event: review\n- passed: false\n\n- 修复竞态\n- 补充失败测试' }],
-      }) }, stderr: { text: '' } }
-      if (spec.command.startsWith('gh api') || spec.command.startsWith('gh issue list')) {
-        return { exitCode: 0, stdout: { text: '[]' }, stderr: { text: '' } }
-      }
+      const api = githubApi(spec.command, { item: currentIssue, prComments: reviewComments })
+      if (api) return api
       if (spec.command === 'git rev-parse --short HEAD') return { exitCode: 0, stdout: { text: 'abc123' }, stderr: { text: '' } }
       if (spec.command.startsWith('gh issue comment')) {
         comments.push({ command: spec.command, body: spec.stdin ?? '' })
@@ -895,12 +970,14 @@ test('completed development without a PR appends its Dev Meta comment to the iss
     const comments: Array<{ command: string; body: string }> = []
     const prompts: string[] = []
     const handler = createHandler(async (spec) => {
+      if (/gh api .*\/issues\/920'/.test(spec.command)) {
+        return { exitCode: 1, stdout: { text: included({ message: 'offline' }, 500) }, stderr: { text: 'offline' } }
+      }
       if (spec.command === 'git rev-parse --short HEAD') {
         return { exitCode: 0, stdout: { text: 'def4567' }, stderr: { text: '' } }
       }
-      if (spec.command.startsWith('gh pr list')) {
-        return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
-      }
+      const api = githubApi(spec.command)
+      if (api) return api
       if (spec.command.startsWith('gh issue comment')) {
         comments.push({ command: spec.command, body: spec.stdin ?? '' })
         return { exitCode: 0, stdout: { text: 'https://github.com/o/r/issues/920#issuecomment-3' }, stderr: { text: '' } }
@@ -963,15 +1040,18 @@ test('concurrent resume requests reserve one workflow task before refreshing the
     await saveWorkflow(workflow)
     let issueReads = 0
     let starts = 0
+    const currentIssue = {
+      url: workflow.url, title: 'resume gate', body: '## 验收标准\n- one task',
+      state: 'OPEN', updatedAt: '2026-08-22T07:00:00Z', comments: [],
+    }
     const handler = createHandler(async (spec) => {
-      if (spec.command.startsWith('gh issue view')) {
+      if (/gh api .*\/issues\/930'/.test(spec.command)) {
         issueReads += 1
         await new Promise((resolve) => setTimeout(resolve, 25))
-        return { exitCode: 0, stdout: { text: JSON.stringify({
-          url: workflow.url, title: 'resume gate', body: '## 验收标准\n- one task',
-          state: 'OPEN', updatedAt: '2026-08-22T07:00:00Z', comments: [],
-        }) }, stderr: { text: '' } }
+        return githubApi(spec.command, { item: currentIssue })
       }
+      const api = githubApi(spec.command, { item: currentIssue })
+      if (api) return api
       if (spec.command.startsWith('gh issue comment')) {
         return { exitCode: 0, stdout: { text: 'https://github.com/o/r/issues/930#issuecomment-1' }, stderr: { text: '' } }
       }
@@ -1091,20 +1171,25 @@ test('invalid exact review session clears the stale id and falls back to a fresh
     const reviewedBody = '## 验收标准\n- frozen review contract'
     const reviewedUpdatedAt = '2026-08-22T01:02:03Z'
     const issueSpill = join(tempHome, 'issue-contract.json')
-    await writeFile(issueSpill, JSON.stringify({
-      url: workflow.url,
+    const currentIssue = {
+      url: workflow.url, number: 918,
       title: 'review issue', body: reviewedBody, state: 'OPEN', updatedAt: reviewedUpdatedAt,
       comments: [{ author: { login: 'bot' }, body: 'related note' }],
-    }))
+    }
+    await writeFile(issueSpill, included(restIssue(currentIssue)))
     let reviewFetches = 0
     const comments: Array<{ command: string; body: string }> = []
     const issueTimeouts: number[] = []
+    const pr = {
+      number: 29, state: 'open', html_url: 'https://github.com/o/r/pull/29', updated_at: reviewedUpdatedAt,
+      base: { ref: 'main' }, head: { ref: workflow.branch },
+    }
     const handler = createHandler(async (spec) => {
       if (spec.command === 'git fetch origin --prune') {
         reviewFetches++
         return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
       }
-      if (spec.command.startsWith('gh issue view')) {
+      if (/gh api .*\/issues\/918'/.test(spec.command)) {
         issueTimeouts.push(spec.timeoutMs ?? 0)
         return {
           exitCode: 0,
@@ -1112,7 +1197,8 @@ test('invalid exact review session clears the stale id and falls back to a fresh
           stderr: { text: '' },
         }
       }
-      if (spec.command.startsWith('gh pr view')) return { exitCode: 0, stdout: { text: 'main' }, stderr: { text: '' } }
+      const api = githubApi(spec.command, { item: currentIssue, pr })
+      if (api) return api
       if (spec.command === 'git rev-parse --short HEAD') return { exitCode: 0, stdout: { text: 'abc123' }, stderr: { text: '' } }
       if (spec.command.startsWith('gh issue comment')) {
         comments.push({ command: spec.command, body: spec.stdin ?? '' })
@@ -1205,16 +1291,22 @@ test('duplicate review requests reuse the reserved task before fetching the Issu
     const issueBlocked = new Promise<void>((resolve) => { releaseIssue = resolve })
     let finishProcess!: () => void
     const processDone = new Promise<void>((resolve) => { finishProcess = resolve })
+    const currentIssue = {
+      url: workflow.url, number: 920, title: 'review issue', body: '## 验收标准\n- gate',
+      state: 'OPEN', updatedAt: '2026-08-22T03:04:05Z', comments: [],
+    }
     const handler = createHandler(async (spec) => {
-      if (spec.command.startsWith('gh issue view')) {
+      if (/gh api .*\/issues\/920'/.test(spec.command)) {
         issueCalls += 1
         notifyIssueEntered()
         await issueBlocked
-        return { exitCode: 0, stdout: { text: JSON.stringify({
-          url: workflow.url, title: 'review issue', body: '## 验收标准\n- gate', state: 'OPEN', updatedAt: '2026-08-22T03:04:05Z',
-        }) }, stderr: { text: '' } }
+        return githubApi(spec.command, { item: currentIssue })
       }
-      if (spec.command.startsWith('gh pr view')) return { exitCode: 0, stdout: { text: 'main' }, stderr: { text: '' } }
+      const api = githubApi(spec.command, {
+        item: currentIssue,
+        pr: { number: 29, state: 'open', html_url: 'https://github.com/o/r/pull/29', base: { ref: 'main' }, head: { ref: workflow.branch } },
+      })
+      if (api) return api
       if (spec.command === 'git rev-parse --short HEAD') return { exitCode: 0, stdout: { text: 'gate123' }, stderr: { text: '' } }
       return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
     }, () => ({
@@ -1275,10 +1367,11 @@ test('cross-agent review starts fresh and an empty failed verdict requires re-re
     const starts: string[] = []
     const reviewedBody = '## 验收标准\n- current contract'
     const handler = createHandler(async (spec) => {
-      if (spec.command.startsWith('gh issue view')) return { exitCode: 0, stdout: { text: JSON.stringify({
-        url: workflow.url, title: 'review issue', body: reviewedBody, state: 'OPEN', updatedAt: '2026-08-22T02:03:04Z',
-      }) }, stderr: { text: '' } }
-      if (spec.command.startsWith('gh pr view')) return { exitCode: 0, stdout: { text: 'main' }, stderr: { text: '' } }
+      const api = githubApi(spec.command, {
+        item: { url: workflow.url, number: 919, title: 'review issue', body: reviewedBody, state: 'OPEN', updatedAt: '2026-08-22T02:03:04Z' },
+        pr: { number: 29, base: { ref: 'main' }, head: { ref: workflow.branch } },
+      })
+      if (api) return api
       if (spec.command === 'git rev-parse --short HEAD') return { exitCode: 0, stdout: { text: 'def456' }, stderr: { text: '' } }
       return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
     }, (spec) => {
@@ -1341,13 +1434,7 @@ test('/fetch resolves blockedBy from the body and blocking from a repo scan', as
     { number: 8, title: 'issue 8', state: 'OPEN', body: '## 依赖\n\nBlocked by #7' },
   ]
   const handler = createHandler(async (spec) => {
-    if (spec.command.startsWith('gh issue view')) {
-      return { exitCode: 0, stdout: { text: JSON.stringify(item) }, stderr: { text: '' } }
-    }
-    if (spec.command.startsWith('gh issue list')) {
-      return { exitCode: 0, stdout: { text: JSON.stringify(issues) }, stderr: { text: '' } }
-    }
-    return { exitCode: 0, stdout: { text: '[]' }, stderr: { text: '' } }
+    return githubApi(spec.command, { item, issues }) ?? { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
   })
   const result = await post(handler, '/clickvibe/api/fetch', { url: item.url })
   assert.equal(result.status, 200, JSON.stringify(result.body))
@@ -1368,13 +1455,7 @@ test('/fetch on an issue without a 依赖 section yields no blockedBy (and no bl
     { number: 7, title: 'issue 7', state: 'OPEN', body: '## 依赖\n\nBlocked by #5' },
   ]
   const handler = createHandler(async (spec) => {
-    if (spec.command.startsWith('gh issue view')) {
-      return { exitCode: 0, stdout: { text: JSON.stringify(item) }, stderr: { text: '' } }
-    }
-    if (spec.command.startsWith('gh issue list')) {
-      return { exitCode: 0, stdout: { text: JSON.stringify(issues) }, stderr: { text: '' } }
-    }
-    return { exitCode: 0, stdout: { text: '[]' }, stderr: { text: '' } }
+    return githubApi(spec.command, { item, issues }) ?? { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
   })
   const result = await post(handler, '/clickvibe/api/fetch', { url: item.url })
   assert.equal(result.status, 200)
@@ -1391,15 +1472,8 @@ test('/fetch keeps issue data but reports dependency refresh failure without inv
     body: '## 依赖\n\nBlocked by #4', comments: [],
   }
   const handler = createHandler(async (spec) => {
-    if (spec.command.startsWith('gh issue view')) {
-      return { exitCode: 0, stdout: { text: JSON.stringify(item) }, stderr: { text: '' } }
-    }
-    if (spec.command.startsWith('gh issue list')) {
-      return { exitCode: 1, stdout: { text: '' }, stderr: { text: 'offline' } }
-    }
-    if (spec.command.startsWith('gh api')) {
-      return { exitCode: 0, stdout: { text: '[]' }, stderr: { text: '' } }
-    }
+    const api = githubApi(spec.command, { item, failRepoIssues: 'offline' })
+    if (api) return api
     throw new Error(`unexpected command: ${spec.command}`)
   })
 
@@ -1409,6 +1483,98 @@ test('/fetch keeps issue data but reports dependency refresh failure without inv
   assert.equal(result.body.ok, true)
   assert.match((result.body as { dependencyError?: string }).dependencyError ?? '', /offline/)
   assert.equal((result.body as { data?: { dependencies?: unknown } }).data?.dependencies, undefined)
+})
+
+test('/fetch maps PR REST fields and latest reviews without any GraphQL read command', async () => {
+  const url = 'https://github.com/o/r/pull/41'
+  const commands: string[] = []
+  const pr = {
+    number: 41, title: 'REST PR', state: 'open', body: 'body', html_url: url,
+    user: { login: 'author' }, created_at: '2026-08-22T01:00:00Z', updated_at: '2026-08-22T02:00:00Z',
+    additions: 12, deletions: 3, changed_files: 2, commits: 4, draft: false,
+    mergeable: true, mergeable_state: 'clean', base: { ref: 'main' }, head: { ref: 'feature', sha: 'abc123' },
+  }
+  const reviews = [
+    { id: 1, user: { login: 'alice' }, state: 'CHANGES_REQUESTED', submitted_at: '2026-08-22T02:00:00Z' },
+    { id: 2, user: { login: 'alice' }, state: 'APPROVED', submitted_at: '2026-08-22T03:00:00Z' },
+  ]
+  const handler = createHandler(async (spec) => {
+    commands.push(spec.command)
+    const api = githubApi(spec.command, {
+      pr,
+      reviews,
+      prComments: [{ author: { login: 'commenter' }, body: 'looks good', createdAt: '2026-08-22T03:00:00Z' }],
+    })
+    if (api) return api
+    throw new Error(`unexpected command: ${spec.command}`)
+  })
+
+  const first = await post(handler, '/clickvibe/api/fetch', { url }) as {
+    status: number
+    body: { ok: boolean; data?: { item?: Record<string, unknown> } }
+  }
+  assert.equal(first.status, 200, JSON.stringify(first.body))
+  assert.equal(first.body.data?.item?.reviewDecision, 'APPROVED')
+  assert.equal(first.body.data?.item?.changedFiles, 2)
+  assert.equal(first.body.data?.item?.baseRefName, 'main')
+  assert.equal((first.body.data?.item?.comments as unknown[])?.length, 1)
+  assert.ok(commands.length >= 4)
+  assert.ok(commands.every((command) => command.startsWith('gh api ')))
+
+  const readsAfterFirst = commands.length
+  const second = await post(handler, '/clickvibe/api/fetch', { url })
+  assert.equal(second.status, 200)
+  assert.equal(commands.length, readsAfterFirst, 'unchanged PR detail should be served entirely from cache')
+})
+
+test('rate-limit response opens a circuit and returns the friendly recovery time on later routes', async () => {
+  const reset = Math.floor((Date.now() + 10 * 60_000) / 1000)
+  let requests = 0
+  const handler = createHandler(async () => {
+    requests++
+    return {
+      exitCode: 1,
+      stdout: { text: [
+        'HTTP/2.0 403 Forbidden',
+        'x-ratelimit-remaining: 0',
+        `x-ratelimit-reset: ${reset}`,
+        '',
+        JSON.stringify({ message: 'API rate limit exceeded' }),
+      ].join('\n') },
+      stderr: { text: '' },
+    }
+  })
+
+  const first = await post(handler, '/clickvibe/api/fetch', { url: 'https://github.com/o/r/issues/41' })
+  const second = await post(handler, '/clickvibe/api/state', { repoKey: 'o/r' })
+  assert.equal(first.status, 429)
+  assert.equal(second.status, 429)
+  assert.match(first.body.error ?? '', /^GitHub 额度已用完,约 \d{2}:\d{2} 恢复$/)
+  assert.equal(second.body.error, first.body.error)
+  assert.equal(requests, 1, 'open circuit must reject without another GitHub request')
+})
+
+test('repository GitHub aggregation uses its short TTL cache and force refresh bypasses it', async () => {
+  const issue = { number: 1, title: 'cached', state: 'open', body: '', html_url: 'https://github.com/o/r/issues/1' }
+  const commands: string[] = []
+  const ctx = {
+    shell: {
+      resolve(spec: unknown) { return spec },
+      async run(spec: { command: string }) {
+        commands.push(spec.command)
+        if (spec.command.includes('/issues?')) return { exitCode: 0, stdout: { text: included([issue]) }, stderr: { text: '' } }
+        if (spec.command.includes('/pulls?')) return { exitCode: 0, stdout: { text: included([]) }, stderr: { text: '' } }
+        throw new Error(`unexpected command: ${spec.command}`)
+      },
+    },
+  }
+  const overrides = { config: { repos: { 'o/r': '/remote/r' }, worktreeRoot: '/remote/worktrees' }, workflows: [] }
+
+  assert.equal((await fetchRepositoryIssues(ctx as never, { repoKey: 'o/r' }, overrides)).ok, true)
+  assert.equal((await fetchRepositoryIssues(ctx as never, { repoKey: 'o/r' }, overrides)).ok, true)
+  assert.equal(commands.length, 2)
+  assert.equal((await fetchRepositoryIssues(ctx as never, { repoKey: 'o/r', forceRefresh: true }, overrides)).ok, true)
+  assert.equal(commands.length, 4)
 })
 
 test('repo issue aggregation includes open issues without workflows and honors live merged PR state', async () => {
@@ -1424,8 +1590,8 @@ test('repo issue aggregation includes open issues without workflows and honors l
     shell: {
       resolve(spec: unknown) { return spec },
       async run(spec: { command: string }) {
-        if (spec.command.includes('/issues?')) return { exitCode: 0, stdout: { text: JSON.stringify([allIssues]) }, stderr: { text: '' } }
-        if (spec.command.includes('/pulls?')) return { exitCode: 0, stdout: { text: JSON.stringify([prs]) }, stderr: { text: '' } }
+        if (spec.command.includes('/issues?')) return { exitCode: 0, stdout: { text: included(allIssues) }, stderr: { text: '' } }
+        if (spec.command.includes('/pulls?')) return { exitCode: 0, stdout: { text: included(prs) }, stderr: { text: '' } }
         throw new Error(`unexpected command: ${spec.command}`)
       },
     },
@@ -1468,15 +1634,18 @@ test('repo aggregation keeps a closed issue visible while merged cleanup is pend
     shell: {
       resolve(spec: unknown) { return spec },
       async run(spec: { command: string }) {
-        if (spec.command.includes('/issues?')) return { exitCode: 0, stdout: { text: JSON.stringify([[issue]]) }, stderr: { text: '' } }
-        if (spec.command.includes('/pulls?')) return { exitCode: 0, stdout: { text: JSON.stringify([[
+        if (spec.command.includes('/issues?')) return { exitCode: 0, stdout: { text: included([issue]) }, stderr: { text: '' } }
+        if (spec.command.includes('/pulls?')) return { exitCode: 0, stdout: { text: included([
           { number: 29, state: 'closed', merged_at: '2026-08-22T00:00:00Z', head: { ref: workflow.branch }, html_url: 'https://github.com/o/r/pull/29' },
-        ]]) }, stderr: { text: '' } }
-        if (spec.command.startsWith('gh pr view')) return {
+        ]) }, stderr: { text: '' } }
+        if (spec.command.includes('/pulls/29/reviews')) return { exitCode: 0, stdout: { text: included([
+          { id: 1, user: { login: 'reviewer' }, state: 'APPROVED', submitted_at: '2026-08-22T00:00:00Z' },
+        ]) }, stderr: { text: '' } }
+        if (spec.command.includes('/pulls/29')) return {
           exitCode: 0,
-          stdout: { text: JSON.stringify({
-            number: 29, state: 'MERGED', mergedAt: '2026-08-22T00:00:00Z', headRefName: workflow.branch,
-            headRefOid: 'abcdef1', baseRefName: 'main', url: 'https://github.com/o/r/pull/29', reviewDecision: 'APPROVED',
+          stdout: { text: included({
+            number: 29, state: 'closed', merged_at: '2026-08-22T00:00:00Z',
+            head: { ref: workflow.branch, sha: 'abcdef1' }, base: { ref: 'main' }, html_url: 'https://github.com/o/r/pull/29',
           }) }, stderr: { text: '' },
         }
         throw new Error(`unexpected command: ${spec.command}`)
@@ -1507,9 +1676,9 @@ test('repo issue aggregation fails closed when a stored PR cannot be refreshed b
     shell: {
       resolve(spec: unknown) { return spec },
       async run(spec: { command: string }) {
-        if (spec.command.includes('/issues?')) return { exitCode: 0, stdout: { text: JSON.stringify([[issue]]) }, stderr: { text: '' } }
-        if (spec.command.includes('/pulls?')) return { exitCode: 0, stdout: { text: '[[]]' }, stderr: { text: '' } }
-        if (spec.command.startsWith('gh pr view')) return { exitCode: 1, stdout: { text: '' }, stderr: { text: 'offline' } }
+        if (spec.command.includes('/issues?')) return { exitCode: 0, stdout: { text: included([issue]) }, stderr: { text: '' } }
+        if (spec.command.includes('/pulls?')) return { exitCode: 0, stdout: { text: included([]) }, stderr: { text: '' } }
+        if (spec.command.includes('/pulls/99')) return { exitCode: 1, stdout: { text: included({ message: 'offline' }, 500) }, stderr: { text: 'offline' } }
         throw new Error(`unexpected command: ${spec.command}`)
       },
     },
@@ -1540,11 +1709,12 @@ test('repo issue aggregation refreshes stored PR by number when its head no long
     shell: {
       resolve(spec: unknown) { return spec },
       async run(spec: { command: string }) {
-        if (spec.command.includes('/issues?')) return { exitCode: 0, stdout: { text: JSON.stringify([[issue]]) }, stderr: { text: '' } }
-        if (spec.command.includes('/pulls?')) return { exitCode: 0, stdout: { text: '[[]]' }, stderr: { text: '' } }
-        if (spec.command.startsWith("gh pr view '99'")) return {
+        if (spec.command.includes('/issues?')) return { exitCode: 0, stdout: { text: included([issue]) }, stderr: { text: '' } }
+        if (spec.command.includes('/pulls?')) return { exitCode: 0, stdout: { text: included([]) }, stderr: { text: '' } }
+        if (spec.command.includes('/pulls/99/reviews')) return { exitCode: 0, stdout: { text: included([{ id: 1, user: { login: 'reviewer' }, state: 'APPROVED', submitted_at: '2026-08-22T01:00:00Z' }]) }, stderr: { text: '' } }
+        if (spec.command.includes('/pulls/99')) return {
           exitCode: 0,
-          stdout: { text: JSON.stringify({ number: 99, state: 'MERGED', mergedAt: '2026-08-22T00:00:00Z', headRefName: 'new-branch-name', url: 'https://github.com/o/r/pull/99', reviewDecision: 'APPROVED' }) },
+          stdout: { text: included({ number: 99, state: 'closed', merged_at: '2026-08-22T00:00:00Z', head: { ref: 'new-branch-name' }, html_url: 'https://github.com/o/r/pull/99' }) },
           stderr: { text: '' },
         }
         throw new Error(`unexpected command: ${spec.command}`)
@@ -1574,8 +1744,11 @@ test('repo issue aggregation uses unbounded pagination and keeps issues beyond 1
       resolve(spec: unknown) { return spec },
       async run(spec: { command: string }) {
         commands.push(spec.command)
-        if (spec.command.includes('/issues?')) return { exitCode: 0, stdout: { text: JSON.stringify([allIssues.slice(0, 1000), allIssues.slice(1000)]) }, stderr: { text: '' } }
-        if (spec.command.includes('/pulls?')) return { exitCode: 0, stdout: { text: '[[]]' }, stderr: { text: '' } }
+        if (spec.command.includes('/issues?')) {
+          const page = Number(spec.command.match(/[?&]page=(\d+)/)?.[1] ?? 1)
+          return { exitCode: 0, stdout: { text: included(allIssues.slice((page - 1) * 100, page * 100)) }, stderr: { text: '' } }
+        }
+        if (spec.command.includes('/pulls?')) return { exitCode: 0, stdout: { text: included([]) }, stderr: { text: '' } }
         throw new Error(`unexpected command: ${spec.command}`)
       },
     },
@@ -1586,5 +1759,5 @@ test('repo issue aggregation uses unbounded pagination and keeps issues beyond 1
   assert.equal(result.ok, true)
   if (!result.ok) return
   assert.equal(result.issues.length, 1001)
-  assert.equal(commands.filter((command) => command.includes('--paginate --slurp')).length, 2)
+  assert.equal(commands.filter((command) => command.startsWith('gh api ')).length, 12)
 })

--- a/tests/state-view-integration.test.ts
+++ b/tests/state-view-integration.test.ts
@@ -254,13 +254,13 @@ test('/state enrichment checks configured branches and runs GitHub lookups concu
     shell: {
       resolve(spec: unknown) { return spec },
       async run(spec: { command: string; timeoutMs?: number }) {
-        if (spec.command.startsWith('gh pr list')) {
+        if (spec.command.startsWith('gh api ') && spec.command.includes('/pulls?state=all')) {
           githubTimeouts.push(spec.timeoutMs ?? 0)
           activeGithub += 1
           maxGithub = Math.max(maxGithub, activeGithub)
           await new Promise((resolve) => setTimeout(resolve, 40))
           activeGithub -= 1
-          return { exitCode: 0, stdout: { text: '{}' }, stderr: { text: '' } }
+          return { exitCode: 0, stdout: { text: 'HTTP/2.0 200 OK\n\n[]' }, stderr: { text: '' } }
         }
         if (spec.command.startsWith('if git show-ref')) {
           const branch = spec.command.includes('issue-6') ? 'clickvibe-issue-6' : 'clickvibe-issue-5'


### PR DESCRIPTION
Closes #41

## 改动
- 将 Issue/PR 列表、详情、timeline、依赖扫描、状态与 review 读取统一改为 gh api REST
- 增加 updated_at 资源缓存、仓库聚合短 TTL、并发去重与写后失效
- 识别 GitHub 限流恢复时间并熔断，面板显示友好提示
- 保留最新 main 的 Issue 契约与合并门禁语义

## 验证
- pnpm test: 146/146 passed
- pnpm typecheck
- pnpm build