### PR TITLE
feat: issue 详情动作支持附加说明输入(开工/返工/恢复/review)

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -12,9 +12,9 @@ ClickVibe 的每个操作都有一条**纯文本命令形式**,可在对话中�
 | `projects` | 项目 | 列出 `~/.clickvibe/config.yaml` 配置的项目 | 否 |
 | `issues [repoKey]` | 列表 / 工单 | 列出项目 issue、依赖阻塞与下一步动作 | 否 |
 | `status <目标>` | 状态 / 看状态 / 进度 | 某 issue 的权威状态(分支/PR/review 结论/下一步) | 否 |
-| `develop <目标> [repoKey] [codex\|claude]` | 下单开发 / 开始开发 / 开发 | 下单开发,创建 worktree 并启动 agent | 是 |
+| `develop <目标> [repoKey] [codex\|claude] [context=…]` | 下单开发 / 开始开发 / 开发 | 下单开发,创建 worktree 并启动 agent;附加说明拼入 prompt(首次开工仍记「开发」) | 是 |
 | `develop <目标> dryrun`(或 `安全演练 <目标>`) | 安全演练 | 走完整流程但零代码副作用 | 否(仅回环校验) |
-| `review <目标> [repoKey] [codex\|claude]` | 审查 | 启动 review,结论发 PR/issue 评论 | 是 |
+| `review <目标> [repoKey] [codex\|claude] [context=…]` | 审查 | 启动 review,结论发 PR/issue 评论;附加说明拼入 review prompt | 是 |
 | `rework <目标> [context=…]` | 返工 / 按意见返工 | 按 review 意见返工(自动带上意见) | 是 |
 | `resume <目标> [context=…]` | 恢复 / 恢复开发 | 恢复中断的开发会话 | 是 |
 | `sync <目标>` | 同步 / 同步基线 | worktree 同步远端基线并推送 | 是(免授权,仍校验来源) |

--- a/src/client/action-context.ts
+++ b/src/client/action-context.ts
@@ -1,0 +1,41 @@
+/**
+ * 唯一动作「附加说明」输入框的纯状态判定(issue #54)。
+ *
+ * 交互规则来自验收标准,抽成纯函数(参照 panel-layout.ts 的可测模式):
+ * - 返工(rework)首次展开时预填当前 review 意见,可编辑,发送以输入框
+ *   最终文本为准;用户已输入的内容不覆盖;
+ * - 动作成功触发后清空并折叠,避免残留文本被下一次动作误带;
+ * - 实际发送内容为去首尾空白后的文本,空串即不随请求携带。
+ */
+
+/** 附加说明输入框的完整 UI 状态。 */
+export interface ActionContextState {
+  open: boolean
+  text: string
+}
+
+/**
+ * 展开/折叠切换后的输入框状态。返工首次展开(当前为空)且存在未通过的
+ * review 意见时预填意见;其余动作与折叠方向一律保持原文不动。
+ */
+export function toggledContext(
+  state: ActionContextState,
+  actionKind: string,
+  reviewIssues: string[] | null,
+): ActionContextState {
+  const open = !state.open
+  if (open && actionKind === 'rework' && state.text === '' && reviewIssues !== null && reviewIssues.length > 0) {
+    return { open, text: reviewIssues.join('\n') }
+  }
+  return { open, text: state.text }
+}
+
+/** 动作成功触发后的输入框状态:清空并折叠,残留文本不得进入下一次动作。 */
+export function clearedContext(): ActionContextState {
+  return { open: false, text: '' }
+}
+
+/** 动作触发时随 `context` 发送的内容;空串表示不携带,行为与现状一致。 */
+export function contextToSubmit(text: string): string {
+  return text.trim()
+}

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -260,6 +260,12 @@ body[data-cv-panel-dragging] #root.cv-panel-host-open, body[data-cv-panel-draggi
 .cv-dev-btn.cv-dev-merge { background: #1a7f37; }
 .cv-dev-link { border: none; background: transparent; color: #0969da; font-size: 11.5px; cursor: pointer; padding: 4px 2px; text-decoration: underline; }
 .cv-dev-link:hover { opacity: 0.8; }
+.cv-context { display: flex; flex-direction: column; align-items: flex-start; gap: 4px; flex: 1; min-width: 0; }
+.cv-context-toggle { border: none; background: transparent; color: #0969da; font-size: 11.5px; cursor: pointer; padding: 2px 0; text-decoration: underline; }
+.cv-context-toggle:hover { opacity: 0.8; }
+.cv-context-toggle:disabled { opacity: 0.45; cursor: not-allowed; }
+.cv-context-input { width: 100%; box-sizing: border-box; border: 1px solid #d0d7de; border-radius: 6px; padding: 6px 8px; font-size: 12px; font-family: inherit; line-height: 1.5; resize: vertical; }
+.cv-tl-user-context { color: #57606a; word-break: break-all; }
 `
 
 /** Inject the plugin stylesheet once; returns the disposer. */
@@ -769,6 +775,8 @@ interface WorkflowEvent {
   verdict?: { passed: boolean; issues: string[] }
   issueContract?: { bodyHash: string; updatedAt: string }
   fixed?: number
+  /** 用户附加说明(issue #54):动作触发时填写,只进本地时间线。 */
+  userContext?: string
   publication?: DeliveryPublication
   note?: string
   /** 人工放行审计(仅 merge-override 事件)。 */
@@ -903,6 +911,9 @@ function DevSection({ url, issue, workflow, onWorkflow, autoAction, onAutoAction
   const [streamState, setStreamState] = React.useState<'idle' | 'history' | 'connecting' | 'streaming' | 'retrying' | 'ended'>('idle')
   const [streamNotice, setStreamNotice] = React.useState<string | null>(null)
   const [agentChoice, setAgentChoice] = React.useState<'codex' | 'claude'>(() => workflow?.reviewAgent ?? workflow?.devAgent ?? 'codex')
+  /** 附加说明输入(issue #54):develop/resume/rework/review 可展开,触发后清空。 */
+  const [contextOpen, setContextOpen] = React.useState(false)
+  const [contextText, setContextText] = React.useState('')
   const esRef = React.useRef<EventSource | null>(null)
   const streamGenerationRef = React.useRef(0)
   const checkingStreamRef = React.useRef(false)
@@ -1090,6 +1101,12 @@ function DevSection({ url, issue, workflow, onWorkflow, autoAction, onAutoAction
     return { authorizationId: res.authorizationId, authorizationDigest: res.authorizationDigest, ...(res.target ? { target: res.target } : {}) }
   }
 
+  // 动作触发后清空附加说明输入框,避免残留文本被下一次动作误带(issue #54)。
+  const clearUserContext = () => {
+    setContextText('')
+    setContextOpen(false)
+  }
+
   const startDev = async (agent: 'codex' | 'claude' | 'dryrun', context?: string) => {
     setBusy('developing')
     setError(null)
@@ -1100,6 +1117,7 @@ function DevSection({ url, issue, workflow, onWorkflow, autoAction, onAutoAction
       if (agent !== 'dryrun' && !authorization) { setBusy(null); return }
       const res = await apiCall<{ ok: true; taskId: string; worktree: string; branch: string } | { ok: false; error: string }>('develop', { url, agent, ...(context ? { context } : {}), ...authorization })
       if (!res.ok) { setError(res.error); setBusy(null); return }
+      clearUserContext()
       await refresh()
       void openStream(res.taskId)
       setBusy(null)
@@ -1119,6 +1137,7 @@ function DevSection({ url, issue, workflow, onWorkflow, autoAction, onAutoAction
       if (!authorization) { setBusy(null); return }
       const res = await apiCall<{ ok: true; taskId: string } | { ok: false; error: string }>('resume', { url, agent, ...(context ? { context } : {}), ...authorization })
       if (!res.ok) { setError(res.error); setBusy(null); return }
+      clearUserContext()
       await refresh()
       void openStream(res.taskId)
       setBusy(null)
@@ -1127,16 +1146,17 @@ function DevSection({ url, issue, workflow, onWorkflow, autoAction, onAutoAction
     }
   }
 
-  const startReview = async (agent: 'codex' | 'claude') => {
+  const startReview = async (agent: 'codex' | 'claude', context = '') => {
     setBusy('reviewing')
     setError(null)
     setLogEvents([])
     setHistoryKind(null)
     try {
-      const authorization = await authorize('review', agent)
+      const authorization = await authorize('review', agent, context)
       if (!authorization) { setBusy(null); return }
-      const res = await apiCall<{ ok: true; taskId: string } | { ok: false; error: string }>('review', { url, agent, ...authorization })
+      const res = await apiCall<{ ok: true; taskId: string } | { ok: false; error: string }>('review', { url, agent, ...(context ? { context } : {}), ...authorization })
       if (!res.ok) { setError(res.error); setBusy(null); return }
+      clearUserContext()
       await refresh()
       void openStream(res.taskId)
       setBusy(null)
@@ -1291,11 +1311,14 @@ function DevSection({ url, issue, workflow, onWorkflow, autoAction, onAutoAction
       : { kind: 'none', label: '无', hint: '等待状态…' }))
 
   const runAction = () => {
+    const userContext = contextText.trim()
     switch (effectiveAction.kind) {
-      case 'develop': void startDev(agentChoice); break
-      case 'resume': void resume(); break
-      case 'rework': void resume(workflow?.reviewResult?.issues.join('\n')); break
-      case 'review': void startReview(agentChoice); break
+      case 'develop': void startDev(agentChoice, userContext); break
+      case 'resume': void resume(userContext); break
+      // 返工:textarea 预填当前 review 意见(可编辑),发送以输入框最终文本为准;
+      // 清空也不影响服务端既有的 review 意见自动注入(issue #54)。
+      case 'rework': void resume(userContext); break
+      case 'review': void startReview(agentChoice, userContext); break
       case 'sync': void syncWorktree(); break
       case 'create-pr':
         if (workflow) {
@@ -1324,6 +1347,21 @@ function DevSection({ url, issue, workflow, onWorkflow, autoAction, onAutoAction
   // review 锁定:从未 review 过则两个 agent 都可选;锁过只留那个
   const lockedAgent = effectiveAction.kind === 'review' ? workflow?.reviewAgent ?? null : null
   const showAgentToggle = effectiveAction.kind === 'develop' || effectiveAction.kind === 'review'
+
+  // 附加说明(issue #54):仅 develop/resume/rework/review 支持;merge/cleanup/sync 不加。
+  const contextSupported = effectiveAction.kind === 'develop'
+    || effectiveAction.kind === 'resume'
+    || effectiveAction.kind === 'rework'
+    || effectiveAction.kind === 'review'
+  const toggleContext = () => {
+    const next = !contextOpen
+    // 返工首次展开时预填当前 review 意见,供用户编辑;以输入框最终文本为发送内容。
+    if (next && effectiveAction.kind === 'rework' && contextText === ''
+      && workflow?.reviewResult && !workflow.reviewResult.passed) {
+      setContextText(workflow.reviewResult.issues.join('\n'))
+    }
+    setContextOpen(next)
+  }
 
   const actionButtonClass = effectiveAction.kind === 'merge' || effectiveAction.kind === 'cleanup'
     ? 'cv-dev-btn cv-dev-merge'
@@ -1467,6 +1505,29 @@ function DevSection({ url, issue, workflow, onWorkflow, autoAction, onAutoAction
             >
               {busyLabel ?? effectiveAction.label}
             </button>
+            {contextSupported ? (
+              <div className="cv-context">
+                <button
+                  className="cv-context-toggle"
+                  onClick={toggleContext}
+                  disabled={busy !== null}
+                  title="展开后可填写附加说明,随动作拼入 agent prompt;留空则与现状一致"
+                >
+                  附加说明(可选) {contextOpen ? '▾' : '▸'}
+                </button>
+                {contextOpen ? (
+                  <textarea
+                    className="cv-context-input"
+                    value={contextText}
+                    onChange={(event) => setContextText(event.target.value)}
+                    rows={3}
+                    placeholder={effectiveAction.kind === 'rework'
+                      ? '已预填当前 Review 意见,可编辑;发送以这里的最终文本为准'
+                      : '补充给 agent 的附加上下文,可留空'}
+                  />
+                ) : null}
+              </div>
+            ) : null}
           </>
         )}
         {stage === 'idle' && effectiveAction.kind === 'develop' ? (
@@ -1543,6 +1604,11 @@ function DevSection({ url, issue, workflow, onWorkflow, autoAction, onAutoAction
                 ? <span className="cv-tl-note">修复 {ev.fixed} 个问题</span>
                 : null}
               {ev.note ? <span className="cv-tl-note">{ev.note}</span> : null}
+              {ev.userContext ? (
+                <span className="cv-tl-user-context" title={ev.userContext}>
+                  用户附加说明:{ev.userContext.length > 80 ? `${ev.userContext.slice(0, 80)}…` : ev.userContext}
+                </span>
+              ) : null}
               {ev.publication?.status === 'posted'
                 ? ev.publication.url
                   ? <a className="cv-tl-public" href={ev.publication.url} target="_blank" rel="noreferrer">

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -29,6 +29,7 @@ import {
   type LiveLogEvent,
 } from '../live-output.ts'
 import { resolveDesktopPanelWidth, resolvePanelLayout } from './panel-layout.ts'
+import { clearedContext, contextToSubmit, toggledContext } from './action-context.ts'
 import { openDshConversationDraft, resolveDshConversationDeps } from './dsh-conversation.ts'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _SlotLoaders = [typeof LayoutController, SidebarFooterActionOwnerProps]
@@ -1166,8 +1167,9 @@ function DevSection({ url, issue, workflow, onWorkflow, autoAction, onAutoAction
 
   // 动作触发后清空附加说明输入框,避免残留文本被下一次动作误带(issue #54)。
   const clearUserContext = () => {
-    setContextText('')
-    setContextOpen(false)
+    const next = clearedContext()
+    setContextText(next.text)
+    setContextOpen(next.open)
   }
 
   const startDev = async (agent: 'codex' | 'claude' | 'dryrun', context?: string) => {
@@ -1374,7 +1376,7 @@ function DevSection({ url, issue, workflow, onWorkflow, autoAction, onAutoAction
       : { kind: 'none', label: '无', hint: '等待状态…' }))
 
   const runAction = () => {
-    const userContext = contextText.trim()
+    const userContext = contextToSubmit(contextText)
     switch (effectiveAction.kind) {
       case 'develop': void startDev(agentChoice, userContext); break
       case 'resume': void resume(userContext); break
@@ -1417,13 +1419,13 @@ function DevSection({ url, issue, workflow, onWorkflow, autoAction, onAutoAction
     || effectiveAction.kind === 'rework'
     || effectiveAction.kind === 'review'
   const toggleContext = () => {
-    const next = !contextOpen
-    // 返工首次展开时预填当前 review 意见,供用户编辑;以输入框最终文本为发送内容。
-    if (next && effectiveAction.kind === 'rework' && contextText === ''
-      && workflow?.reviewResult && !workflow.reviewResult.passed) {
-      setContextText(workflow.reviewResult.issues.join('\n'))
-    }
-    setContextOpen(next)
+    // 返工首次展开时预填当前 review 意见(纯函数判定,见 action-context.ts)。
+    const prefillIssues = workflow?.reviewResult && !workflow.reviewResult.passed
+      ? workflow.reviewResult.issues
+      : null
+    const next = toggledContext({ open: contextOpen, text: contextText }, effectiveAction.kind, prefillIssues)
+    setContextText(next.text)
+    setContextOpen(next.open)
   }
 
   const actionButtonClass = effectiveAction.kind === 'merge' || effectiveAction.kind === 'cleanup'

--- a/src/index.ts
+++ b/src/index.ts
@@ -2577,9 +2577,12 @@ function buildDevelopPrompt(
   workflow: IssueWorkflow,
   resolved: ResolvedPromptSnapshot,
   extraContext: string,
+  firstDevelopment: boolean,
 ): string {
+  // 附加说明只把「非首次开发」升级为返工;首次开工带说明仍是开发(issue #54)。
+  const rework = extraContext !== '' && !firstDevelopment
   return buildStagePrompt({
-    stage: extraContext === '' ? 'develop' : 'rework',
+    stage: rework ? 'rework' : 'develop',
     ...resolved,
     worktree: workflow.worktree,
     status: [
@@ -2599,6 +2602,7 @@ async function buildReviewPrompt(
   resolved: ResolvedPromptSnapshot,
   reviewedHead: string,
   sessionId: string | null = null,
+  extraContext = '',
 ): Promise<string> {
   // 解析 base:PR 有 baseRefName(若记录过),否则尝试 origin/HEAD 主干
   let base = 'origin/main'
@@ -2619,6 +2623,7 @@ async function buildReviewPrompt(
       `对比 base: ${base}`,
       `契约正文 SHA-256: ${contractHash}`,
       `会话模式: ${sessionId ? `续接 review 会话 ${sessionId};保留既有审查记忆` : '全新 review 会话'}`,
+      ...(extraContext ? ['附加上下文:', extraContext] : []),
     ],
     requirements: [
       '先执行 git fetch origin 同步远端最新状态(并行开发时 base 可能已变化)。',
@@ -3231,6 +3236,8 @@ async function startDevelop(
   // issue 已校验为 OPEN(真实 agent 走授权快照,dryrun 走抓取校验)
   workflow.issueState = 'OPEN'
   if (launchSnapshot) workflow.issueSnapshot = launchSnapshot.snapshot
+  // 首次开工 = 本地无任何开发/返工交付记录;带附加说明也不得误判为返工(issue #54)。
+  const firstDevelopment = !workflow.events.some((event) => event.kind === 'dev' || event.kind === 'rework')
 
   if (agent === 'dryrun') {
     // A safety probe is not a new durable development generation: never
@@ -3286,7 +3293,7 @@ async function startDevelop(
   void (async () => {
     try {
       pushTaskLine(live, `[clickvibe] 使用${launchSnapshot.freshness === 'current' ? '当前' : '持久化回退(可能过期)'} Issue 快照(${launchSnapshot.snapshot.updatedAt || '无更新时间'})`)
-      const prompt = buildDevelopPrompt(workflow, launchSnapshot, extraContext)
+      const prompt = buildDevelopPrompt(workflow, launchSnapshot, extraContext, firstDevelopment)
 
       pushTaskLine(live, `[clickvibe] 启动 ${agent} 开发…`)
       const agentCommand = buildFreshAgentCommand(agent)
@@ -3300,7 +3307,7 @@ async function startDevelop(
             // 开发完成(含 rework):旧的 review 结论已归档到 events 历史,
             // 当前回到"待 review"——不能继续显示"Review 未通过"
             const head = await readWorktreeHead(ctx, workflow.worktree)
-            await recordDevDelivery(ctx, reloaded, agent, head, fixedIssues, extraContext !== '' ? 'rework' : 'dev')
+            await recordDevDelivery(ctx, reloaded, agent, head, fixedIssues, extraContext !== '' && !firstDevelopment ? 'rework' : 'dev', extraContext)
           }
           await saveWorkflow(reloaded)
         }
@@ -3604,8 +3611,9 @@ async function startReview(
   | { ok: true; taskId: string }
   | { ok: false; error: string }
 > {
-  const body = (payload ?? {}) as { url?: unknown; agent?: unknown }
+  const body = (payload ?? {}) as { url?: unknown; agent?: unknown; context?: unknown }
   const url = String(body.url ?? '').trim()
+  const extraContext = typeof body.context === 'string' ? body.context.trim() : ''
   const parsedAgent = parseAgent(body.agent)
   if (parsedAgent === 'dryrun') return { ok: false, error: 'review 不支持 dryrun' }
   const agent: AgentKind = parsedAgent
@@ -3723,7 +3731,7 @@ async function startReview(
   const agentCommand = sessionId
     ? buildResumeAgentCommand(agent, sessionId)
     : buildFreshAgentCommand(agent)
-  const prompt = await buildReviewPrompt(ctx, workflow, resolvedSnapshot, reviewedHead, sessionId)
+  const prompt = await buildReviewPrompt(ctx, workflow, resolvedSnapshot, reviewedHead, sessionId, extraContext)
 
   pushTaskLine(live, `[clickvibe] 启动 ${agent} review${sessionId ? `(续会话 ${sessionId})` : ''}…`)
   attachAgentProcess(ctx, live, agentCommand, workflow.worktree, prompt, async (exitCode, newSessionId) => {
@@ -3772,6 +3780,8 @@ async function startReview(
         verdict: { passed, issues },
         issueContract: reviewIssue.contract,
         note: `${agent} review${passed ? ' 通过' : ` 发现 ${issues.length} 个问题`}`,
+        // 用户附加说明只进本地事件时间线,不进 GitHub 评论(issue #54)。
+        ...(extraContext !== '' ? { userContext: extraContext } : {}),
       }
       await appendEvent(reloaded, event)
       const issueNumber = parseUrl(reloaded.url)?.number ?? 'unknown'
@@ -3801,7 +3811,7 @@ async function startReview(
       if (reloaded && clearStaleSessionId(reloaded, 'review', sessionId)) await saveWorkflow(reloaded)
       return {
         command: buildFreshAgentCommand(agent),
-        prompt: await buildReviewPrompt(ctx, workflow, resolvedSnapshot, reviewedHead),
+        prompt: await buildReviewPrompt(ctx, workflow, resolvedSnapshot, reviewedHead, null, extraContext),
       }
     },
   } : undefined)
@@ -3817,6 +3827,7 @@ async function recordDevDelivery(
   head: string | null,
   fixedIssues: string[],
   kind: 'dev' | 'rework',
+  userContext = '',
 ): Promise<void> {
   if (!workflow.prNumber) {
     const pr = await detectLinkedPr(ctx, workflow.repoKey, workflow.branch)
@@ -3828,6 +3839,8 @@ async function recordDevDelivery(
     hash: head ?? undefined,
     fixed: fixedIssues.length,
     note: `${agent} 完成开发${kind === 'rework' ? '(按 review 意见返工)' : ''}`,
+    // 用户附加说明只进本地事件时间线,不进 GitHub 评论(issue #54)。
+    ...(userContext !== '' ? { userContext } : {}),
   }
   await appendEvent(workflow, event)
   const issueNumber = parseUrl(workflow.url)?.number ?? 'unknown'
@@ -3967,7 +3980,7 @@ export async function resumeDevelop(
         // rework 完成:旧的 review 结论已归档到 events,回到"待 review",
         // 不能继续显示"Review 未通过"让用户无限重复点
         const head = await readWorktreeHead(ctx, workflow.worktree)
-        await recordDevDelivery(ctx, reloaded, agent, head, fixedIssues, 'rework')
+        await recordDevDelivery(ctx, reloaded, agent, head, fixedIssues, 'rework', extraContext)
       }
       await saveWorkflow(reloaded)
     }

--- a/src/state.ts
+++ b/src/state.ts
@@ -83,6 +83,8 @@ export interface WorkflowEvent {
   issueContract?: IssueContractSnapshot
   /** 本次开发完成前仍待修复的上一轮 review 问题数。 */
   fixed?: number
+  /** 用户在动作触发时填写的附加说明(issue #54);只进 prompt 与本地时间线,不发布到 GitHub。 */
+  userContext?: string
   /** 对应公开 GitHub 流水节点的发布结果;缺失表示旧的本地事件。 */
   publication?: DeliveryPublication
   note?: string

--- a/tests/action-context.test.ts
+++ b/tests/action-context.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  clearedContext,
+  contextToSubmit,
+  toggledContext,
+} from '../src/client/action-context.ts'
+
+test('rework prefills the current review issues on first expand', () => {
+  const next = toggledContext(
+    { open: false, text: '' },
+    'rework',
+    ['修复竞态', '补充失败测试'],
+  )
+  assert.deepEqual(next, { open: true, text: '修复竞态\n补充失败测试' })
+})
+
+test('rework expand keeps user-edited text instead of overwriting it', () => {
+  const next = toggledContext(
+    { open: false, text: '用户已编辑的说明' },
+    'rework',
+    ['修复竞态'],
+  )
+  assert.deepEqual(next, { open: true, text: '用户已编辑的说明' })
+})
+
+test('rework expand without review issues stays empty and other actions never prefill', () => {
+  assert.deepEqual(
+    toggledContext({ open: false, text: '' }, 'rework', []),
+    { open: true, text: '' },
+  )
+  assert.deepEqual(
+    toggledContext({ open: false, text: '' }, 'rework', null),
+    { open: true, text: '' },
+  )
+  // develop / resume / review 不预填,即便存在 review 意见。
+  for (const kind of ['develop', 'resume', 'review']) {
+    assert.deepEqual(
+      toggledContext({ open: false, text: '' }, kind, ['修复竞态']),
+      { open: true, text: '' },
+    )
+  }
+})
+
+test('collapsing preserves the text for the next expand', () => {
+  const next = toggledContext(
+    { open: true, text: '暂存的说明' },
+    'rework',
+    ['修复竞态'],
+  )
+  assert.deepEqual(next, { open: false, text: '暂存的说明' })
+})
+
+test('a launched action clears and collapses the input so stale text cannot leak', () => {
+  assert.deepEqual(clearedContext(), { open: false, text: '' })
+})
+
+test('the submitted context is trimmed; blank input means no context is sent', () => {
+  assert.equal(contextToSubmit('  优先补齐边界测试\n'), '优先补齐边界测试')
+  assert.equal(contextToSubmit('   \n\t'), '')
+  assert.equal(contextToSubmit(''), '')
+})

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -2256,3 +2256,242 @@ test('repo issue aggregation uses unbounded pagination and keeps issues beyond 1
   assert.equal(result.issues.length, 1001)
   assert.equal(commands.filter((command) => command.startsWith('gh api ')).length, 12)
 })
+
+test('develop with user context stays a first development and records the note in the timeline', async () => {
+  const previousHome = process.env.HOME
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-develop-context-'))
+  process.env.HOME = tempHome
+  try {
+    const repo = join(tempHome, 'repo')
+    const worktreeRoot = join(tempHome, 'worktrees')
+    await mkdir(repo, { recursive: true })
+    await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
+    await writeFile(join(tempHome, '.clickvibe', 'config.yaml'), [
+      'repos:',
+      `  o/r: ${repo}`,
+      `worktreeRoot: ${worktreeRoot}`,
+      '',
+    ].join('\n'))
+    const url = 'https://github.com/o/r/issues/54'
+    const item = {
+      url, title: 'context issue', body: '## 验收标准\n- context', state: 'OPEN',
+      updatedAt: '2026-08-22T00:00:00Z', comments: [],
+    }
+    const expectedSnapshot = {
+      url: item.url, title: item.title, body: item.body, state: item.state,
+      updatedAt: item.updatedAt, comments: [],
+    }
+    const prompts: string[] = []
+    const comments: Array<{ command: string; body: string }> = []
+    const handler = createHandler(async (spec) => {
+      const api = githubApi(spec.command, { item })
+      if (api) return api
+      if (spec.command === 'git symbolic-ref --quiet --short refs/remotes/origin/HEAD') return { exitCode: 0, stdout: { text: 'origin/main' }, stderr: { text: '' } }
+      if (spec.command === 'git rev-parse --short HEAD') return { exitCode: 0, stdout: { text: 'f00d123' }, stderr: { text: '' } }
+      if (spec.command.startsWith('gh issue comment')) {
+        comments.push({ command: spec.command, body: spec.stdin ?? '' })
+        return { exitCode: 0, stdout: { text: 'https://github.com/o/r/issues/54#issuecomment-9' }, stderr: { text: '' } }
+      }
+      return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
+    }, (spec) => {
+      prompts.push(spec.stdin ?? '')
+      let read = false
+      return {
+        status: 'running', exitCode: 0,
+        done: new Promise<void>((resolve) => setTimeout(resolve, 5)),
+        readOutput() {
+          if (read) return { delta: '', lossy: false }
+          read = true
+          return { delta: `{"type":"thread.started","thread_id":"dev-session-${prompts.length}"}\n`, lossy: false }
+        },
+        kill() { return true },
+      }
+    })
+    const headers = { origin: 'same-origin', 'x-clickvibe-request': '1' }
+
+    // 首次开工:附加说明非空也必须是「开发」,不得沿用 context!==''→rework 的判定。
+    const firstContext = '优先补齐边界测试,注意向后兼容'
+    const firstAuthorized = await post(handler, '/clickvibe/api/authorize', {
+      action: 'develop', url, agent: 'codex', context: firstContext, expectedSnapshot,
+    }, headers) as { status: number; body: { authorizationId?: string; authorizationDigest?: string } }
+    const first = await post(handler, '/clickvibe/api/develop', {
+      url, agent: 'codex', context: firstContext,
+      authorizationId: firstAuthorized.body.authorizationId,
+      authorizationDigest: firstAuthorized.body.authorizationDigest,
+    }, headers) as { status: number; body: { ok: boolean; taskId?: string } }
+    assert.equal(first.status, 200, JSON.stringify(first.body))
+    await waitForTask(handler, first.body.taskId ?? '')
+
+    assert.match(prompts[0], /请执行 ClickVibe 开发阶段。/)
+    assert.doesNotMatch(prompts[0], /返工阶段/)
+    assert.match(prompts[0], /附加上下文:\n优先补齐边界测试,注意向后兼容/)
+    let reloaded = await loadWorkflow('o-r-54')
+    assert.equal(reloaded?.events.at(-1)?.kind, 'dev')
+    assert.equal(reloaded?.events.at(-1)?.userContext, firstContext)
+    // 附加说明只进本地时间线,不进 GitHub 评论。
+    assert.equal(comments[0].body.includes(firstContext), false)
+
+    // 非首次 develop 带附加说明:保留既有「升级为返工」语义。
+    const secondContext = '第二轮:按新约束调整实现'
+    const secondAuthorized = await post(handler, '/clickvibe/api/authorize', {
+      action: 'develop', url, agent: 'codex', context: secondContext, expectedSnapshot,
+    }, headers) as { status: number; body: { authorizationId?: string; authorizationDigest?: string } }
+    const second = await post(handler, '/clickvibe/api/develop', {
+      url, agent: 'codex', context: secondContext,
+      authorizationId: secondAuthorized.body.authorizationId,
+      authorizationDigest: secondAuthorized.body.authorizationDigest,
+    }, headers) as { status: number; body: { ok: boolean; taskId?: string } }
+    assert.equal(second.status, 200, JSON.stringify(second.body))
+    await waitForTask(handler, second.body.taskId ?? '')
+
+    assert.match(prompts[1], /请执行 ClickVibe 按 Review 意见返工阶段。/)
+    assert.match(prompts[1], /附加上下文:\n第二轮:按新约束调整实现/)
+    reloaded = await loadWorkflow('o-r-54')
+    assert.equal(reloaded?.events.at(-1)?.kind, 'rework')
+    assert.equal(reloaded?.events.at(-1)?.userContext, secondContext)
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
+})
+
+test('resume (rework) carries the user context next to the review feedback and audits it locally', async () => {
+  const previousHome = process.env.HOME
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-resume-context-'))
+  process.env.HOME = tempHome
+  try {
+    const worktree = join(tempHome, 'worktree')
+    await mkdir(worktree, { recursive: true })
+    const workflow = interruptedWorkflow('o-r-921', 'https://github.com/o/r/issues/921', worktree)
+    workflow.reviewResult = { passed: false, issues: ['修复竞态', '补充失败测试'] }
+    await saveWorkflow(workflow)
+    const prompts: string[] = []
+    const currentIssue = {
+      url: workflow.url, title: 'resume issue', body: '## 验收标准\n- context', state: 'OPEN',
+      updatedAt: 'now', comments: [],
+    }
+    const handler = createHandler(async (spec) => {
+      const api = githubApi(spec.command, { item: currentIssue })
+      if (api) return api
+      if (spec.command === 'git rev-parse --short HEAD') return { exitCode: 0, stdout: { text: 'abc123' }, stderr: { text: '' } }
+      if (spec.command.startsWith('gh issue comment')) {
+        return { exitCode: 0, stdout: { text: 'https://github.com/o/r/pull/29#issuecomment-4' }, stderr: { text: '' } }
+      }
+      return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
+    }, (spec) => {
+      prompts.push(spec.stdin ?? '')
+      let read = false
+      return {
+        status: 'running', exitCode: 0,
+        done: new Promise<void>((resolve) => setTimeout(resolve, 5)),
+        readOutput() {
+          if (read) return { delta: '', lossy: false }
+          read = true
+          return { delta: '{"type":"thread.started","thread_id":"resumed-session"}\n', lossy: false }
+        },
+        kill() { return true },
+      }
+    })
+    const headers = { origin: 'same-origin', 'x-clickvibe-request': '1' }
+    const userContext = '重点先修竞态,再补并发测试'
+    const authorized = await post(handler, '/clickvibe/api/authorize', {
+      action: 'resume', url: workflow.url, agent: 'codex', context: userContext,
+    }, headers) as { status: number; body: { authorizationId?: string; authorizationDigest?: string } }
+    const resumed = await post(handler, '/clickvibe/api/resume', {
+      url: workflow.url, agent: 'codex', context: userContext,
+      authorizationId: authorized.body.authorizationId,
+      authorizationDigest: authorized.body.authorizationDigest,
+    }, headers) as { status: number; body: { ok: boolean; taskId?: string } }
+    assert.equal(resumed.status, 200, JSON.stringify(resumed.body))
+    await waitForTask(handler, resumed.body.taskId ?? '')
+
+    // 服务端既有 review 意见注入与用户附加说明同时出现在 prompt。
+    assert.match(prompts[0], /请执行 ClickVibe 按 Review 意见返工阶段。/)
+    assert.match(prompts[0], /修复竞态/)
+    assert.match(prompts[0], /重点先修竞态,再补并发测试/)
+    const reloaded = await loadWorkflow(workflow.key)
+    assert.equal(reloaded?.events.at(-1)?.kind, 'rework')
+    assert.equal(reloaded?.events.at(-1)?.userContext, userContext)
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
+})
+
+test('review with user context appends it to the prompt and audits it in the review event', async () => {
+  const previousHome = process.env.HOME
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-review-context-'))
+  process.env.HOME = tempHome
+  try {
+    const worktree = join(tempHome, 'worktree')
+    await mkdir(worktree, { recursive: true })
+    const workflow = interruptedWorkflow('o-r-922', 'https://github.com/o/r/issues/922', worktree)
+    workflow.stage = 'review-ready'
+    await saveWorkflow(workflow)
+    const starts: Array<{ command: string; prompt: string }> = []
+    const reviewedBody = '## 验收标准\n- review context'
+    const currentIssue = {
+      url: workflow.url, number: 922,
+      title: 'review issue', body: reviewedBody, state: 'OPEN', updatedAt: '2026-08-22T02:00:00Z',
+      comments: [],
+    }
+    const pr = {
+      number: 29, state: 'open', html_url: 'https://github.com/o/r/pull/29', updated_at: '2026-08-22T02:00:00Z',
+      base: { ref: 'main' }, head: { ref: workflow.branch },
+    }
+    const handler = createHandler(async (spec) => {
+      const api = githubApi(spec.command, { item: currentIssue, pr })
+      if (api) return api
+      if (spec.command === 'git rev-parse --short HEAD') return { exitCode: 0, stdout: { text: 'abc123' }, stderr: { text: '' } }
+      if (spec.command.startsWith('gh issue comment')) {
+        return { exitCode: 0, stdout: { text: 'https://github.com/o/r/pull/29#issuecomment-5' }, stderr: { text: '' } }
+      }
+      return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
+    }, (spec) => {
+      starts.push({ command: spec.command, prompt: spec.stdin ?? '' })
+      let read = false
+      return {
+        status: 'running', exitCode: 0,
+        done: (async () => {
+          await mkdir(join(worktree, '.clickvibe'), { recursive: true })
+          await writeFile(join(worktree, '.clickvibe', 'review-result.json'), '{"passed":true,"issues":[]}')
+          await new Promise((resolve) => setTimeout(resolve, 5))
+        })(),
+        readOutput() {
+          if (read) return { delta: '', lossy: false }
+          read = true
+          return { delta: '{"type":"thread.started","thread_id":"review-session"}\n', lossy: false }
+        },
+        kill() { return true },
+      }
+    })
+    const headers = { origin: 'same-origin', 'x-clickvibe-request': '1' }
+    const userContext = '额外关注并发安全与错误处理路径'
+    const authorized = await post(handler, '/clickvibe/api/authorize', {
+      action: 'review', url: workflow.url, agent: 'codex', context: userContext,
+    }, headers) as { status: number; body: { authorizationId?: string; authorizationDigest?: string } }
+    const reviewed = await post(handler, '/clickvibe/api/review', {
+      url: workflow.url, agent: 'codex', context: userContext,
+      authorizationId: authorized.body.authorizationId,
+      authorizationDigest: authorized.body.authorizationDigest,
+    }, headers) as { status: number; body: { ok: boolean; taskId?: string } }
+    assert.equal(reviewed.status, 200, JSON.stringify(reviewed.body))
+    await waitForTask(handler, reviewed.body.taskId ?? '')
+
+    assert.equal(starts.length, 1)
+    assert.match(starts[0].prompt, /请执行 ClickVibe Review阶段。/)
+    assert.match(starts[0].prompt, /附加上下文:\n额外关注并发安全与错误处理路径/)
+    const reloaded = await loadWorkflow(workflow.key)
+    assert.equal(reloaded?.events.at(-1)?.kind, 'review')
+    assert.equal(reloaded?.events.at(-1)?.userContext, userContext)
+    // 附加说明不自动发布为 GitHub 评论。
+    const comments = await readLogHistory(workflow.key, 'review')
+    assert.equal(comments.some((line) => line.includes('额外关注并发安全')), false)
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
Closes #54

## 改动

**服务端(src/index.ts、src/state.ts)**
- `startDevelop`:首次开工 = 本地无任何 dev/rework 事件;带附加说明不再误判为返工(prompt 阶段与交付事件均为「开发」)。非首次 develop 带说明保留既有「升级为返工」语义
- `startReview`:新增 `context` 解析,拼入 review prompt 的「附加上下文」(含 stale-session 重建 prompt 路径)
- `recordDevDelivery` / review 事件:非空附加说明记入 `WorkflowEvent.userContext`,只进本地时间线,不进 GitHub 评论

**客户端(src/client/index.tsx)**
- 唯一动作按钮旁可展开「附加说明(可选)」textarea(仅 develop/resume/rework/review;merge/cleanup/sync/create-pr 不加)
- 返工首次展开预填当前 review 意见(可编辑),发送以输入框最终文本为准;清空后服务端仍自动注入 review 意见(不回归)
- 动作成功触发后输入框清空并折叠
- 交付流水时间线展示「用户附加说明:…」(超 80 字截断,悬停看全文)

## 验证

- `pnpm test`:206 个测试全部通过,新增 3 个集成测试覆盖:
  - develop 首次开工带说明 → 开发阶段 + dev 事件 + userContext;非首次 → 返工
  - resume(返工)带说明 → prompt 同时含 review 意见与附加说明 + rework 事件审计
  - review 带说明 → prompt 附加上下文 + review 事件审计,且不发布为 GitHub 评论
- `pnpm typecheck` / `pnpm build` 通过
- 「清空输入框不丢 review 意见」由既有测试 `invalid exact dev session falls back...`(context: '' 仍注入 Review Meta)覆盖

🤖 Generated with [Claude Code](https://claude.com/claude-code)