### PR TITLE
feat: issue 详情一键在 DSH 对应项目新开对话并预填 issue 链接

### DIFF
--- a/docs/plans/2026-08-23-dsh-issue-conversation-design.md
+++ b/docs/plans/2026-08-23-dsh-issue-conversation-design.md
@@ -1,0 +1,38 @@
+# issue 详情「在 DSH 对话中打开」设计(#53)
+
+> 2026-08-23。issue 详情视图一键在仓库对应的 DSH workspace 新开空白对话,
+> 并把 issue 链接预填进输入框草稿(不自动发送)。
+
+## 机制(实现前已对照 deepseek-harness 源码确认)
+
+全部走 DSH 客户端公开服务(`ctx.get(...)` 运行时解析,宿主注入):
+
+1. `workspaces.create({ path })` —— 宿主 `ensureWorkspace` 先
+   `resolveByPath`(realpath 规范化,任意拼写均可)再落库,
+   **幂等**:已注册则复用,未注册则自动注册。无需先查 list。
+2. `workspaces.connectWorkspace(workspaceId)` —— 建/复用该 workspace 的
+   空白会话,返回 sessionId。契约明确:返回的会话已进列表、binding 同步
+   可解析,**允许先写草稿再导航**。
+3. `conversation.input.for(sessions.scope(sessionId)).setDraft(url)` ——
+   ui-conversation 的 SessionInput 单一草稿写路径,只改草稿不发送。
+4. `sessions.open(sessionId)` —— 导航。
+
+失败语义:workspace/会话创建失败 → 不导航、报可读错误;草稿失败 →
+仍导航(session 已可开),再如实报告"草稿未预填"原因;workspaces/sessions
+服务缺失 → 直接报缺哪个服务。不静默失败。
+
+## 改动
+
+- `src/client/dsh-conversation.ts`(新)—— 桥接逻辑,服务面用本地结构
+  类型描述并依赖注入,纯逻辑可测。
+- `src/client/index.tsx` —— `DshOpenButton` 组件(issue 详情渲染,PR 不
+  渲染;远程配置禁用并给原因);`apply` 捕获 ctx 供按钮解析服务。
+- `tests/dsh-conversation.test.ts`(新)—— 注册幂等、草稿先于导航、
+  不发送、三类失败的可读错误、服务缺失命名。
+
+## 边界
+
+- 远程配置(无本机路径):按钮禁用,title 说明原因。
+- 仓库未配置:按钮禁用,提示配置路径。
+- config 路径含 `~`/symlink:服务端 projects 已展开 `~`;realpath 由宿主
+  规范化,幂等不受影响。

--- a/src/client/dsh-conversation.ts
+++ b/src/client/dsh-conversation.ts
@@ -1,0 +1,114 @@
+/**
+ * DSH 会话桥(issue #53):issue 详情 → 仓库本地路径对应 workspace 的
+ * 空白对话 + 预填 issue 链接草稿。
+ *
+ * 机制(均为 DSH 客户端公开服务,运行时由宿主注入,缺一不可):
+ * - workspaces.create({path})   按 realpath 幂等注册/复用 workspace
+ * - workspaces.connectWorkspace 建/复用该 workspace 的空白会话,返回会话 id
+ * - conversation.input.for(scope).setDraft  写草稿(在 open 之前,见
+ *   connectWorkspace 契约:返回的会话已进列表,允许先写草稿再导航)
+ * - sessions.open               导航到该会话
+ *
+ * 服务形态用本地结构类型描述(ui-conversation 不在编译期依赖里),全部
+ * 经依赖注入传入,便于纯逻辑测试。
+ */
+
+/** 对话输入的 session 域写草稿面(宿主 SessionInput 的最小结构)。 */
+export interface DshSessionInput {
+  setDraft(text: string): void
+}
+
+/** conversation 服务(ctx.get('conversation'))的最小结构。 */
+export interface DshConversation {
+  input: { for(actx: unknown): DshSessionInput }
+}
+
+/** sessions 服务(ctx.get('sessions'))的最小结构。 */
+export interface DshSessions {
+  open(id: string): void
+  scope(id: string): unknown | undefined
+}
+
+/** workspaces 服务(ctx.get('workspaces'))的最小结构。 */
+export interface DshWorkspaces {
+  create(input: { path: string }): Promise<{ workspaceId: string }>
+  connectWorkspace(workspaceId: string): Promise<string>
+}
+
+/** 完整桥接依赖;缺任何一个服务都无法完成全流程。 */
+export interface DshConversationDeps {
+  workspaces: DshWorkspaces
+  sessions: DshSessions
+  conversation: DshConversation | null
+}
+
+/** 从 DSH 客户端上下文解析桥接依赖;返回缺失的服务名供报错。 */
+export function resolveDshConversationDeps(ctx: {
+  get(name: string): unknown
+}): DshConversationDeps | { missing: string[] } {
+  const workspaces = ctx.get('workspaces')
+  const sessions = ctx.get('sessions')
+  const conversation = ctx.get('conversation')
+  const missing: string[] = []
+  if (workspaces === undefined || workspaces === null) missing.push('workspaces')
+  if (sessions === undefined || sessions === null) missing.push('sessions')
+  if (missing.length > 0) return { missing }
+  return {
+    workspaces: workspaces as DshWorkspaces,
+    sessions: sessions as DshSessions,
+    conversation: (conversation ?? null) as DshConversation | null,
+  }
+}
+
+export type DshOpenResult =
+  | { ok: true; warning?: string }
+  | { ok: false; error: string }
+
+/**
+ * 在 path 对应 workspace 的空白对话中预填 draftText(不发送)。
+ *
+ * 草稿失败不拦导航:会话能开就开,再如实报告草稿未预填的原因,
+ * 不静默失败。
+ */
+export async function openDshConversationDraft(
+  deps: DshConversationDeps,
+  path: string,
+  draftText: string,
+): Promise<DshOpenResult> {
+  let workspaceId: string
+  try {
+    // 幂等:宿主按 realpath 解析,已注册则复用,未注册则自动注册。
+    workspaceId = (await deps.workspaces.create({ path })).workspaceId
+  } catch (reason) {
+    return { ok: false, error: `DSH workspace 注册失败(${path}): ${errorMessage(reason)}` }
+  }
+
+  let sessionId: string
+  try {
+    sessionId = await deps.workspaces.connectWorkspace(workspaceId)
+  } catch (reason) {
+    return { ok: false, error: `DSH 空白会话创建失败: ${errorMessage(reason)}` }
+  }
+
+  // 先写草稿再导航(connectWorkspace 契约保证会话已可寻址)。
+  let draftError: string | null = null
+  try {
+    if (!deps.conversation) throw new Error('conversation 输入服务未注入')
+    const actx = deps.sessions.scope(sessionId)
+    if (actx === undefined) throw new Error(`会话 ${sessionId} 无法建立输入作用域`)
+    deps.conversation.input.for(actx).setDraft(draftText)
+  } catch (reason) {
+    draftError = `草稿未预填: ${errorMessage(reason)}`
+  }
+
+  try {
+    deps.sessions.open(sessionId)
+  } catch (reason) {
+    return { ok: false, error: `DSH 会话打开失败: ${errorMessage(reason)}${draftError ? `;${draftError}` : ''}` }
+  }
+  return draftError ? { ok: true, warning: `对话已打开,但${draftError}` } : { ok: true }
+}
+
+function errorMessage(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason)
+}

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -29,11 +29,18 @@ import {
   type LiveLogEvent,
 } from '../live-output.ts'
 import { resolveDesktopPanelWidth, resolvePanelLayout } from './panel-layout.ts'
+import { openDshConversationDraft, resolveDshConversationDeps } from './dsh-conversation.ts'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _SlotLoaders = [typeof LayoutController, SidebarFooterActionOwnerProps]
 
 const PANEL_ID = 'clickvibe'
 const MAX_BATCH_ISSUES = 10
+
+/**
+ * DSH 客户端上下文:apply 时捕获。「在 DSH 对话中打开」按钮经它解析
+ * workspaces / sessions / conversation 服务(运行时由宿主注入)。
+ */
+let clientCtx: ClientContext | null = null
 
 /** Panel open state shared between the footer toggle and the overlay. */
 const panelState: {
@@ -118,6 +125,11 @@ body[data-cv-panel-dragging] #root.cv-panel-host-open, body[data-cv-panel-draggi
 .cv-badge-kind { background: #f6f8fa; color: #57606a; }
 .cv-issue-title { font-size: 15px; font-weight: 700; color: #0969da; text-decoration: none; }
 .cv-issue-title:hover { text-decoration: underline; }
+.cv-dsh-open-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.cv-dsh-open-btn { border: 1px solid #d0d7de; background: #f6f8fa; border-radius: 6px; padding: 4px 10px; font-size: 12px; color: #1f2328; cursor: pointer; }
+.cv-dsh-open-btn:hover:not(:disabled) { background: #eff1f3; }
+.cv-dsh-open-btn:disabled { opacity: .55; cursor: not-allowed; }
+.cv-dsh-open-status { font-size: 11px; color: #9a6700; word-break: break-all; }
 .cv-issue-labels { display: flex; flex-wrap: wrap; gap: 4px; font-size: 11px; }
 .cv-issue-labels span { padding: 1px 6px; border-radius: 10px; background: #ddf4ff; color: #0969da; }
 .cv-issue-assignees { font-size: 12px; color: #57606a; }
@@ -524,7 +536,55 @@ function repoOf(url: string | undefined): string {
   return match ? match[1] : ''
 }
 
-function IssueView({ issue, kind, workflow, onWorkflow, timeline, dependencies, autoAction, onAutoActionHandled, onDelivered }: {
+/**
+ * 「在 DSH 对话中打开」按钮(issue #53):在仓库本地路径对应的 DSH
+ * workspace 新开空白对话并预填 issue 链接草稿,回车前不发送。
+ * 远程配置(无本机路径)或 DSH 服务缺失时禁用并给出原因,不静默失败。
+ */
+function DshOpenButton({ project, issueUrl }: { project: ProjectOption | null; issueUrl: string }) {
+  const [busy, setBusy] = React.useState(false)
+  const [status, setStatus] = React.useState<string | null>(null)
+  const disabledReason = !project
+    ? '该仓库未在 ~/.clickvibe/config.yaml 配置,无法定位本地路径'
+    : !project.available
+      ? '该仓库为远程配置(无本机路径),无法打开 DSH 对话'
+      : null
+
+  const onClick = async () => {
+    if (!project?.available || !clientCtx || busy) return
+    setBusy(true)
+    setStatus(null)
+    try {
+      const deps = resolveDshConversationDeps(clientCtx)
+      if ('missing' in deps) {
+        setStatus(`DSH 服务不可用(缺 ${deps.missing.join('、')}),无法打开对话`)
+        return
+      }
+      const result = await openDshConversationDraft(deps, project.path, issueUrl)
+      setStatus(result.ok ? result.warning ?? null : result.error)
+    } catch (reason) {
+      setStatus(`DSH 对话打开失败: ${reason instanceof Error ? reason.message : String(reason)}`)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="cv-dsh-open-row">
+      <button
+        className="cv-dsh-open-btn"
+        onClick={() => { void onClick() }}
+        disabled={disabledReason !== null || busy}
+        title={disabledReason ?? '在该仓库对应的 DSH 项目新开空白对话,并预填此 issue 链接(回车前不会发送)'}
+      >
+        {busy ? 'DSH 打开中…' : '💬 在 DSH 对话中打开'}
+      </button>
+      {status ? <span className="cv-dsh-open-status" role="status">{status}</span> : null}
+    </div>
+  )
+}
+
+function IssueView({ issue, kind, workflow, onWorkflow, timeline, dependencies, autoAction, onAutoActionHandled, onDelivered, project }: {
   issue: GhIssue
   kind: 'issue' | 'pr'
   workflow: Workflow | null
@@ -534,6 +594,8 @@ function IssueView({ issue, kind, workflow, onWorkflow, timeline, dependencies, 
   autoAction?: boolean
   onAutoActionHandled?: () => void
   onDelivered?: () => void
+  /** 当前 issue 所属仓库的本地配置;PR 详情不传,「在 DSH 对话中打开」随之不渲染。 */
+  project?: ProjectOption | null
 }) {
   const isPR = kind === 'pr'
   const state = String(issue.state || '').toUpperCase()
@@ -568,6 +630,7 @@ function IssueView({ issue, kind, workflow, onWorkflow, timeline, dependencies, 
         <span className="cv-badge cv-badge-kind">{isPR ? `PR #${issue.number}` : `Issue #${issue.number}`}</span>
       </div>
       <a className="cv-issue-title" href={issue.url} target="_blank" rel="noreferrer">{issue.title}</a>
+      {!isPR && issue.url ? <DshOpenButton project={project ?? null} issueUrl={String(issue.url)} /> : null}
       {labels ? <div className="cv-issue-labels">{labels.split(' ').map((l, i) => <span key={i}>{l}</span>)}</div> : null}
       {assignees ? <div className="cv-issue-assignees">👤 {assignees}</div> : null}
       <table className="cv-meta">
@@ -1975,6 +2038,7 @@ function PanelContent() {
           onWorkflow={updateWorkflow}
           timeline={result.timeline}
           dependencies={result.dependencies}
+          project={result.kind === 'issue' ? projects.find((p) => p.repoKey === repoOf(String(result.item.url ?? ''))) ?? null : null}
           autoAction={autoAction}
           onAutoActionHandled={() => setAutoAction(false)}
           onDelivered={() => {
@@ -2240,6 +2304,7 @@ export const inject = ['slots']
 export function apply(ctx: ClientContext): void {
   const slots = ctx.get('slots')
   if (slots === undefined) return
+  clientCtx = ctx
 
   ctx.effect(() => {
     const disposers: (() => void)[] = [installStyles()]

--- a/tests/dsh-conversation.test.ts
+++ b/tests/dsh-conversation.test.ts
@@ -1,0 +1,158 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  openDshConversationDraft,
+  resolveDshConversationDeps,
+  type DshConversationDeps,
+} from '../src/client/dsh-conversation.ts'
+
+interface Harness {
+  deps: DshConversationDeps
+  createdPaths: string[]
+  connected: string[]
+  opened: string[]
+  drafts: { sessionId: string; text: string }[]
+  connectError: Error | null
+  conversation: DshConversationDeps['conversation']
+}
+
+function makeHarness(): Harness {
+  const harness: Harness = {
+    deps: undefined as unknown as DshConversationDeps,
+    createdPaths: [],
+    connected: [],
+    opened: [],
+    drafts: [],
+    connectError: null,
+    conversation: null,
+  }
+  const scopeCtxBySession = new Map<string, object>([['session-blank-1', { scope: 'session-blank-1' }]])
+  harness.deps = {
+    workspaces: {
+      async create({ path }: { path: string }) {
+        harness.createdPaths.push(path)
+        return { workspaceId: `ws:${path}` }
+      },
+      async connectWorkspace(workspaceId: string) {
+        if (harness.connectError) throw harness.connectError
+        harness.connected.push(workspaceId)
+        return 'session-blank-1'
+      },
+    },
+    sessions: {
+      open(id: string) { harness.opened.push(id) },
+      scope(id: string) { return scopeCtxBySession.get(id) },
+    },
+    get conversation() { return harness.conversation },
+    set conversation(value) { harness.conversation = value },
+  }
+  return harness
+}
+
+/** 标准conversation 服务:记录 setDraft、绝不发送。 */
+function recordingConversation(harness: Harness): NonNullable<DshConversationDeps['conversation']> {
+  return {
+    input: {
+      for(actx: unknown) {
+        const sessionId = String((actx as { scope: string }).scope)
+        return {
+          setDraft(text: string) { harness.drafts.push({ sessionId, text }) },
+        }
+      },
+    },
+  }
+}
+
+test('opens a blank conversation with the issue link as draft, never sending', async () => {
+  const harness = makeHarness()
+  harness.conversation = recordingConversation(harness)
+  const result = await openDshConversationDraft(harness.deps, '/repo/local', 'https://github.com/o/r/issues/53')
+  assert.deepEqual(result, { ok: true })
+  assert.deepEqual(harness.createdPaths, ['/repo/local'])
+  assert.deepEqual(harness.connected, ['ws:/repo/local'])
+  assert.deepEqual(harness.drafts, [{ sessionId: 'session-blank-1', text: 'https://github.com/o/r/issues/53' }])
+  assert.deepEqual(harness.opened, ['session-blank-1'])
+})
+
+test('draft is written before navigation so the target machine exists', async () => {
+  const calls: string[] = []
+  const deps: DshConversationDeps = {
+    workspaces: {
+      async create() { return { workspaceId: 'ws' } },
+      async connectWorkspace() { return 'session-blank-1' },
+    },
+    sessions: {
+      open() { calls.push('open') },
+      scope: () => ({}),
+    },
+    conversation: { input: { for: () => ({ setDraft() { calls.push('setDraft') } }) } },
+  }
+  await openDshConversationDraft(deps, '/repo/local', 'https://github.com/o/r/issues/53')
+  assert.deepEqual(calls, ['setDraft', 'open'])
+})
+
+test('workspace path is registered (idempotently by the host) on every call', async () => {
+  const harness = makeHarness()
+  harness.conversation = recordingConversation(harness)
+  await openDshConversationDraft(harness.deps, '/repo/local', 'url-1')
+  await openDshConversationDraft(harness.deps, '/repo/local', 'url-2')
+  // create is the single registration entry: host resolves by realpath, so a
+  // repeat call reuses rather than duplicates.
+  assert.deepEqual(harness.createdPaths, ['/repo/local', '/repo/local'])
+  assert.equal(harness.connected.length, 2)
+})
+
+test('reports a readable error when the input service is missing but still navigates', async () => {
+  const harness = makeHarness()
+  harness.conversation = null
+  const result = await openDshConversationDraft(harness.deps, '/repo/local', 'https://github.com/o/r/issues/53')
+  assert.equal(result.ok, true)
+  if (result.ok) assert.match(result.warning ?? '', /草稿未预填.*conversation 输入服务未注入/)
+  assert.deepEqual(harness.opened, ['session-blank-1'])
+})
+
+test('reports a readable error when the session scope cannot be resolved', async () => {
+  const harness = makeHarness()
+  harness.conversation = recordingConversation(harness)
+  ;(harness.deps.sessions as { scope(id: string): unknown }).scope = () => undefined
+  const result = await openDshConversationDraft(harness.deps, '/repo/local', 'url')
+  assert.equal(result.ok, true)
+  if (result.ok) assert.match(result.warning ?? '', /草稿未预填/)
+  assert.deepEqual(harness.opened, ['session-blank-1'])
+})
+
+test('surfaces workspace registration failures without navigating', async () => {
+  const harness = makeHarness()
+  harness.conversation = recordingConversation(harness)
+  harness.deps.workspaces.create = async () => { throw new Error('no such directory') }
+  const result = await openDshConversationDraft(harness.deps, '/repo/local', 'url')
+  assert.equal(result.ok, false)
+  if (!result.ok) assert.match(result.error, /workspace 注册失败.*no such directory/)
+  assert.deepEqual(harness.opened, [])
+})
+
+test('surfaces blank-session connect failures without navigating', async () => {
+  const harness = makeHarness()
+  harness.conversation = recordingConversation(harness)
+  harness.connectError = new Error('host unavailable')
+  const result = await openDshConversationDraft(harness.deps, '/repo/local', 'url')
+  assert.equal(result.ok, false)
+  if (!result.ok) assert.match(result.error, /空白会话创建失败.*host unavailable/)
+  assert.deepEqual(harness.opened, [])
+})
+
+test('resolveDshConversationDeps names the missing services', () => {
+  const empty = resolveDshConversationDeps({ get: () => undefined })
+  assert.deepEqual(empty, { missing: ['workspaces', 'sessions'] })
+
+  const partial = resolveDshConversationDeps({
+    get: (name: string) => (name === 'sessions' ? { open() {}, scope() {} } : undefined),
+  })
+  assert.deepEqual(partial, { missing: ['workspaces'] })
+
+  const full = resolveDshConversationDeps({
+    get: (name: string) => (name === 'conversation' ? { input: { for: () => ({ setDraft() {} }) } } : { open() {}, scope() {}, create: async () => ({ workspaceId: 'ws' }), connectWorkspace: async () => 's' }),
+  })
+  assert.ok(!('missing' in full))
+  assert.equal(full.workspaces !== undefined && full.sessions !== undefined && full.conversation !== null, true)
+})


### PR DESCRIPTION
## 目标(#53)

issue 详情视图新增「💬 在 DSH 对话中打开」按钮:点击后在当前仓库本地路径对应的 DSH workspace 新开空白对话并导航,同时把该 issue 的 GitHub 链接预填进输入框草稿(不自动发送)。

## 机制(对照 deepseek-harness 源码逐项确认)

1. `workspaces.create({ path })` —— 宿主 `ensureWorkspace` 先 `resolveByPath`(realpath 规范化,任意拼写均可)再落库,幂等:已注册复用、未注册自动注册
2. `workspaces.connectWorkspace(id)` —— 建/复用空白会话;契约明确允许「先写草稿再导航」
3. `conversation.input.for(sessions.scope(sessionId)).setDraft(url)` —— 单一草稿写路径,只写不发
4. `sessions.open(sessionId)` —— 导航

## 验收标准对照

- [x] issue 详情出现按钮,PR 详情不渲染(`!isPR` 守卫)
- [x] 点击后导航到对应 workspace 空白对话;路径未注册时经幂等 create 自动注册
- [x] 草稿预填 issue 链接,仅有 setDraft、无任何 prompt/send
- [x] 远程配置(无本机路径)时按钮禁用,title 给出原因
- [x] DSH 服务缺失/各步失败时报可读错误,不静默失败;草稿失败仍导航后如实报告

## 改动

- 新增 `src/client/dsh-conversation.ts`:桥接逻辑,服务面为本地结构类型 + 依赖注入,纯逻辑可测
- `src/client/index.tsx`:`DshOpenButton` 组件 + `apply` 捕获 ctx
- 新增 `tests/dsh-conversation.test.ts`(8 用例);`docs/plans/2026-08-23-dsh-issue-conversation-design.md`

## 测试

`pnpm test` 211 通过(含新增 8 例),`pnpm typecheck`、`pnpm build` 通过。

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)