### PR TITLE
feat: 合并门禁支持同步等价免重审 (issue #48)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1561,6 +1561,76 @@ function sameCommitHash(reviewedHash: string, prHead: string): boolean {
     && (reviewed === head || head.startsWith(reviewed) || reviewed.startsWith(head))
 }
 
+/**
+ * 判定实时 PR HEAD 是否为「R 与 origin/main 的纯同步合并」(issue #48):
+ * H 必须是恰好两个父提交的 merge commit,其中一个父提交精确等于被审提交 R
+ * (R 的任何后代 —— 分支侧新提交、叠加 merge —— 都不放行),另一个父提交位于
+ * 当前 origin/main 的历史上,且 H 的树与 git merge-tree 对两父的自动合并结果
+ * 完全一致 —— 任何手工冲突决断(哪怕一行)都会破坏该等价。
+ * 任一 git 事实无法核实时按不满足处理(fail closed)。
+ */
+export async function isSyncEquivalentMerge(
+  ctx: Context,
+  worktree: string,
+  reviewedHash: string,
+  prHead: string,
+): Promise<boolean> {
+  if (!existsSync(worktree)) return false
+  const policy = { mode: 'danger-full-access' as const, workspaceRoot: worktree }
+  const gitOk = async (args: string, timeoutMs = 30_000): Promise<boolean> => {
+    try {
+      await runCommand(ctx, `git ${args}`, { workdir: worktree, timeoutMs, sandboxPolicy: policy })
+      return true
+    } catch {
+      return false
+    }
+  }
+  const gitOut = async (args: string): Promise<string | null> => {
+    try {
+      const output = await runCommand(ctx, `git ${args}`, { workdir: worktree, timeoutMs: 30_000, sandboxPolicy: policy })
+      return output.trim() || null
+    } catch {
+      return null
+    }
+  }
+  // 先同步远端:被检的 H(远端分支 HEAD)与最新 origin/main 对象必须在本地可解析
+  if (!await gitOk('fetch origin --prune', 60_000)) return false
+  const head = await gitOut(`rev-parse --verify ${shellQuote(`${prHead}^{commit}`)}`)
+  const reviewed = await gitOut(`rev-parse --verify ${shellQuote(`${reviewedHash}^{commit}`)}`)
+  if (!head || !reviewed || head === reviewed) return false
+  const parentsLine = await gitOut(`rev-list --parents -n 1 ${head}`)
+  if (!parentsLine) return false
+  const [headOid, ...parents] = parentsLine.split(/\s+/)
+  if (headOid !== head || parents.length !== 2) return false
+  if (!parents.includes(reviewed)) return false
+  const mainSide = parents[0] === reviewed ? parents[1] : parents[0]
+  // 另一父必须位于当前 origin/main 历史上(同步来源只能是 main)
+  const mergeBase = await gitOut(`merge-base ${mainSide} origin/main`)
+  if (!mergeBase || mergeBase !== mainSide) return false
+  // 树等价:H 的树必须与 R、main 侧的干净自动合并结果逐字节一致
+  const autoTree = await gitOut(`merge-tree --write-tree ${reviewed} ${mainSide}`)
+  const headTree = autoTree === null ? null : await gitOut(`rev-parse ${head}^{tree}`)
+  return !!autoTree && !!headTree && headTree === autoTree.split(/\s+/)[0]
+}
+
+/**
+ * 合并门禁的 HEAD 一致性校验(issue #48):R 与 H 哈希一致直接放行;不一致时
+ * 唯一例外是 H 为 R 与最新 origin/main 的纯同步合并,其余(含 H 比 R 旧、
+ * 分叉、分支侧新提交)一律要求重新 Review。
+ */
+export async function assertReviewHeadMatchesPr(
+  ctx: Context,
+  worktree: string,
+  reviewedHash: string | null,
+  prHead: string | null | undefined,
+): Promise<void> {
+  if (prHead && reviewedHash) {
+    if (sameCommitHash(reviewedHash, prHead)) return
+    if (await isSyncEquivalentMerge(ctx, worktree, reviewedHash, prHead)) return
+  }
+  throw new Error('合并门禁拒绝:实时 PR HEAD 与最近一次通过的 review 结论哈希不一致,且不满足同步等价,需重新 Review')
+}
+
 /** Server-side merge gate: unknown and changed contracts both fail closed. */
 async function assertReviewContractCurrent(ctx: Context, workflow: IssueWorkflow): Promise<void> {
   const reviewedContract = latestPassingReview(workflow)?.issueContract
@@ -1595,10 +1665,7 @@ async function mergeAuthorizationPreview(ctx: Context, url: string): Promise<{
   if (lookup.pr.state === 'CLOSED') throw new Error('PR 已关闭且未合并,不能执行合并')
   if (lookup.pr.headRefName !== workflow.branch) throw new Error('实时 PR 分支与 workflow 不一致,拒绝合并')
   if (!workflow.delivery) {
-    const reviewedHash = latestPassingReviewHash(workflow)
-    if (!lookup.pr.headRefOid || !reviewedHash || !sameCommitHash(reviewedHash, lookup.pr.headRefOid)) {
-      throw new Error('合并门禁拒绝:实时 PR HEAD 与最近一次通过的 review 结论哈希不一致')
-    }
+    await assertReviewHeadMatchesPr(ctx, workflow.worktree, latestPassingReviewHash(workflow), lookup.pr.headRefOid)
     await assertReviewContractCurrent(ctx, workflow)
   }
   return {
@@ -1719,11 +1786,8 @@ async function mergeAndCleanupUnlocked(ctx: Context, payload: unknown): Promise<
   if (!pr.headRefOid) return { ok: false, error: '实时 PR HEAD 缺失,拒绝合并' }
 
   if (!workflow.delivery) {
-    const reviewedHash = latestPassingReviewHash(workflow)
-    if (!reviewedHash || !sameCommitHash(reviewedHash, pr.headRefOid)) {
-      return { ok: false, error: '合并门禁拒绝:实时 PR HEAD 与最近一次通过的 review 结论哈希不一致' }
-    }
     try {
+      await assertReviewHeadMatchesPr(ctx, workflow.worktree, latestPassingReviewHash(workflow), pr.headRefOid)
       await assertReviewContractCurrent(ctx, workflow)
     } catch (error) {
       return { ok: false, error: String(error instanceof Error ? error.message : error) }

--- a/tests/sync-equivalence.test.ts
+++ b/tests/sync-equivalence.test.ts
@@ -1,0 +1,191 @@
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import test from 'node:test'
+import { assertReviewHeadMatchesPr, isSyncEquivalentMerge } from '../src/index.ts'
+
+const execFileAsync = promisify(execFile)
+
+/** A minimal real-shell ctx: resolve passes the spec through, run executes it. */
+function realShellCtx() {
+  return {
+    shell: {
+      resolve(spec: unknown) { return spec },
+      async run(spec: { command: string; workdir?: string }) {
+        try {
+          const out = await execFileAsync('/bin/sh', ['-c', spec.command], {
+            cwd: spec.workdir, encoding: 'utf8',
+          })
+          return { exitCode: 0, stdout: { text: out.stdout }, stderr: { text: out.stderr } }
+        } catch (error) {
+          const e = error as { code?: number; stdout?: string; stderr?: string }
+          return { exitCode: e.code ?? 1, stdout: { text: e.stdout ?? '' }, stderr: { text: e.stderr ?? '' } }
+        }
+      },
+    },
+  }
+}
+
+const ctx = realShellCtx() as never
+
+/**
+ * 基础仓库:main 上有 base.md;worktree 分支上完成被审提交 R(与 main 改动
+ * 不冲突),随后 main 前进 —— 即 review 通过后需要同步的标准现场。
+ */
+async function setupSyncScene(options: { branchEditsConflictFile?: boolean } = {}) {
+  const root = await mkdtemp(join(tmpdir(), 'clickvibe-sync-equiv-'))
+  const remote = join(root, 'remote.git')
+  const repo = join(root, 'repo')
+  const worktree = join(root, 'issue')
+  const branch = 'clickvibe-issue-48'
+  const git = (...args: string[]) => execFileAsync('git', ['-C', repo, ...args])
+  const wt = (...args: string[]) => execFileAsync('git', ['-C', worktree, ...args])
+  const remoteGit = (...args: string[]) => execFileAsync('git', [`--git-dir=${remote}`, ...args])
+  await execFileAsync('git', ['init', '--bare', remote])
+  await execFileAsync('git', ['clone', remote, repo])
+  await git('config', 'user.name', 'clickvibe-test')
+  await git('config', 'user.email', 'clickvibe-test@example.invalid')
+  await writeFile(join(repo, 'base.md'), 'base A\n')
+  await git('add', '.')
+  await git('commit', '-m', 'base A')
+  await git('branch', '-M', 'main')
+  await git('push', '-u', 'origin', 'main')
+  await remoteGit('symbolic-ref', 'HEAD', 'refs/heads/main')
+  await git('fetch', 'origin', '--prune')
+  await git('worktree', 'add', '-b', branch, worktree, 'origin/main')
+  // 被审提交 R:分支侧改动
+  await writeFile(join(worktree, options.branchEditsConflictFile ? 'base.md' : 'feature.md'), 'dev work\n')
+  await wt('add', '.')
+  await wt('commit', '-m', 'dev work (reviewed R)')
+  await wt('push', '-u', 'origin', branch)
+  const reviewedShort = (await wt('rev-parse', '--short', 'HEAD')).stdout.trim()
+  const reviewedFull = (await wt('rev-parse', 'HEAD')).stdout.trim()
+  // review 通过后 main 前进
+  await git('switch', 'main')
+  await writeFile(join(repo, 'base.md'), `base B\n${options.branchEditsConflictFile ? 'main extra\n' : ''}`)
+  await git('add', '.')
+  await git('commit', '-m', 'main advances')
+  await git('push', 'origin', 'main')
+  const remoteBranchHead = async () =>
+    (await remoteGit('rev-parse', `refs/heads/${branch}`)).stdout.trim()
+  return { root, remote, repo, worktree, branch, git, wt, remoteGit, reviewedShort, reviewedFull, remoteBranchHead }
+}
+
+test('pure sync merge of R with origin/main is sync-equivalent (issue #48)', async () => {
+  const scene = await setupSyncScene()
+  try {
+    // 同步:worktree 合并最新 origin/main 并推送(PR HEAD H ≠ R)
+    await scene.wt('merge', '--no-edit', 'origin/main')
+    await scene.wt('push', 'origin', scene.branch)
+    const head = await scene.remoteBranchHead()
+    assert.notEqual(head, scene.reviewedFull)
+
+    assert.equal(await isSyncEquivalentMerge(ctx, scene.worktree, scene.reviewedShort, head), true)
+    // 全量哈希与短哈希均可判定
+    assert.equal(await isSyncEquivalentMerge(ctx, scene.worktree, scene.reviewedFull, head), true)
+    // 门禁:H 为纯同步合并时放行
+    await assert.doesNotReject(assertReviewHeadMatchesPr(ctx, scene.worktree, scene.reviewedShort, head))
+  } finally {
+    await rm(scene.root, { recursive: true, force: true })
+  }
+})
+
+test('identical hashes pass the gate without any git access (regression, issue #48)', async () => {
+  // worktree 指向不存在的路径,证明哈希相等时完全短路、不触发 git
+  await assert.doesNotReject(
+    assertReviewHeadMatchesPr(ctx, '/nonexistent/worktree', 'abc1234', 'abc1234def5678'),
+  )
+})
+
+test('manual conflict resolution in the sync merge breaks equivalence (issue #48)', async () => {
+  const scene = await setupSyncScene({ branchEditsConflictFile: true })
+  try {
+    // 冲突同步:分支与 main 改同一文件,人工改写一行后完成 merge
+    await assert.rejects(scene.wt('merge', '--no-edit', 'origin/main'))
+    await writeFile(join(scene.worktree, 'base.md'), 'manually resolved, not a clean merge\n')
+    await scene.wt('add', '.')
+    await scene.wt('commit', '--no-edit')
+    await scene.wt('push', 'origin', scene.branch)
+    const head = await scene.remoteBranchHead()
+
+    assert.equal(await isSyncEquivalentMerge(ctx, scene.worktree, scene.reviewedShort, head), false)
+    await assert.rejects(
+      assertReviewHeadMatchesPr(ctx, scene.worktree, scene.reviewedShort, head),
+      /合并门禁拒绝/,
+    )
+  } finally {
+    await rm(scene.root, { recursive: true, force: true })
+  }
+})
+
+test('branch-side commit after the sync merge is rejected (issue #48)', async () => {
+  const scene = await setupSyncScene()
+  try {
+    await scene.wt('merge', '--no-edit', 'origin/main')
+    // 同步之后又叠加分支侧新提交:即使树差异来自 R 之外也不放行
+    await writeFile(join(scene.worktree, 'feature.md'), 'dev work\nextra branch commit\n')
+    await scene.wt('add', '.')
+    await scene.wt('commit', '-m', 'extra branch commit after sync')
+    await scene.wt('push', 'origin', scene.branch)
+    const head = await scene.remoteBranchHead()
+
+    assert.equal(await isSyncEquivalentMerge(ctx, scene.worktree, scene.reviewedShort, head), false)
+    await assert.rejects(
+      assertReviewHeadMatchesPr(ctx, scene.worktree, scene.reviewedShort, head),
+      /合并门禁拒绝/,
+    )
+  } finally {
+    await rm(scene.root, { recursive: true, force: true })
+  }
+})
+
+test('PR head older than R (force-push fork) is rejected (issue #48)', async () => {
+  const scene = await setupSyncScene()
+  try {
+    // 远端分支被拨回 R 的父提交:PR HEAD 比 R 旧
+    const parent = (await scene.wt('rev-parse', `${scene.reviewedFull}^`)).stdout.trim()
+    await scene.git('push', '-f', 'origin', `${parent}:refs/heads/${scene.branch}`)
+    const head = await scene.remoteBranchHead()
+
+    assert.equal(await isSyncEquivalentMerge(ctx, scene.worktree, scene.reviewedShort, head), false)
+  } finally {
+    await rm(scene.root, { recursive: true, force: true })
+  }
+})
+
+test('merging a non-main branch into R is not sync-equivalent (issue #48)', async () => {
+  const scene = await setupSyncScene()
+  try {
+    // 另一条非 main 分支上的提交,合并进 R:即使树等价也拒绝
+    await scene.git('switch', '-c', 'side-branch', 'origin/main~1')
+    await writeFile(join(scene.repo, 'side.md'), 'side change\n')
+    await scene.git('add', '.')
+    await scene.git('commit', '-m', 'side change')
+    await scene.git('push', '-u', 'origin', 'side-branch')
+    await scene.wt('fetch', 'origin')
+    await scene.wt('merge', '--no-edit', 'origin/side-branch')
+    await scene.wt('push', 'origin', scene.branch)
+    const head = await scene.remoteBranchHead()
+
+    assert.equal(await isSyncEquivalentMerge(ctx, scene.worktree, scene.reviewedShort, head), false)
+  } finally {
+    await rm(scene.root, { recursive: true, force: true })
+  }
+})
+
+test('missing reviewed commit locally fails closed (issue #48)', async () => {
+  const scene = await setupSyncScene()
+  try {
+    // R 在本地不存在(如对象被回收):无法核实即不满足
+    const head = await scene.remoteBranchHead()
+    assert.equal(
+      await isSyncEquivalentMerge(ctx, scene.worktree, '0123456789abcdef0123456789abcdef01234567', head),
+      false,
+    )
+  } finally {
+    await rm(scene.root, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
Closes #48

## 改动

- 新增 `isSyncEquivalentMerge(ctx, worktree, reviewedHash, prHead)`:在 worktree 内用 git 事实判定实时 PR HEAD H 是否为「被审提交 R 与最新 origin/main 的纯同步合并」:
  - `git fetch origin --prune` 确保 H 与 origin/main 对象在本地
  - H 必须是**恰好两个父提交**的 merge commit,其中一个父提交**精确等于** R(排除分支侧新提交、叠加 merge、rebase/force-push 分叉)
  - 另一父必须位于当前 origin/main 历史上(`merge-base` 等值断言,排除合并非 main 分支)
  - **树等价**:H 的树必须与 `git merge-tree --write-tree R M` 的自动合并结果逐字节一致 —— 任何手工冲突决断(哪怕一行)都会破坏等价
  - 任一 git 事实无法核实即 fail closed(不满足)
- 新增共享门禁 `assertReviewHeadMatchesPr`:哈希相等(`sameCommitHash\))直接放行;不一致时唯一例外是同步等价,其余一律要求重新 Review。`mergeAuthorizationPreview` 与 `mergeAndCleanupUnlocked` 两处内联判断替换为该门禁
- 契约门禁 `assertReviewContractCurrent`(issueContract 快照 + bodyHash)不动,仍在 HEAD 校验之后执行
- 不引入自动合并:合并仍需人在面板确认

## 测试

新增 `tests/sync-equivalence.test.ts`(真实 git 仓库,7 个用例):

- 纯同步合并 H → 放行(短/全量哈希均可判定)
- 哈希完全相等 → 门禁直接放行且不触发任何 git(回归最常见情形)
- 冲突同步中人工改写一行 → 拒绝
- 同步后叠加分支侧新提交 → 拒绝
- PR HEAD 旧于 R(force-push 拨回)→ 拒绝
- 合并非 main 分支(树等价但来源不合法)→ 拒绝
- R 本地不可解析 → fail closed 拒绝

`pnpm test` 全量 172 通过,`pnpm typecheck` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)