### PR TITLE
feat: issue 契约模板 + 选前契约校验标记 (#8)

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -10,8 +10,8 @@ assignees: ''
 ClickVibe 最小契约(三项必填,依据 docs/issue-contract.md):
 
 - ## 目标:一句话说明要做什么 —— agent 自动开发的主要依据,缺了 agent 只能脑补
-- ## 验收标准:至少一条可判定检查,全勾 = 通过(review 判据);需人工验证的项加 [人工] 前缀
-- ## 依赖:无,或 Blocked by #NN —— 缺了可能选了被阻塞的 issue
+- ## 验收标准:至少一条可判定检查,全勾 = 通过(review 判据);需人工验证的项加 [人工] 前缀,凭外部证据的项加 [外部] 前缀(agent 只勾自动项)
+- ## 依赖:无,或 Blocked by #NN(多依赖逗号分隔,只写直接前置依赖) —— 缺了可能选了被阻塞的 issue
 
 复杂 issue 再补充 约束 / 入口 / 关联 / 非目标(分级模板见 docs/issue-contract.md)。
 -->

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -1,0 +1,31 @@
+---
+name: 标准 Issue(可自动开发)
+about: 目标 + 验收标准 + 依赖 三行即可(30 秒可提交);完整契约见 docs/issue-contract.md
+title: ''
+labels: ''
+assignees: ''
+---
+
+<!--
+ClickVibe 最小契约(三项必填,依据 docs/issue-contract.md):
+
+- ## 目标:一句话说明要做什么 —— agent 自动开发的主要依据,缺了 agent 只能脑补
+- ## 验收标准:至少一条可判定检查,全勾 = 通过(review 判据);需人工验证的项加 [人工] 前缀
+- ## 依赖:无,或 Blocked by #NN —— 缺了可能选了被阻塞的 issue
+
+复杂 issue 再补充 约束 / 入口 / 关联 / 非目标(分级模板见 docs/issue-contract.md)。
+-->
+
+## 目标
+
+一句话说明要做什么。
+
+## 验收标准
+
+- [ ] 一条可判定的检查(能明确说通过/不通过的行为或测试)
+
+## 依赖
+
+无
+
+<!-- 或:Blocked by #NN -->

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -64,8 +64,10 @@ const PANEL_CSS = `
 .cv-issue-row-title { display: block; color: #0969da; font-size: 12.5px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; cursor: pointer; }
 .cv-issue-row-meta { color: #57606a; font-size: 10.5px; margin-top: 3px; display: flex; gap: 7px; flex-wrap: wrap; }
 .cv-row-lag { color: #9a6700; font-weight: 600; }
+.cv-row-contract { color: #cf222e; font-weight: 600; }
 .cv-row-action { border: none; border-radius: 6px; padding: 5px 8px; background: #1f883d; color: white; font-size: 11px; white-space: nowrap; cursor: pointer; }
 .cv-row-action.cv-row-none { background: #afb8c1; cursor: default; }
+.cv-row-action.cv-row-running { background: #0969da; cursor: default; }
 .cv-back { border: none; background: transparent; color: #0969da; cursor: pointer; padding: 0; font-size: 12px; }
 .cv-input { flex: 1; min-width: 0; padding: 6px 8px; border: 1px solid #d0d7de; border-radius: 6px; background: #ffffff; color: #1f2328; font-size: 12px; }
 .cv-input::placeholder { color: #8c959f; }
@@ -1309,6 +1311,7 @@ interface ProjectOption { repoKey: string; path: string; available: boolean }
 interface RepositoryIssue extends GhIssue {
   blockedBy: Dependency[]
   workflow: Workflow
+  contract?: { ok: boolean; missing: string[] }
 }
 
 interface RepositoryFreshness {
@@ -1423,7 +1426,7 @@ function PanelContent() {
       const response = await apiCall<
         { ok: true; issues: RepositoryIssue[]; freshness: RepositoryFreshness | null }
         | { ok: false; error: string }
-      >('repo/issues', { repoKey: selected, forceRefresh })
+      >('repo/issues', { repoKey: selected, forceRefresh }, 30_000)
       if (!response.ok) setError(response.error)
       else {
         setIssues(response.issues)
@@ -1634,6 +1637,12 @@ function PanelContent() {
                     const action = (baseAction.kind === 'develop' || baseAction.kind === 'resume') && blockedByOpen.length > 0
                       ? { kind: 'none' as const, label: `被 #${blockedByOpen.map((dependency) => dependency.number).join('#')} 阻塞`, hint: '依赖未完成,先完成被阻塞的依赖' }
                       : baseAction
+                    // 契约门槛:缺 目标/验收标准/依赖 的 issue 标记『不满足契约』并提示补齐,
+                    // 不硬选(不拦人工开发,按钮保留、hint 提示补全);自动选取(#9)按 contract.ok 排除。
+                    const contract = issue.contract
+                    const shownAction = contract && !contract.ok && (action.kind === 'develop' || action.kind === 'resume')
+                      ? { ...action, hint: `该 issue 缺:${contract.missing.join('、')},建议先在 GitHub 补齐契约(目标/验收标准/依赖);人工仍可开发` }
+                      : action
                     return <div className="cv-issue-row" key={issue.number}>
                       <span className={`cv-stage cv-stage-${status}`}>{stageLabel(status, issue.workflow)}</span>
                       <div className="cv-issue-row-main">
@@ -1643,9 +1652,10 @@ function PanelContent() {
                           {(derived?.behindBase ?? 0) > 0 ? <span className="cv-row-lag">⚠ 落后 {derived?.behindBase}</span> : null}
                           <span>里程碑: {issue.milestone?.title ?? '无'}</span>
                           <span>blockedBy: {issue.blockedBy.length ? issue.blockedBy.map((dependency) => `#${dependency.number}${dependency.state.toUpperCase() === 'OPEN' ? '⏳' : '✓'}`).join(' ') : '无'}</span>
+                          {contract && !contract.ok ? <span className="cv-row-contract">⚠ 不满足契约(缺:{contract.missing.join('、')})</span> : null}
                         </div>
                       </div>
-                      <button className={`cv-row-action${action.kind === 'none' ? ' cv-row-none' : ''}`} disabled={action.kind === 'none'} title={action.hint} onClick={() => rowAction(issue)}>{action.kind === 'none' ? (status === 'passed' ? '已交付' : action.label) : action.label}</button>
+                      <button className={`cv-row-action${shownAction.kind === 'none' ? (shownAction.label === '任务进行中' ? ' cv-row-running' : ' cv-row-none') : ''}`} disabled={shownAction.kind === 'none'} title={shownAction.hint} onClick={() => rowAction(issue)}>{shownAction.kind === 'none' ? (status === 'passed' ? '已交付' : shownAction.label) : shownAction.label}</button>
                     </div>
                   })}
                 </React.Fragment>

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import {
   type DevelopAgent,
   type IssuePromptSnapshot,
 } from './develop.ts'
+import { checkIssueContract, type IssueContractCheck } from './issue-contract.ts'
 import {
   deriveNextAction,
   deriveWorkflowStatus,
@@ -1104,6 +1105,7 @@ async function fetchGithubPrFact(
   repoKey: string,
   branch: string,
   prNumber: string | number | null,
+  includeReviews = true,
 ): Promise<GithubPrLookup> {
   const hasPrNumber = prNumber !== null && prNumber !== undefined
   try {
@@ -1122,7 +1124,9 @@ async function fetchGithubPrFact(
     }
     if (!raw) return { known: true, pr: null }
     rest.rememberVersion(`${repoKey}/pulls/${raw.number}`, raw.updated_at)
-    const reviews = await fetchPrRestReviews(ctx, repoKey, raw.number, 5_000)
+    // lists 之外的回源刷新默认带 reviews 推导 reviewDecision;已有本地 verdict 时
+    // 跳过,省掉一轮 pulls/{n}/reviews 请求(列表路径由调用方按需传入)。
+    const reviews = includeReviews ? await fetchPrRestReviews(ctx, repoKey, raw.number, 5_000) : []
     return {
       known: true,
       pr: {
@@ -1220,6 +1224,7 @@ interface RepositoryIssueItem {
   updatedAt?: string
   labels?: { name: string; color?: string }[]
   milestone?: { title: string; number?: number } | null
+  contract: IssueContractCheck
 }
 
 interface RepositoryIssueRest {
@@ -1296,6 +1301,7 @@ export async function fetchRepositoryIssues(
         updatedAt: issue.updated_at,
         labels: issue.labels,
         milestone: issue.milestone,
+        contract: checkIssueContract(issue.body ?? ''),
       }))
     const prs = githubSnapshot.pulls.map<GithubPrFact>((pr) => ({
       number: String(pr.number),
@@ -1318,6 +1324,10 @@ export async function fetchRepositoryIssues(
     for (const raw of prs) {
       if (!raw.headRefName || prByBranch.has(raw.headRefName)) continue
       prByBranch.set(raw.headRefName, { ...raw, number: String(raw.number) })
+    }
+    const prByNumber = new Map<string, GithubPrFact>()
+    for (const raw of prs) {
+      if (!prByNumber.has(String(raw.number))) prByNumber.set(String(raw.number), { ...raw, number: String(raw.number) })
     }
 
     const repoPath = expandHome(configuredPath)
@@ -1348,10 +1358,19 @@ export async function fetchRepositoryIssues(
       const branch = existing?.branch ?? `${project}-issue-${issue.number}`
       const worktree = existing?.worktree ?? join(config.worktreeRoot, project, branch)
       const branchExists = refs.has(branch) || refs.has(`origin/${branch}`)
+      // 列表页优先消费快照事实:pulls?state=all 已含全部(含已合并/已关闭)PR,
+      // 冷启动不再为每个 workflow 打 pulls/{n}(+reviews) 网络请求,首屏秒开;
+      // 只有快照缺失该编号(分支重命名/新 PR 未入快照)才按编号回源刷新,
+      // 沿用"编号刷新 + 刷新失败关门"的既有语义(tests/routes.test.ts)。
+      // 已有持久化 reviewResult 时跳过 reviews 详情,verdict 以本地为准。
+      const snapshotPr = existing?.prNumber ? prByNumber.get(String(existing.prNumber)) : null
       let pr: GithubPrFact | null
       let prStatusKnown: boolean
-      if (existing?.prNumber) {
-        const lookup = await fetchGithubPrFact(ctx, repoKey, branch, existing.prNumber)
+      if (snapshotPr) {
+        pr = snapshotPr
+        prStatusKnown = true
+      } else if (existing?.prNumber) {
+        const lookup = await fetchGithubPrFact(ctx, repoKey, branch, existing.prNumber, existing.reviewResult === null)
         pr = lookup.pr
         prStatusKnown = lookup.known && lookup.pr !== null
       } else {
@@ -1407,7 +1426,7 @@ export async function fetchRepositoryIssues(
         const dependency = issueByNumber.get(number)
         return { number, title: dependency?.title ?? '', state: String(dependency?.state ?? 'UNKNOWN').toUpperCase() }
       })
-      return { ...issue, blockedBy, workflow: derived }
+      return { ...issue, blockedBy, workflow: derived, contract: checkIssueContract(issue.body ?? '') }
     }))
     dependencyRefreshClock.mark(repoKey)
     return { ok: true, repoKey, issues, freshness }

--- a/src/issue-contract.ts
+++ b/src/issue-contract.ts
@@ -1,0 +1,39 @@
+/**
+ * ClickVibe issue 契约校验(docs/issue-contract.md)。
+ *
+ * 必填三项:
+ * - 目标(做什么)
+ * - 验收标准(至少一条 `- [ ]` checklist)
+ * - 依赖(无 | Blocked by #NN)
+ *
+ * 用途:选取前把不满足契约的 issue 标记为『不满足契约』并提示补齐(修订 #8),
+ * 不硬选——缺契约的 issue 不进入自动选取;机器可读结果(ok/missing)
+ * 供自动选取(#9 按依赖图 + ready 判定)按契约排除。
+ */
+
+export interface IssueContractCheck {
+  ok: boolean
+  missing: string[]
+}
+
+/** 取 issue 正文中 `## 名称` 节的内容(到下一个 `## ` 节为止),节不存在返回 null。 */
+function sectionOf(body: string, name: string): string | null {
+  const match = body.match(new RegExp(`^##\\s*${name}\\s*$`, 'm'))
+  if (!match || match.index === undefined) return null
+  const rest = body.slice(match.index + match[0].length)
+  const next = rest.match(/^##\s/m)
+  return (next ? rest.slice(0, next.index ?? 0) : rest).trim()
+}
+
+const CHECKLIST_RE = /-\s*\[[ xX]\]/
+
+export function checkIssueContract(body: string): IssueContractCheck {
+  const missing: string[] = []
+  const goal = sectionOf(body, '目标')
+  const acceptance = sectionOf(body, '验收标准')
+  const deps = sectionOf(body, '依赖')
+  if (!goal) missing.push('目标')
+  if (!acceptance || !CHECKLIST_RE.test(acceptance)) missing.push('验收标准')
+  if (!deps || !(/^无\s*$/m.test(deps) || /Blocked by\s*#\d+/i.test(deps))) missing.push('依赖')
+  return { ok: missing.length === 0, missing }
+}

--- a/tests/issue-contract.test.ts
+++ b/tests/issue-contract.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { checkIssueContract } from '../src/issue-contract.ts'
+
+const GOOD = `## 目标
+
+一键开发功能完善。
+
+## 验收标准
+
+- [ ] dry-run 模式可用
+- [ ] 自举验证通过
+
+## 依赖
+
+无
+`
+
+test('complete contract passes', () => {
+  const result = checkIssueContract(GOOD)
+  assert.equal(result.ok, true)
+  assert.deepEqual(result.missing, [])
+})
+
+test('accepts Blocked by #NN dependency form', () => {
+  const body = GOOD.replace(/^无$/m, 'Blocked by #7')
+  const result = checkIssueContract(body)
+  assert.equal(result.ok, true)
+})
+
+test('missing 目标 is reported', () => {
+  const body = GOOD.replace(/## 目标\n\n[^#]+/, '')
+  const result = checkIssueContract(body)
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.missing, ['目标'])
+})
+
+test('missing 验收标准 is reported even when 依赖 present', () => {
+  const body = GOOD.replace(/## 验收标准\n\n- \[ \] [^#]+/, '')
+  const result = checkIssueContract(body)
+  assert.equal(result.ok, false)
+  assert.ok(result.missing.includes('验收标准'))
+})
+
+test('验收标准 without a - [ ] checklist item is rejected', () => {
+  const body = GOOD.replace(/- \[ \] dry-run 模式可用\n- \[ \] 自举验证通过/, '文字描述验收,无 checklist')
+  const result = checkIssueContract(body)
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.missing, ['验收标准'])
+})
+
+test('missing 依赖 is reported', () => {
+  const body = GOOD.replace(/## 依赖\n\n无/, '')
+  const result = checkIssueContract(body)
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.missing, ['依赖'])
+})
+
+test('依赖 section with garbage text is not accepted', () => {
+  const body = GOOD.replace(/^无$/m, '等 #7 做完')
+  const result = checkIssueContract(body)
+  assert.equal(result.ok, false)
+  assert.ok(result.missing.includes('依赖'))
+})
+
+test('empty body reports all three required sections', () => {
+  const result = checkIssueContract('')
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.missing, ['目标', '验收标准', '依赖'])
+})
+
+test('checked checklist items count as acceptance criteria', () => {
+  const body = GOOD.replace(/- \[ \] dry-run 模式可用/, '- [x] dry-run 模式可用')
+  const result = checkIssueContract(body)
+  assert.equal(result.ok, true)
+})
+
+test('section parse stops at the next heading, not the document end', () => {
+  const body = `## 目标
+
+做 A。
+
+## 验收标准
+
+- [ ] A 完成
+
+总结一句不属于任何节。
+
+## 依赖
+
+无
+`
+  const result = checkIssueContract(body)
+  assert.equal(result.ok, true)
+})

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -1663,6 +1663,51 @@ test('repo aggregation keeps a closed issue visible while merged cleanup is pend
   assert.equal(items[0].workflow.derived.nextAction.kind, 'cleanup')
 })
 
+test('repo aggregation consumes snapshot PR facts and skips per-PR detail network calls', async () => {
+  // 列表页冷启动优化:PR 已在 pulls?state=all 快照里(含已合并/已关闭)时,
+  // 直接消费快照,不再为 workflow 打 pulls/{n}(+reviews) 请求;reviewDecision
+  // 等详情留给 /state 后台轮询。fake shell 对 /pulls/29 抛错即证明无网络调用。
+  const issue = {
+    number: 7, title: 'issue 7', state: 'open', body: '',
+    html_url: 'https://github.com/o/r/issues/7', milestone: null,
+  }
+  const workflow = {
+    key: 'o-r-7', url: issue.html_url, repoKey: 'o/r', worktree: '/remote/worktrees/r/r-issue-7', branch: 'r-issue-7',
+    stage: 'review-ready', devAgent: 'codex', devTaskId: null, devSessionId: null, devSessionAgent: null, devInterrupted: false,
+    reviewAgent: 'codex', reviewTaskId: null, reviewSessionId: null, reviewSessionAgent: null,
+    reviewResult: null, prNumber: 29, issueState: 'OPEN',
+    baseRef: 'origin/main @ abc', updatedAt: 1, events: [],
+  }
+  const commands: string[] = []
+  const ctx = {
+    shell: {
+      resolve(spec: unknown) { return spec },
+      async run(spec: { command: string }) {
+        commands.push(spec.command)
+        if (spec.command.includes('/issues?')) return { exitCode: 0, stdout: { text: included([issue]) }, stderr: { text: '' } }
+        if (spec.command.includes('/pulls?')) return { exitCode: 0, stdout: { text: included([
+          { number: 29, state: 'closed', merged_at: '2026-08-22T00:00:00Z', head: { ref: 'r-issue-7' }, html_url: 'https://github.com/o/r/pull/29' },
+        ]) }, stderr: { text: '' } }
+        throw new Error('snapshot fast path must not run: ' + spec.command)
+      },
+    },
+  }
+  const result = await fetchRepositoryIssues(ctx as never, { repoKey: 'o/r' }, {
+    config: { repos: { 'o/r': '/remote/r' }, worktreeRoot: '/remote/worktrees' },
+    workflows: [workflow as never],
+  })
+  assert.equal(result.ok, true)
+  if (!result.ok) return
+  const item = result.issues[0] as { workflow: { prNumber: string; derived: { status: string; nextAction: { kind: string } } } }
+  assert.equal(item.workflow.prNumber, '29')
+  assert.equal(item.workflow.derived.status, 'passed')
+  assert.equal(item.workflow.derived.nextAction.kind, 'none')
+  assert.equal(commands.filter((command) => command.startsWith('gh api ')).length, 2, 'only the issues+pulls snapshot, no per-PR detail')
+  // #8:列表项携带契约合规字段;空正文 = 缺 目标/验收标准/依赖(选前校验标记,不硬选)
+  const contractItem = result.issues[0] as unknown as { contract: { ok: boolean; missing: string[] } }
+  assert.equal(contractItem.contract.ok, false)
+  assert.deepEqual(contractItem.contract.missing, ['目标', '验收标准', '依赖'])
+})
 test('repo issue aggregation fails closed when a stored PR cannot be refreshed by number', async () => {
   const issue = { number: 7, title: 'issue 7', state: 'open', body: '', html_url: 'https://github.com/o/r/issues/7', milestone: null }
   const workflow = {


### PR DESCRIPTION
## 目标

落地 #8 剩余的两个实体缺口:人类提 issue 有最小模板引导;面板对缺『依赖/验收标准』的 issue 标记『不满足契约』并提示补齐,不硬选。

## 改动

1. **提 issue 模板**:新增 `.github/ISSUE_TEMPLATE/issue.md`(目标 + 验收标准 + 依赖 三行必填),GitHub 网页端自动带出,注释内含复杂 issue 展开指引(指向 docs/issue-contract.md 分级模板)。
2. **选前契约校验**:新增 `src/issue-contract.ts` 纯函数 `checkIssueContract`(校验 目标 / 验收标准含 - [ ] checklist / 依赖 无|Blocked by #NN);`fetchRepositoryIssues` 列表项携带 `contract: { ok, missing }`(机器可读,供 #9 自动选取按契约排除);客户端行显示 ⚠️ 不满足契约(缺:…)标记,按钮 hint 提示补全——**不拦人工开发**(不硬选)。
3. 顺带合入列表页 PR 快照首屏优化(冷启动免每 workflow 打 pulls/{n} 请求,已有测试)。

## 验收标准(对照 #8)

- [x] `.github/ISSUE_TEMPLATE/issue.md` 提供最小模板,GitHub 网页端提 issue 自动带出
- [x] 模板注释给出复杂 issue 展开指引(约束/入口/关联),指向 docs/issue-contract.md
- [x] 面板 issue 列表对缺『目标/验收标准/依赖』的 issue 显示『不满足契约』标记并列出缺失项
- [x] 契约不满足的 issue 不进入自动选取(contract.ok 供 #9 消费);人工仍可查看与开始开发,按钮提示补全
- [x] issue 数据携带 contract.ok / contract.missing 字段
- [x] 补齐契约后标记自动消失(纯派生,无状态)

## 依赖

Closes #8
