### PR TITLE
fix: align per-run agent permissions

### DIFF
--- a/docs/state-model.md
+++ b/docs/state-model.md
@@ -79,6 +79,7 @@
 - **会话 id 归属缺失或与当前 agent 不一致** → 清除 id + owner,不得跨 Codex/Claude resume,直接在原 worktree 启动全新会话
 - **精确会话 id 被 agent 快速拒绝** → 清除 stale id,在同一 task/worktree 内仅回退一次全新会话;已完成 session 初始化或长时间运行后的普通失败不得触发回退
 - **review 未通过但问题列表为空** → 视为结论解析异常,清空当前 verdict 并要求重新 Review,不得进入空意见返工
+- **review 验证证据** → 命令实际执行后失败标记为「[验证不通过]」;因权限、环境或外部依赖无法执行标记为「[无法验证]」,问题列表原样展示,不得把后者伪装成前者
 - **验收契约状态** → `current` 才允许沿用 verdict；`changed` 明确要求重新 Review；`unknown/current-contract-unavailable` 暂停合并并要求刷新，不得谎称「验收已变更」
 - **review 结论缺失** → ①本地事件缓存 → ②comment meta → ③GitHub 原生 review(`reviews` 字段)→ ④「人工确认」；GitHub approval 可恢复 verdict，但不含 Issue body 快照，必须标记 `unknown/missing-review-snapshot` 并重新 Review，不自动解锁合并
 - **结论缺契约指纹**(历史旧结论) → 标记 `unknown/missing-review-snapshot`，按 #11 重新 Review；它会阻断合并，但不得伪装成已证实的契约变更

--- a/src/develop.ts
+++ b/src/develop.ts
@@ -6,23 +6,26 @@ export type AgentAction = 'develop' | 'review' | 'resume' | 'merge'
 
 export const RESUME_REJECT_WINDOW_MS = 15_000
 
+const CODEX_PERMISSION_FLAGS = `-c 'approval_policy="never"' -s danger-full-access`
+const CLAUDE_PERMISSION_FLAGS = '--dangerously-skip-permissions'
+
 /** Build a brand-new agent command; used after an exact resume id is rejected. */
 export function buildFreshAgentCommand(agent: Exclude<DevelopAgent, 'dryrun'>): string {
   return agent === 'claude'
-    ? 'claude -p --dangerously-skip-permissions --verbose --output-format stream-json'
-    : 'codex exec -c approval_policy=never -s danger-full-access --json -'
+    ? `claude -p ${CLAUDE_PERMISSION_FLAGS} --verbose --output-format stream-json`
+    : `codex exec ${CODEX_PERMISSION_FLAGS} --json -`
 }
 
 /** Build the command that continues an existing development session. */
 export function buildResumeAgentCommand(agent: Exclude<DevelopAgent, 'dryrun'>, sessionId: string | null): string {
   if (agent === 'claude') {
     return sessionId
-      ? `claude -p --resume ${shellQuote(sessionId)} --dangerously-skip-permissions --verbose --output-format stream-json`
-      : 'claude -p --continue --dangerously-skip-permissions --verbose --output-format stream-json'
+      ? `claude -p --resume ${shellQuote(sessionId)} ${CLAUDE_PERMISSION_FLAGS} --verbose --output-format stream-json`
+      : `claude -p --continue ${CLAUDE_PERMISSION_FLAGS} --verbose --output-format stream-json`
   }
   return sessionId
-    ? `codex exec resume ${shellQuote(sessionId)} -c approval_policy=never -c 'sandbox_mode="danger-full-access"' --json -`
-    : 'codex exec resume --last -c approval_policy=never -c \'sandbox_mode="danger-full-access"\' --json -'
+    ? `codex exec ${CODEX_PERMISSION_FLAGS} resume ${shellQuote(sessionId)} --json -`
+    : `codex exec ${CODEX_PERMISSION_FLAGS} resume --last --json -`
 }
 
 /** Only a quick failure before session initialization proves an exact id is stale. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1839,6 +1839,7 @@ async function buildReviewPrompt(
       `执行 git diff ${base}...HEAD 查看完整改动。`,
       ...(sessionId ? ['先复核之前发现的问题是否已解决,再审查全部新改动。'] : []),
       '严格按当前需求快照中的验收标准逐条审查,同时检查 bug、安全隐患和测试覆盖。',
+      '验证结果必须区分:命令已执行但断言/检查失败的问题以「[验证不通过]」开头;因权限、环境或外部依赖导致命令无法执行的问题以「[无法验证]」开头,不得混淆。',
       `除 ${REVIEW_RESULT_RELATIVE_PATH} 外不要修改任何文件,只做只读 review。`,
       `必须使用写文件工具把最终结论写入 ${REVIEW_RESULT_RELATIVE_PATH},格式:{"passed":true|false,"issues":["问题1(含文件/位置/原因)",...]};passed=true 表示无问题,有任意问题则 false 并列全。`,
       '最后一行再输出同一个 JSON 对象(单独一行,不要代码块),仅作为兼容兜底。',
@@ -2417,9 +2418,7 @@ async function startDevelop(
       const prompt = buildDevelopPrompt(workflow, launchSnapshot, extraContext)
 
       pushTaskLine(live, `[clickvibe] 启动 ${agent} 开发…`)
-      const agentCommand = agent === 'claude'
-        ? 'claude -p --dangerously-skip-permissions --verbose --output-format stream-json'
-        : 'codex exec -c approval_policy=never -s danger-full-access --json -'
+      const agentCommand = buildFreshAgentCommand(agent)
 
       attachAgentProcess(ctx, live, agentCommand, workflow.worktree, prompt, async (exitCode, sessionId) => {
         pushTaskLine(live, `[clickvibe] ${agent} 结束,退出码 ${exitCode}`)

--- a/tests/develop.test.ts
+++ b/tests/develop.test.ts
@@ -42,11 +42,11 @@ test('shellQuote prevents POSIX shell expansion', () => {
 test('resume commands continue the exact session and use a valid codex fallback', () => {
   assert.equal(
     buildResumeAgentCommand('codex', 'thread-123'),
-    `codex exec resume 'thread-123' -c approval_policy=never -c 'sandbox_mode="danger-full-access"' --json -`,
+    `codex exec -c 'approval_policy="never"' -s danger-full-access resume 'thread-123' --json -`,
   )
   assert.equal(
     buildResumeAgentCommand('codex', null),
-    `codex exec resume --last -c approval_policy=never -c 'sandbox_mode="danger-full-access"' --json -`,
+    `codex exec -c 'approval_policy="never"' -s danger-full-access resume --last --json -`,
   )
   assert.equal(
     buildResumeAgentCommand('claude', 'session-123'),
@@ -55,7 +55,7 @@ test('resume commands continue the exact session and use a valid codex fallback'
 })
 
 test('fresh commands never retry the stale session', () => {
-  assert.equal(buildFreshAgentCommand('codex'), 'codex exec -c approval_policy=never -s danger-full-access --json -')
+  assert.equal(buildFreshAgentCommand('codex'), `codex exec -c 'approval_policy="never"' -s danger-full-access --json -`)
   assert.equal(buildFreshAgentCommand('claude'), 'claude -p --dangerously-skip-permissions --verbose --output-format stream-json')
 })
 

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -852,8 +852,8 @@ test('invalid exact dev session falls back once to a fresh session on the same t
     assert.ok(resumed.body.taskId)
     const completed = await waitForTask(handler, resumed.body.taskId)
     assert.equal(starts.length, 2)
-    assert.match(starts[0].command, /exec resume 'dead-session'/)
-    assert.equal(starts[1].command, 'codex exec -c approval_policy=never -s danger-full-access --json -')
+    assert.match(starts[0].command, /danger-full-access resume 'dead-session'/)
+    assert.equal(starts[1].command, `codex exec -c 'approval_policy="never"' -s danger-full-access --json -`)
     assert.deepEqual(starts.map((start) => start.workdir), [worktree, worktree])
     for (const start of starts) {
       assert.match(start.prompt, /=== 需求快照 ===/)
@@ -1154,8 +1154,8 @@ test('invalid exact review session clears the stale id and falls back to a fresh
     const completed = await waitForTask(handler, reviewed.body.taskId)
     assert.equal(starts.length, 2)
     assert.equal(reviewFetches, 1)
-    assert.match(starts[0].command, /exec resume 'dead-review'/)
-    assert.equal(starts[1].command, 'codex exec -c approval_policy=never -s danger-full-access --json -')
+    assert.match(starts[0].command, /danger-full-access resume 'dead-review'/)
+    assert.equal(starts[1].command, `codex exec -c 'approval_policy="never"' -s danger-full-access --json -`)
     for (const start of starts) {
       assert.match(start.prompt, /=== 需求快照 ===/)
       assert.match(start.prompt, /updatedAt: 2026-08-22T01:02:03Z/)
@@ -1163,6 +1163,7 @@ test('invalid exact review session clears the stale id and falls back to a fresh
       assert.match(start.prompt, new RegExp(`契约正文 SHA-256: ${issueBodyHash(reviewedBody)}`))
       assert.match(start.prompt, /PR: https:\/\/github\.com\/o\/r\/pull\/29/)
       assert.match(start.prompt, /被审 commit: abc123/)
+      assert.match(start.prompt, /\[验证不通过\].*\[无法验证\]/)
       assert.match(start.prompt, /=== 信任边界 ===/)
     }
     const reloaded = await loadWorkflow(workflow.key)


### PR DESCRIPTION
## Summary

- centralize explicit per-invocation permission flags for fresh and resumed Claude/Codex sessions
- make initial development use the same command builder as review/resume paths
- require review output to distinguish `[验证不通过]` from `[无法验证]`

## Verification

- `pnpm typecheck`
- `pnpm test` (140 passed)
- `pnpm build`
- real Claude smoke with `--dangerously-skip-permissions`: `gh issue view 21` and `npm test` both executed successfully with no permission denials

Closes #21