### PR TITLE
fix: 同步后自动推送 PR 分支

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2834,7 +2834,7 @@ function stopTask(payload: unknown): { ok: true; taskId: string; stopped: boolea
   return { ok: true, taskId, stopped }
 }
 
-/** Sync a workflow's worktree with the remote base (git fetch + merge origin/main).
+/** Sync a workflow's worktree with the remote base, then push the PR branch.
  *  Keeps the worktree on the latest base so dev/review never target stale code
  *  (issue #5). The merge result is recorded as a timeline event.
  *  合并冲突时不回滚:现场(MERGE_HEAD + 冲突标记)原样保留,转交返工 agent
@@ -2858,6 +2858,18 @@ export async function syncWorktree(
   }
   const policy = { mode: 'danger-full-access' as const, workspaceRoot: workflow.worktree }
   try {
+    // Do not rely on git merge to reject a dirty tree:Git permits unrelated
+    // local changes, which would otherwise let the merge commit be pushed.
+    // An existing conflicted merge keeps following the conflict-preservation
+    // path below so callers still receive conflict:true and the file list.
+    if (!await hasMergeConflict(ctx, workflow.worktree)) {
+      const changes = await runCommand(ctx, 'git status --porcelain', {
+        workdir: workflow.worktree,
+        timeoutMs: 10_000,
+        sandboxPolicy: { mode: 'read-only', workspaceRoot: workflow.worktree },
+      })
+      if (changes) throw new Error('worktree 有未提交改动,请先提交或清理后再同步')
+    }
     await appendLog(workflow.key, 'dev', '[clickvibe] 同步:git fetch origin…')
     await runCommand(ctx, 'git fetch origin --prune', { workdir: workflow.worktree, timeoutMs: 60_000, sandboxPolicy: policy })
     await appendLog(workflow.key, 'dev', '[clickvibe] 同步:合并 origin/main…')
@@ -2892,7 +2904,13 @@ export async function syncWorktree(
       throw error
     }
     const head = await readWorktreeHead(ctx, workflow.worktree)
-    await appendLog(workflow.key, 'dev', `[clickvibe] 同步完成,HEAD ${head ?? '未知'}`)
+    await appendLog(workflow.key, 'dev', `[clickvibe] 同步:推送 ${workflow.branch} 到 origin…`)
+    await runCommand(ctx, `git push origin ${shellQuote(workflow.branch)}`, {
+      workdir: workflow.worktree,
+      timeoutMs: 60_000,
+      sandboxPolicy: policy,
+    })
+    await appendLog(workflow.key, 'dev', `[clickvibe] 同步并推送完成,HEAD ${head ?? '未知'}`)
     // 记录同步事件到权威时间线(不改变开发/审查语义)
     const reloaded = await loadWorkflow(workflow.key)
     if (reloaded) {

--- a/tests/sync-conflict.test.ts
+++ b/tests/sync-conflict.test.ts
@@ -41,6 +41,7 @@ async function setupConflictedRepo() {
   const worktree = join(root, 'issue')
   const git = (...args: string[]) => execFileAsync('git', ['-C', repo, ...args])
   const wt = (...args: string[]) => execFileAsync('git', ['-C', worktree, ...args])
+  const remoteGit = (...args: string[]) => execFileAsync('git', [`--git-dir=${remote}`, ...args])
   await execFileAsync('git', ['init', '--bare', remote])
   await execFileAsync('git', ['clone', remote, repo])
   await git('config', 'user.name', 'clickvibe-test')
@@ -62,7 +63,42 @@ async function setupConflictedRepo() {
   await git('add', '.')
   await git('commit', '-m', 'parallel base B')
   await git('push', 'origin', 'main')
-  return { root, repo, worktree, git, wt }
+  return { root, repo, worktree, git, wt, remoteGit }
+}
+
+/** Set up an existing remote PR branch that can merge the advanced main cleanly. */
+async function setupSyncableRepo() {
+  const root = await mkdtemp(join(tmpdir(), 'clickvibe-sync-push-'))
+  const remote = join(root, 'remote.git')
+  const repo = join(root, 'repo')
+  const worktree = join(root, 'issue')
+  const branch = 'clickvibe-issue-45'
+  const git = (...args: string[]) => execFileAsync('git', ['-C', repo, ...args])
+  const wt = (...args: string[]) => execFileAsync('git', ['-C', worktree, ...args])
+  const remoteGit = (...args: string[]) => execFileAsync('git', [`--git-dir=${remote}`, ...args])
+  await execFileAsync('git', ['init', '--bare', remote])
+  await execFileAsync('git', ['clone', remote, repo])
+  await git('config', 'user.name', 'clickvibe-test')
+  await git('config', 'user.email', 'clickvibe-test@example.invalid')
+  await writeFile(join(repo, 'base.md'), 'base A\n')
+  await git('add', '.')
+  await git('commit', '-m', 'base A')
+  await git('branch', '-M', 'main')
+  await git('push', '-u', 'origin', 'main')
+  await remoteGit('symbolic-ref', 'HEAD', 'refs/heads/main')
+  await git('fetch', 'origin', '--prune')
+  await git('worktree', 'add', '-b', branch, worktree, 'origin/main')
+  await writeFile(join(worktree, 'feature.md'), 'development\n')
+  await wt('add', '.')
+  await wt('commit', '-m', 'dev work')
+  await wt('push', '-u', 'origin', branch)
+  const remoteHeadBeforeSync = (await remoteGit('rev-parse', `refs/heads/${branch}`)).stdout.trim()
+  await git('switch', 'main')
+  await writeFile(join(repo, 'base.md'), 'base B\n')
+  await git('add', '.')
+  await git('commit', '-m', 'parallel base B')
+  await git('push', 'origin', 'main')
+  return { root, remote, worktree, branch, wt, remoteGit, remoteHeadBeforeSync }
 }
 
 function conflictedWorkflow(worktree: string): IssueWorkflow {
@@ -78,6 +114,21 @@ function conflictedWorkflow(worktree: string): IssueWorkflow {
       body: '## 验收标准\n- resolve conflicts', state: 'OPEN', updatedAt: '2026-08-21T00:00:00Z', comments: [],
     },
     updatedAt: Date.now(), events: [],
+  }
+}
+
+function syncableWorkflow(worktree: string, branch: string): IssueWorkflow {
+  return {
+    ...conflictedWorkflow(worktree),
+    key: 'o-r-45',
+    url: 'https://github.com/o/r/issues/45',
+    branch,
+    reviewResult: { passed: true, issues: [] },
+    prNumber: '24',
+    issueSnapshot: {
+      url: 'https://github.com/o/r/issues/45', title: 'sync then push',
+      body: '## 验收标准\n- push synced branch', state: 'OPEN', updatedAt: '2026-08-22T00:00:00Z', comments: [],
+    },
   }
 }
 
@@ -97,8 +148,48 @@ async function withTempHome<T>(root: string, run: () => Promise<T>): Promise<T> 
   }
 }
 
+test('sync pushes the clean merge commit to the existing PR branch (issue #45)', async () => {
+  const { root, worktree, branch, wt, remoteGit, remoteHeadBeforeSync } = await setupSyncableRepo()
+  try {
+    await withTempHome(root, async () => {
+      await saveWorkflow(syncableWorkflow(worktree, branch))
+
+      const result = await syncWorktree(ctx, { url: 'https://github.com/o/r/issues/45' })
+      assert.equal(result.ok, true)
+      const localHead = (await wt('rev-parse', 'HEAD')).stdout.trim()
+      const localShortHead = (await wt('rev-parse', '--short', 'HEAD')).stdout.trim()
+      const remoteHead = (await remoteGit('rev-parse', `refs/heads/${branch}`)).stdout.trim()
+      assert.notEqual(localHead, remoteHeadBeforeSync)
+      assert.equal(remoteHead, localHead)
+      assert.equal(result.head, localShortHead)
+    })
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('sync does not merge or push when the worktree has unrelated local changes (issue #45)', async () => {
+  const { root, worktree, branch, wt, remoteGit, remoteHeadBeforeSync } = await setupSyncableRepo()
+  try {
+    await withTempHome(root, async () => {
+      await saveWorkflow(syncableWorkflow(worktree, branch))
+      await writeFile(join(worktree, 'local-notes.md'), 'uncommitted local change\n')
+
+      const result = await syncWorktree(ctx, { url: 'https://github.com/o/r/issues/45' })
+      assert.equal(result.ok, false)
+      assert.equal((result as { conflict?: boolean }).conflict, undefined)
+      assert.match(result.error, /未提交改动/)
+      const remoteHead = (await remoteGit('rev-parse', `refs/heads/${branch}`)).stdout.trim()
+      assert.equal(remoteHead, remoteHeadBeforeSync)
+      assert.match((await wt('status', '--short')).stdout, /local-notes\.md/)
+    })
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
 test('sync keeps the conflicted merge scene and rework stays reachable (issue #26)', async () => {
-  const { root, worktree, git } = await setupConflictedRepo()
+  const { root, worktree, git, remoteGit } = await setupConflictedRepo()
   try {
     await withTempHome(root, async () => {
       await saveWorkflow(conflictedWorkflow(worktree))
@@ -119,6 +210,7 @@ test('sync keeps the conflicted merge scene and rework stays reachable (issue #2
       assert.match(mergeHead.stdout, /^[0-9a-f]+/)
       const content = await readFile(join(worktree, 'readme.md'), 'utf8')
       assert.match(content, /<<<<<<< HEAD/)
+      await assert.rejects(remoteGit('rev-parse', 'refs/heads/clickvibe-issue-26'))
 
       // 冲突已记录到权威时间线(含文件清单)
       const reloaded = await loadWorkflow('o-r-26')


### PR DESCRIPTION
Closes #45

## 改动
- `syncWorktree` 无冲突合并成功后自动推送当前 workflow 分支到 origin
- worktree 有未提交改动时在 fetch/merge/push 前失败
- 保持冲突现场、冲突文件返回和 review/contract 合并门禁不变

## 验证
- `pnpm test` (148 passed)
- `pnpm typecheck`
- 真实裸 Git 远端测试验证同步后远端分支 HEAD 等于本地 HEAD