### PR TITLE
review 通过时发布 GitHub 原生 Approve

### DIFF
--- a/docs/plans/2026-08-22-native-review-approval-design.md
+++ b/docs/plans/2026-08-22-native-review-approval-design.md
@@ -1,0 +1,7 @@
+# GitHub 原生 Review Approve 设计
+
+Review 的本地结论、事件和 `== Review Meta ==` 评论仍沿用现有流水，保持它们是主要审计记录。仅当解析后的结论为通过且 workflow 已关联 PR 时，在评论发布完成后追加 `gh pr review <PR URL> --approve --body LGTM`，让 GitHub PR 页面显示原生 Approved。
+
+原生 approve 是独立的 best-effort 外显动作。未通过或没有 PR 时跳过；GitHub 因自审限制、权限或网络问题拒绝时吞掉错误，只写诊断日志，不回滚或覆盖已经落盘的 verdict、event 和评论结果。
+
+测试分别覆盖通过时调用、未通过时保持中性、approve 抛错不向上传播，并在 Review 路由集成测试中确认成功流水实际发出原生 approve 命令。最终门禁为全量测试、类型检查、构建和 `git diff --check`。

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ import {
 } from './state.ts'
 import { buildDevComment, buildReviewComment } from './delivery-comment.ts'
 import { extractGithubCommentUrl } from './delivery-publication.ts'
+import { approvePassedReview } from './review-approval.ts'
 import { parseAgentChunk, type AgentKind } from './agent-stream.ts'
 import {
   clearReviewResultFile,
@@ -2890,6 +2891,16 @@ async function startReview(
       if (event.publication?.status === 'posted' && event.publication.url && reloaded.reviewResult) {
         reloaded.reviewResult.commentUrl = event.publication.url
         await saveWorkflow(reloaded)
+      }
+      const approval = await approvePassedReview({
+        repoKey: reloaded.repoKey,
+        prNumber: reloaded.prNumber,
+        passed,
+      }, (command) => runCommand(ctx, command, { timeoutMs: 30000 }))
+      if (approval === 'approved') {
+        pushTaskLine(live, '[clickvibe] 已提交 GitHub 原生 Approve (LGTM)')
+      } else if (approval === 'failed') {
+        pushTaskLine(live, '[clickvibe] GitHub 原生 Approve 失败(继续,不影响 Review 结论与评论)')
       }
     }
   }, sessionId ? {

--- a/src/review-approval.ts
+++ b/src/review-approval.ts
@@ -1,0 +1,29 @@
+import { shellQuote } from './develop.ts'
+
+export interface ReviewApprovalInput {
+  repoKey: string
+  prNumber: string | number | null
+  passed: boolean
+}
+
+export type ReviewApprovalResult = 'approved' | 'skipped' | 'failed'
+
+/** Submit a native GitHub approval only for a passing PR review.
+ *
+ * GitHub can reject this write (notably when the authenticated user authored
+ * the PR), so approval is deliberately best-effort and never escapes errors.
+ */
+export async function approvePassedReview(
+  input: ReviewApprovalInput,
+  run: (command: string) => Promise<unknown>,
+): Promise<ReviewApprovalResult> {
+  if (!input.passed || !input.prNumber) return 'skipped'
+
+  const prUrl = `https://github.com/${input.repoKey}/pull/${input.prNumber}`
+  try {
+    await run(`gh pr review ${shellQuote(prUrl)} --approve --body ${shellQuote('LGTM')}`)
+    return 'approved'
+  } catch {
+    return 'failed'
+  }
+}

--- a/tests/review-approval.test.ts
+++ b/tests/review-approval.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { approvePassedReview } from '../src/review-approval.ts'
+
+test('passed review with a PR submits a native GitHub approval', async () => {
+  const commands: string[] = []
+  const result = await approvePassedReview({
+    repoKey: 'o/r', prNumber: '29', passed: true,
+  }, async (command) => {
+    commands.push(command)
+  })
+
+  assert.equal(result, 'approved')
+  assert.deepEqual(commands, [
+    "gh pr review 'https://github.com/o/r/pull/29' --approve --body 'LGTM'",
+  ])
+})
+
+test('failed review stays neutral and does not submit an approval', async () => {
+  const commands: string[] = []
+  const result = await approvePassedReview({
+    repoKey: 'o/r', prNumber: '29', passed: false,
+  }, async (command) => {
+    commands.push(command)
+  })
+
+  assert.equal(result, 'skipped')
+  assert.deepEqual(commands, [])
+})
+
+test('native approval failure is best-effort and does not escape', async () => {
+  const result = await approvePassedReview({
+    repoKey: 'o/r', prNumber: '29', passed: true,
+  }, async () => {
+    throw new Error('Review Can not approve your own pull request')
+  })
+
+  assert.equal(result, 'failed')
+})

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -1098,6 +1098,7 @@ test('invalid exact review session clears the stale id and falls back to a fresh
     }))
     let reviewFetches = 0
     const comments: Array<{ command: string; body: string }> = []
+    const approvals: string[] = []
     const issueTimeouts: number[] = []
     const handler = createHandler(async (spec) => {
       if (spec.command === 'git fetch origin --prune') {
@@ -1117,6 +1118,10 @@ test('invalid exact review session clears the stale id and falls back to a fresh
       if (spec.command.startsWith('gh issue comment')) {
         comments.push({ command: spec.command, body: spec.stdin ?? '' })
         return { exitCode: 0, stdout: { text: 'https://github.com/o/r/pull/29#issuecomment-2' }, stderr: { text: '' } }
+      }
+      if (spec.command.startsWith('gh pr review')) {
+        approvals.push(spec.command)
+        return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
       }
       return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
     }, (spec) => {
@@ -1180,6 +1185,9 @@ test('invalid exact review session clears the stale id and falls back to a fresh
     assert.match(comments[0].command, /github\.com\/o\/r\/pull\/29/)
     assert.match(comments[0].body, /^== Review Meta ==\n- event: review\n- commit: abc123\n- issue: #918\n- passed: true\n- next: merge/m)
     assert.match(comments[0].body, /下一步:可合并当前提交。/)
+    assert.deepEqual(approvals, [
+      "gh pr review 'https://github.com/o/r/pull/29' --approve --body 'LGTM'",
+    ])
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome


### PR DESCRIPTION
Closes #39

## 变更

- Review 通过且关联 PR 时追加原生 `gh pr review --approve --body LGTM`
- Review 未通过或没有 PR 时保持中性，不调用 approve
- approve 失败仅记录诊断，不影响 verdict、事件与 `== Review Meta ==` 评论流水

## 验证

- `pnpm test`（143 tests）
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`