### PR TITLE
feat: 主仓库基线安全同步

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@
 
 ClickVibe 是一个 DSH Web 插件:右侧面板把 GitHub issue 变成「开发 → review → 返工 → 合并」的异步流水线,git + GitHub 是唯一事实源,merge 留给人拍板。宿主侧(server)与客户端(client)分居 `src/index.ts` 与 `src/client/index.tsx` 两个 bundle 入口(构建与产物见 `tsdown.config.ts`)。
 
+### 主仓库开发守则
+
+直接在主仓库 checkout 工作的 agent,开始任务前必须先执行 `git fetch origin --prune`,检查遗留冲突(`MERGE_HEAD`)、工作区状态与本地分支落后情况;先同步最新代码并解决冲突,再开始任务。禁止用自动 stash、rebase 或丢弃改动绕过现场。
+
 ## 1. 结构三规则(issue #61,机器门禁守护)
 
 **规则一:每文件 ≤500 行(>800 无条件拆)。**

--- a/docs/plans/2026-08-23-repo-advance-sync-design.md
+++ b/docs/plans/2026-08-23-repo-advance-sync-design.md
@@ -1,0 +1,80 @@
+# 主仓库基线同步:远端 main 更新信号 + 安全同步(仓库级)
+
+> 2026-08-23 讨论沉淀。痛点:用户/agent 直接在主仓库 checkout 里开发时,主仓库只 fetch refs、从不 pull,面板也没有"远端 main 领先本地"的任何信号——于是基于旧基线开发(真实案例:docs/issue-60-61-design 分支基于旧 main,缺失领域拆分 6 个提交)。
+>
+> worktree 流程**不受影响**(判断基准 = origin/* 远端 ref,见 [state-model.md](../state-model.md) §七 规则 2),本设计只补**主仓库本体**。
+> 配套 [state-model.md](../state-model.md) §七(展示规范);落地遵守 AGENTS.md §3 契约红线(不新增 API method、既有响应形状不变)。
+
+## 目标与边界
+
+**现状缺口**:
+
+- 面板每次 /state 与 /repo/issues 已对配置仓库执行 `git fetch origin --prune`(`ensureConfiguredRepoFresh`,src/index.ts:377,TTL 30-60s)——远端 refs 是新鲜的,但**主仓库本地 main ref 与当前 checkout 工作区从不更新**,也没有"领先本地 N 个提交"的信号。
+- worktree 落后已有完整链路:落后徽章 + 「同步 worktree」(`deriveNextAction` src/state-view.ts:177-199,P2 优先)+ `syncWorktree`(src/index.ts:3516)。本地 main 落后被设计为不影响判断(state-model §七)。**worktree 一侧无缺口。**
+- **缺口只在主仓库本体**:无信号、无同步入口、agent 介入无固定指引。
+
+**目标**:仓库级信号(远端默认分支领先本地 main N / 当前 checkout 分支落后 M)+ 一个「安全同步」动作:纯落后 ff-only 快进、分叉真实 merge(冲突现场保留并交还 agent)、工作区脏硬拒;agent 介入靠固定附加说明(AGENTS.md 主仓库守则),面板不做自动派发。
+
+**边界**(对齐现有硬原则):
+
+1. **不新增 API method**:扩展现有 `/clickvibe/api/sync` 输入({repoKey} 与现有 {url} 并存);url 路径响应形状零变化(红线 4)。
+2. **不新增轮询**:信号基于 fetch 后 refs 派生;fetch 沿用现有 TTL 门。
+3. **唯一硬拒绝 = 工作区脏**(绝不覆盖未提交改动);detached HEAD 拒;分叉**不拒**,真 merge(对接用户确认)。
+4. **不做**:自动 stash、自动 rebase、push 主仓库 checkout 分支、新增"agent 进主仓库"能力、改动 worktree 流程判断。
+5. 冲突现场保留语义对齐 `syncWorktree`(issue #26):MERGE_HEAD + 冲突标记原样留场,不回滚。
+
+## 第 1 节 信号(仓库横幅,列表头部)
+
+位置:列表头部 freshness 横幅区(src/client/index.tsx:2092 的 .cv-stale 一族附近),一个仓库一条:
+
+```
+远端 origin/main 领先本地 main 8 · 上次 fetch 于 14:32
+当前分支 docs/issue-60-61-design 落后 origin/main 6   ← 仅 checkout ≠ 默认分支且落后>0 时显示
+```
+
+- 对比对象 = 仓库默认分支:origin/HEAD(symbolic-ref)→ 兜底 origin/main(复用 `workflowBaseBranch` 语义,state-view.ts:29)。
+- N/M=0 或无可比 ref → 不显示该行;fetch 失败/慢沿用现有 .cv-stale 横幅语义(状态可能过期提示)。
+- 同步动作成功后客户端刷新横幅,落后归零。
+
+## 第 2 节 动作:安全同步(扩展 /clickvibe/api/sync)
+
+**输入**:payload { repoKey };现有 { url }(worktree 路径)完全不变。
+
+**执行序列**(仓库根;工作区检查对齐 syncWorktree 同款 porcelain 检查):
+
+1. `git fetch origin --prune`
+2. 当前 checkout 分支判定:
+   - detached HEAD → 拒("不在任何分支上,无法安全同步")
+   - 工作区脏(`git status --porcelain` 非空)→ **硬拒**(唯一一律拒绝;提示先提交/清理,绝不 stash、绝不丢弃)
+   - 纯落后(ahead=0 且 behind>0)→ `git merge --ff-only origin/<默认>`(快进分支 + 工作区;git 自身保证不覆盖未提交改动)
+   - 分叉(ahead>0 且 behind>0)→ `git merge --no-edit origin/<默认>`:
+     - 干净 → 产生 merge commit,返回新 HEAD
+     - 冲突 → MERGE_HEAD + 标记留场,返回冲突文件清单 + 指引文案:"现场已保留;请在主仓库 workspace 让 agent 处理(附加说明:先同步最新代码并解决冲突),或手动解决后继续"
+3. 本地 main ref:纯落后且未被 checkout → `git branch -f main origin/main`(仅 ref 移动,reflog 可回退,不碰任何已检出内容)
+4. **逐项独立判定、独立报告**:一项失败不阻塞另一项。
+
+**agent 介入(机制 b)**:面板不自动派发 agent。落地为固定守则:AGENTS.md 主仓库开发守则新增"直接在主仓库工作的 agent,先 `git fetch origin --prune` 并检查遗留冲突(MERGE_HEAD)/本地 main 落后,先同步最新代码再开始任务";同步按钮的拒绝/冲突指引文案同步带上这条附加说明。
+
+**响应形状**(对现有 url 路径响应形状零变化):
+
+```ts
+{ ok: true
+  branchHead: { branch: string; head: string | null } | null  // 分支快进/merge 后
+  mainRefForwarded: boolean
+  conflict?: { files: string[] } | null
+  refused?: string[] }
+| { ok: false, error: string }
+```
+
+## 第 3 节 数据与测试
+
+- **纯函数**(repo-freshness.ts 或新文件):输入 origin/<默认>、本地 main、checkout 分支(名/HEAD)、porcelain → 信号两组数字 + 各目标(分支快进 / merge / main ref 快进)的判定;不依赖 shell,单测直测。
+- **I/O 收口** index.ts:runCommand / readRevCount / readRefShort(既有)。
+- **routes.test.ts fake-shell 模式**(拦截 `git fetch/rev-list/status/merge/branch`)覆盖:信号数据、ff 成功、脏树拒绝、detached 拒绝、分叉 clean merge、分叉冲突留场 + 文件清单、main ref 快进、url 路径回归零变化;不引入 mock 库(AGENTS.md §2.3)。
+- **配套文档**:state-model §七 补"主仓库本体信号"(worktree 判断逻辑不变)。
+- **门禁**:typecheck / build / test(覆盖率 ≥85%)/ lint / check:size 全绿(AGENTS.md §5)。
+
+## 与 state-model 的关系
+
+- §七 规则 2"对比对象只有一个 origin/main,不显示本地 main"——**worktree 判断不变**;本设计新增的是仓库级横幅(本地 main 落后是它的信号对象),两条线互不干扰。
+- 本地 main 落后在本设计中第一次**可被看见、可被清零**,但从不参与 worktree 推导。

--- a/docs/state-model.md
+++ b/docs/state-model.md
@@ -127,7 +127,7 @@
 ### 原则
 
 1. **基础事实常驻,派生信号按需**——客观存在的信息常显;对比算出来的信息"有情况才显示,没情况不显示"。
-2. **对比对象只有一个:origin/main(远端)**。不显示本地 main(判断不用它,且本地未 pull 会误导)。
+2. **worktree 对比对象只有一个:origin/main(远端)**。worktree 推导不使用本地 main;本地 main 只出现在下述独立的主仓库本体信号中。
 3. **数字必须带语义**,不能裸数字:"落后 2"要能读成"主干有 2 个新提交我还没有"。
 
 ### 基础事实(常驻 3 项)
@@ -150,6 +150,20 @@
 | 领先 M > 0 | 领先 M | 比主干多 M 个提交(开发成果/待 review 量) | 无(状态徽章已表达"有内容") |
 | 领先 M · 落后 N(分叉) | 领先 M · 落后 N | 分支与主干分叉,同步将 merge 主干进来 | 「同步 worktree」 |
 | 契约已变 | 📋 issue 契约已改 | issue 正文目标/验收与结论绑定指纹不符,结论过期 | 「重新 Review」 |
+
+### 主仓库本体信号(列表头部)
+
+主仓库每次沿用既有 TTL fetch 后的 refs 派生独立横幅,不新增轮询,也不改变上述 worktree 判断:
+
+```
+远端 origin/main 领先本地 main 4 · 上次 fetch 2026/8/23 15:30
+当前分支 feature/x 落后 origin/main 2
+```
+
+- 默认分支取 `origin/HEAD`,不可读时回退 `origin/main`;无可比 ref 或落后数为 0 时隐藏对应行。
+- checkout 等于默认分支时隐藏第二行;非默认分支落后时提供「安全同步」。
+- 安全同步对纯落后 checkout 做 ff-only,对分叉 checkout 做真实 merge;工作区脏或 detached HEAD 拒绝 checkout 目标。冲突现场保留,不自动 stash/rebase/push。
+- 未被 checkout 的本地 main 纯落后时只移动 ref 到远端默认分支;checkout 与 main 两个目标独立判定、独立报告。
 
 配套出现项:
 

--- a/src/client/domain.ts
+++ b/src/client/domain.ts
@@ -191,6 +191,21 @@ export interface RepositoryFreshness {
   error?: string
 }
 
+export interface RepositoryAdvanceSignal {
+  defaultBranch: string
+  remoteRef: string
+  mainBehind: number | null
+  checkoutBranch: string | null
+  checkoutBehind: number | null
+  fetchedAt: number | null
+}
+
 export type WorkflowStateResponse =
-  | { ok: true; workflows: Workflow[]; freshness: RepositoryFreshness | null; dependenciesRefreshDue: boolean }
+  | {
+      ok: true
+      workflows: Workflow[]
+      freshness: RepositoryFreshness | null
+      dependenciesRefreshDue: boolean
+      repoAdvance: RepositoryAdvanceSignal | null
+    }
   | { ok: false; error: string }

--- a/src/client/project-state.ts
+++ b/src/client/project-state.ts
@@ -2,6 +2,7 @@
 import React from 'react'
 import {
   type ProjectOption,
+  type RepositoryAdvanceSignal,
   type RepositoryFreshness,
   type RepositoryIssue,
   type Workflow,
@@ -28,6 +29,9 @@ export function useProjectPanel() {
   const [workflow, setWorkflow] = React.useState<Workflow | null>(null)
   const [autoAction, setAutoAction] = React.useState(false)
   const [freshness, setFreshness] = React.useState<RepositoryFreshness | null>(null)
+  const [repoAdvance, setRepoAdvance] = React.useState<RepositoryAdvanceSignal | null>(null)
+  const [repoSyncBusy, setRepoSyncBusy] = React.useState(false)
+  const [repoSyncMessage, setRepoSyncMessage] = React.useState<string | null>(null)
   const [dependencyRefreshError, setDependencyRefreshError] = React.useState<string | null>(null)
   const [stateRefreshError, setStateRefreshError] = React.useState<string | null>(null)
   const [selectedIssues, setSelectedIssues] = React.useState<Set<number>>(new Set())
@@ -64,6 +68,7 @@ export function useProjectPanel() {
         setStateRefreshError(null)
         mergeWorkflowStates(response.workflows)
         setFreshness(response.freshness)
+        setRepoAdvance(response.repoAdvance)
         if (response.dependenciesRefreshDue) {
           try {
             if (result) {
@@ -79,12 +84,18 @@ export function useProjectPanel() {
               }
             } else {
               const next = await apiCall<
-                | { ok: true; issues: RepositoryIssue[]; freshness: RepositoryFreshness | null }
+                | {
+                    ok: true
+                    issues: RepositoryIssue[]
+                    freshness: RepositoryFreshness | null
+                    repoAdvance: RepositoryAdvanceSignal | null
+                  }
                 | { ok: false; error: string }
               >('repo/issues', { repoKey }, 4_000)
               if (next.ok) {
                 setIssues(next.issues)
                 setFreshness(next.freshness)
+                setRepoAdvance(next.repoAdvance)
                 setDependencyRefreshError(null)
               } else {
                 setDependencyRefreshError(next.error)
@@ -111,18 +122,27 @@ export function useProjectPanel() {
     setResult(null)
     setIssues([])
     setFreshness(null)
+    setRepoAdvance(null)
+    setRepoSyncMessage(null)
     setStateRefreshError(null)
     setDependencyRefreshError(null)
     setSelectedIssues(new Set())
     setBatchStatus(null)
     try {
       const response = await apiCall<
-        { ok: true; issues: RepositoryIssue[]; freshness: RepositoryFreshness | null } | { ok: false; error: string }
+        | {
+            ok: true
+            issues: RepositoryIssue[]
+            freshness: RepositoryFreshness | null
+            repoAdvance: RepositoryAdvanceSignal | null
+          }
+        | { ok: false; error: string }
       >('repo/issues', { repoKey: selected, forceRefresh }, 30_000)
       if (!response.ok) setError(response.error)
       else {
         setIssues(response.issues)
         setFreshness(response.freshness)
+        setRepoAdvance(response.repoAdvance)
         setDependencyRefreshError(null)
       }
     } catch (reason) {
@@ -170,6 +190,7 @@ export function useProjectPanel() {
       if (stateResponse?.ok) mergeWorkflowStates(stateResponse.workflows)
       if (stateResponse?.ok) {
         setFreshness(stateResponse.freshness)
+        setRepoAdvance(stateResponse.repoAdvance)
         setStateRefreshError(null)
       } else if (stateResponse && !stateResponse.ok) {
         setStateRefreshError(stateResponse.error)
@@ -214,6 +235,7 @@ export function useProjectPanel() {
         mergeWorkflowStates(stateResponse.workflows)
         setWorkflow(stateResponse.workflows.find((item) => item.url === url) ?? workflow)
         setFreshness(stateResponse.freshness)
+        setRepoAdvance(stateResponse.repoAdvance)
         setStateRefreshError(null)
       } else {
         setStateRefreshError(stateResponse.error)
@@ -222,6 +244,45 @@ export function useProjectPanel() {
       setError(`Issue 刷新失败: ${String(reason)}`)
     } finally {
       setLoading(false)
+    }
+  }
+
+  const safeSyncRepository = async () => {
+    if (!repoKey || repoSyncBusy) return
+    setRepoSyncBusy(true)
+    setRepoSyncMessage(null)
+    try {
+      const response = await apiCall<
+        | {
+            ok: true
+            branchHead: { branch: string; head: string | null } | null
+            mainRefForwarded: boolean
+            conflict: { files: string[] } | null
+            refused: string[]
+          }
+        | { ok: false; error: string }
+      >('sync', { repoKey }, 90_000)
+      if (!response.ok) {
+        setRepoSyncMessage(response.error)
+        return
+      }
+      await loadRepo(repoKey, true)
+      if (response.conflict) {
+        const files = response.conflict.files.length > 0 ? response.conflict.files.join('、') : '请用 git status 查看'
+        setRepoSyncMessage(`合并冲突现场已保留 · ${files} · 附加说明:先同步最新代码并解决冲突`)
+      } else if (response.refused.length > 0) {
+        setRepoSyncMessage(response.refused.join('；'))
+      } else {
+        const updates = [
+          response.branchHead ? `当前分支 HEAD ${response.branchHead.head ?? '未知'}` : '',
+          response.mainRefForwarded ? '本地 main 已快进' : '',
+        ].filter(Boolean)
+        setRepoSyncMessage(updates.length > 0 ? `安全同步完成 · ${updates.join(' · ')}` : '仓库已是最新')
+      }
+    } catch (reason) {
+      setRepoSyncMessage(`安全同步失败:${String(reason)}`)
+    } finally {
+      setRepoSyncBusy(false)
     }
   }
 
@@ -242,7 +303,10 @@ export function useProjectPanel() {
     projects,
     refreshDetail,
     refreshWorkflowStates,
+    repoAdvance,
     repoKey,
+    repoSyncBusy,
+    repoSyncMessage,
     result,
     selectedIssues,
     setAutoAction,
@@ -255,6 +319,7 @@ export function useProjectPanel() {
     setRepoKey,
     setResult,
     setSelectedIssues,
+    safeSyncRepository,
     stateRefreshError,
     updateWorkflow,
     workflow,

--- a/src/client/styles.ts
+++ b/src/client/styles.ts
@@ -50,6 +50,7 @@ body[data-cv-panel-dragging] #root.cv-panel-host-open, body[data-cv-panel-draggi
 .cv-fetch:disabled { opacity: 0.6; }
 .cv-error { margin: 0 14px 10px; padding: 8px 10px; border-radius: 6px; background: #ffebe9; color: #cf222e; border: 1px solid #ff8182; flex-shrink: 0; }
 .cv-stale { margin: 8px 12px 0; padding: 6px 8px; border-radius: 6px; background: #fff8c5; color: #9a6700; border: 1px solid #d4a72c; font-size: 11.5px; flex-shrink: 0; }
+.cv-repo-advance { margin: 8px 12px 0; padding: 7px 8px; border-radius: 6px; background: #fff8c5; color: #7d4e00; border: 1px solid #d4a72c; font-size: 11.5px; flex-shrink: 0; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .cv-hint { padding: 20px 14px; color: #8c959f; text-align: center; }
 .cv-loading { padding: 20px 14px; color: #57606a; text-align: center; }
 .cv-issue { padding: 12px 14px; display: flex; flex-direction: column; gap: 8px; flex: 1; overflow-y: auto; }

--- a/src/client/views/project-panel.tsx
+++ b/src/client/views/project-panel.tsx
@@ -5,6 +5,7 @@ import { githubCompareUrl } from '../runtime.ts'
 import { type RepositoryIssue, apiCall, fetchIssue, stageLabel } from '../domain.ts'
 import { MAX_BATCH_ISSUES, setPanelOpen } from '../panel-state.ts'
 import { type Dependencies, type GhIssue, IssueView, type TimelineEvent, repoOf } from './issue-view.tsx'
+import { RepositoryAdvanceBanner } from './repository-advance-banner.tsx'
 
 export function PanelContent() {
   const {
@@ -24,7 +25,10 @@ export function PanelContent() {
     projects,
     refreshDetail,
     refreshWorkflowStates,
+    repoAdvance,
     repoKey,
+    repoSyncBusy,
+    repoSyncMessage,
     result,
     selectedIssues,
     setAutoAction,
@@ -37,6 +41,7 @@ export function PanelContent() {
     setRepoKey,
     setResult,
     setSelectedIssues,
+    safeSyncRepository,
     stateRefreshError,
     updateWorkflow,
     workflow,
@@ -225,6 +230,10 @@ export function PanelContent() {
             : '⚠ 依赖状态可能过期 · GitHub 刷新失败，当前保留上次结果'}
         </div>
       ) : null}
+      {!result ? (
+        <RepositoryAdvanceBanner signal={repoAdvance} busy={repoSyncBusy} onSync={() => void safeSyncRepository()} />
+      ) : null}
+      {!result && repoSyncMessage ? <div className="cv-project-meta">{repoSyncMessage}</div> : null}
       {result ? (
         <IssueView
           issue={result.item}

--- a/src/client/views/repository-advance-banner.tsx
+++ b/src/client/views/repository-advance-banner.tsx
@@ -1,0 +1,35 @@
+/** Repository-level remote advance signal and safe-sync action. */
+import React from 'react'
+import type { RepositoryAdvanceSignal } from '../domain.ts'
+
+export function RepositoryAdvanceBanner({
+  signal,
+  busy,
+  onSync,
+}: {
+  signal: RepositoryAdvanceSignal | null
+  busy: boolean
+  onSync: () => void
+}) {
+  if (!signal || ((signal.mainBehind ?? 0) === 0 && (signal.checkoutBehind ?? 0) === 0)) return null
+  return (
+    <div className="cv-repo-advance">
+      <div>
+        {(signal.mainBehind ?? 0) > 0 ? (
+          <div>
+            远端 {signal.remoteRef} 领先本地 main {signal.mainBehind} · 上次 fetch{' '}
+            {signal.fetchedAt === null ? '未知' : new Date(signal.fetchedAt).toLocaleString()}
+          </div>
+        ) : null}
+        {signal.checkoutBranch && (signal.checkoutBehind ?? 0) > 0 ? (
+          <div>
+            当前分支 {signal.checkoutBranch} 落后 {signal.remoteRef} {signal.checkoutBehind}
+          </div>
+        ) : null}
+      </div>
+      <button className="cv-batch-btn" disabled={busy} onClick={onSync}>
+        {busy ? '同步中…' : '安全同步'}
+      </button>
+    </div>
+  )
+}

--- a/src/infra/git.ts
+++ b/src/infra/git.ts
@@ -22,7 +22,7 @@ import { shellQuote } from './develop-core.ts'
 import { runCommand } from './runtime.ts'
 import { type IssueContractSnapshot } from './state.ts'
 
-interface GitCompare {
+export interface GitCompare {
   behind: number
   ahead: number
 }

--- a/src/infra/repository-git.ts
+++ b/src/infra/repository-git.ts
@@ -1,0 +1,65 @@
+/** Git I/O facts and mutations for a configured repository checkout. */
+import type { Context } from '@deepseek-ai/cordis'
+import { shellQuote } from './develop-core.ts'
+import { type GitCompare, readBranch, readRevCount } from './git.ts'
+import { runCommand } from './runtime.ts'
+
+export interface RepositoryGitFacts {
+  defaultBranch: string
+  checkoutBranch: string | null
+  main: GitCompare | null
+  checkout: GitCompare | null
+}
+
+export interface RepositorySyncGitFacts extends RepositoryGitFacts {
+  dirty: boolean | null
+}
+
+export async function readRepositoryGitFacts(ctx: Context, repoPath: string): Promise<RepositoryGitFacts> {
+  const defaultRef = await runCommand(ctx, 'git symbolic-ref --quiet --short refs/remotes/origin/HEAD', {
+    workdir: repoPath,
+    timeoutMs: 3_000,
+    sandboxPolicy: { mode: 'read-only', workspaceRoot: repoPath },
+  }).catch(() => '')
+  const defaultBranch = defaultRef.replace(/^origin\//, '') || 'main'
+  const checkoutBranch = await readBranch(ctx, repoPath)
+  const remoteRef = `origin/${defaultBranch}`
+  const [main, checkout] = await Promise.all([
+    readRevCount(ctx, repoPath, remoteRef, 'main'),
+    checkoutBranch === null ? Promise.resolve(null) : readRevCount(ctx, repoPath, remoteRef, 'HEAD'),
+  ])
+  return { defaultBranch, checkoutBranch, main, checkout }
+}
+
+export async function readRepositorySyncGitFacts(ctx: Context, repoPath: string): Promise<RepositorySyncGitFacts> {
+  const [facts, porcelain] = await Promise.all([
+    readRepositoryGitFacts(ctx, repoPath),
+    runCommand(ctx, 'git status --porcelain', {
+      workdir: repoPath,
+      timeoutMs: 10_000,
+      sandboxPolicy: { mode: 'read-only', workspaceRoot: repoPath },
+    }).catch(() => null),
+  ])
+  return { ...facts, dirty: porcelain === null ? null : porcelain !== '' }
+}
+
+export async function mergeRepositoryCheckout(
+  ctx: Context,
+  repoPath: string,
+  remoteRef: string,
+  fastForwardOnly: boolean,
+): Promise<void> {
+  await runCommand(ctx, `git merge ${fastForwardOnly ? '--ff-only' : '--no-edit'} ${shellQuote(remoteRef)}`, {
+    workdir: repoPath,
+    timeoutMs: 60_000,
+    sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: repoPath },
+  })
+}
+
+export async function forwardLocalMain(ctx: Context, repoPath: string, remoteRef: string): Promise<void> {
+  await runCommand(ctx, `git branch -f main ${shellQuote(remoteRef)}`, {
+    workdir: repoPath,
+    timeoutMs: 10_000,
+    sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: repoPath },
+  })
+}

--- a/src/workflow/dispatch.ts
+++ b/src/workflow/dispatch.ts
@@ -8,6 +8,7 @@ import { startDevelop } from './develop-start.ts'
 import { handleCommand, listProjects, stateWorkflows } from './handlers.ts'
 import { authorizeAgent, mergeAndCleanup } from './merge.ts'
 import { fetchRepositoryIssues } from './repository-issues.ts'
+import { syncConfiguredRepository } from './repository-sync.ts'
 import { resumeDevelop } from './resume.ts'
 import { startReview } from './review-flow.ts'
 import { syncWorktree } from './sync.ts'
@@ -104,7 +105,8 @@ export async function handleApiPost(
   if (method === 'sync') {
     const securityError = privilegedRequestError(req)
     if (securityError) return { status: 403, body: { ok: false, error: securityError } }
-    const result = await syncWorktree(ctx, payload)
+    const repoKey = String((payload as { repoKey?: unknown } | undefined)?.repoKey ?? '').trim()
+    const result = repoKey ? await syncConfiguredRepository(ctx, payload) : await syncWorktree(ctx, payload)
     return { status: result.ok ? 200 : 400, body: result }
   }
   if (method === 'merge') {

--- a/src/workflow/handlers.ts
+++ b/src/workflow/handlers.ts
@@ -54,6 +54,7 @@ import {
 import { authorizeAgent } from './merge.ts'
 import { fetchRepositoryIssues } from './repository-issues.ts'
 import { enrichWorkflowStates } from './repository-state.ts'
+import { readConfiguredRepositoryAdvance } from './repository-sync.ts'
 
 /** `/state` implementation, shared by the route and the `status` command (issue #13). */
 export async function stateWorkflows(
@@ -79,17 +80,25 @@ export async function stateWorkflows(
   try {
     const circuitError = githubRest(ctx).rateLimitError()
     if (circuitError) throw circuitError
-    const freshnesses = (
-      await Promise.all(
-        [...repoKeys].map((key) => ensureConfiguredRepoFresh(ctx, config, key, filter?.forceRefresh === true)),
-      )
-    ).filter((value): value is RepositoryFreshness => value !== null)
+    const keyedFreshness = await Promise.all(
+      [...repoKeys].map(async (key) => ({
+        key,
+        freshness: await ensureConfiguredRepoFresh(ctx, config, key, filter?.forceRefresh === true),
+      })),
+    )
+    const freshnesses = keyedFreshness
+      .map((item) => item.freshness)
+      .filter((value): value is RepositoryFreshness => value !== null)
     const dependenciesRefreshDue = [...repoKeys]
       .map((key) => dependencyRefreshClock.take(key, fetchTtlMs(config), filter?.forceRefresh === true))
       .some(Boolean)
     const enriched = await enrichWorkflowStates(ctx, workflows, config)
     const freshness = aggregateRepositoryFreshness(freshnesses)
-    return { status: 200, body: { ok: true, workflows: enriched, freshness, dependenciesRefreshDue } }
+    const onlyRepo = keyedFreshness.length === 1 ? keyedFreshness[0] : null
+    const repoAdvance = onlyRepo
+      ? await readConfiguredRepositoryAdvance(ctx, config, onlyRepo.key, onlyRepo.freshness?.lastSuccessAt ?? null)
+      : null
+    return { status: 200, body: { ok: true, workflows: enriched, freshness, dependenciesRefreshDue, repoAdvance } }
   } catch (error) {
     const message = isGithubRateLimitError(error) ? error.message : `状态刷新失败: ${githubErrorMessage(error)}`
     return { status: isGithubRateLimitError(error) ? 429 : 400, body: { ok: false, error: message } }

--- a/src/workflow/repository-issues.ts
+++ b/src/workflow/repository-issues.ts
@@ -41,13 +41,21 @@ import { deriveAutoDevelopment } from './auto-development.ts'
 import { deriveWorkflowState } from './derive.ts'
 import { checkIssueContract } from './issue-contract.ts'
 import { firstDevelopmentFor, maintainCompletedDependencyLedger } from './repository-state.ts'
+import { readConfiguredRepositoryAdvance, type RepositoryAdvanceSignal } from './repository-sync.ts'
 
 export async function fetchRepositoryIssues(
   ctx: Context,
   payload: unknown,
   overrides: { config?: ClickVibeConfig; workflows?: IssueWorkflow[] } = {},
 ): Promise<
-  { ok: true; repoKey: string; issues: unknown[]; freshness: RepositoryFreshness | null } | { ok: false; error: string }
+  | {
+      ok: true
+      repoKey: string
+      issues: unknown[]
+      freshness: RepositoryFreshness | null
+      repoAdvance: RepositoryAdvanceSignal | null
+    }
+  | { ok: false; error: string }
 > {
   const repoKey = String((payload as { repoKey?: unknown } | undefined)?.repoKey ?? '').trim()
   const config = overrides.config ?? (await loadConfig())
@@ -58,9 +66,10 @@ export async function fetchRepositoryIssues(
 
   try {
     const rest = githubRest(ctx)
-    const [githubSnapshot, allWorkflows] = await Promise.all([
+    const [githubSnapshot, allWorkflows, repoAdvance] = await Promise.all([
       fetchGithubRepoSnapshot(ctx, repoKey, fetchTtlMs(config), forceRefresh),
       overrides.workflows ? Promise.resolve(overrides.workflows) : loadAllWorkflows(),
+      readConfiguredRepositoryAdvance(ctx, config, repoKey, freshness?.lastSuccessAt ?? null),
     ])
     const allIssues = githubSnapshot.issues
       .filter((issue) => issue.pull_request === undefined)
@@ -247,7 +256,7 @@ export async function fetchRepositoryIssues(
       }),
     )
     dependencyRefreshClock.mark(repoKey)
-    return { ok: true, repoKey, issues, freshness }
+    return { ok: true, repoKey, issues, freshness, repoAdvance }
   } catch (error) {
     return {
       ok: false,

--- a/src/workflow/repository-sync-policy.ts
+++ b/src/workflow/repository-sync-policy.ts
@@ -1,0 +1,58 @@
+/** Pure repository-level advance signal and safe-sync decisions. */
+import type { GitCompare } from '../infra/git.ts'
+
+export interface RepositorySyncPolicyInput {
+  defaultBranch: string
+  checkoutBranch: string | null
+  dirty: boolean | null
+  main: GitCompare | null
+  checkout: GitCompare | null
+}
+
+export interface RepositoryAdvanceInput extends Omit<RepositorySyncPolicyInput, 'dirty'> {}
+
+export interface RepositoryAdvance {
+  defaultBranch: string
+  remoteRef: string
+  mainBehind: number | null
+  checkoutBranch: string | null
+  checkoutBehind: number | null
+}
+
+export type CheckoutSyncDecision = 'unchanged' | 'fast-forward' | 'merge' | 'dirty' | 'detached' | 'unavailable'
+
+export type MainSyncDecision = 'unchanged' | 'fast-forward' | 'diverged' | 'checked-out' | 'unavailable'
+
+export function deriveRepositoryAdvance(input: RepositoryAdvanceInput): RepositoryAdvance {
+  return {
+    defaultBranch: input.defaultBranch,
+    remoteRef: `origin/${input.defaultBranch}`,
+    mainBehind: input.main?.behind ?? null,
+    checkoutBranch: input.checkoutBranch,
+    checkoutBehind:
+      input.checkoutBranch === null || input.checkoutBranch === input.defaultBranch
+        ? null
+        : (input.checkout?.behind ?? null),
+  }
+}
+
+export function decideRepositorySync(input: RepositorySyncPolicyInput): {
+  checkout: CheckoutSyncDecision
+  main: MainSyncDecision
+} {
+  let checkout: CheckoutSyncDecision
+  if (input.checkoutBranch === null) checkout = 'detached'
+  else if (input.dirty === null || input.checkout === null) checkout = 'unavailable'
+  else if (input.dirty) checkout = 'dirty'
+  else if (input.checkout.behind === 0) checkout = 'unchanged'
+  else if (input.checkout.ahead === 0) checkout = 'fast-forward'
+  else checkout = 'merge'
+
+  let main: MainSyncDecision
+  if (input.checkoutBranch === 'main') main = 'checked-out'
+  else if (input.main === null) main = 'unavailable'
+  else if (input.main.behind === 0) main = 'unchanged'
+  else if (input.main.ahead === 0) main = 'fast-forward'
+  else main = 'diverged'
+  return { checkout, main }
+}

--- a/src/workflow/repository-sync.ts
+++ b/src/workflow/repository-sync.ts
@@ -1,0 +1,164 @@
+/** Repository-level advance signal and safe-sync workflow. */
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+import type { Context } from '@deepseek-ai/cordis'
+import { hasMergeConflict, listConflictFiles } from '../infra/git.ts'
+import {
+  forwardLocalMain,
+  mergeRepositoryCheckout,
+  readRepositoryGitFacts,
+  readRepositorySyncGitFacts,
+} from '../infra/repository-git.ts'
+import { type ClickVibeConfig, expandHome, loadConfig, readWorktreeHead, runCommand } from '../infra/runtime.ts'
+import { decideRepositorySync, deriveRepositoryAdvance, type RepositoryAdvance } from './repository-sync-policy.ts'
+
+export interface RepositoryAdvanceSignal extends RepositoryAdvance {
+  fetchedAt: number | null
+}
+
+type TargetStatus =
+  | 'unchanged'
+  | 'fast-forwarded'
+  | 'merged'
+  | 'conflict'
+  | 'refused'
+  | 'diverged'
+  | 'checked-out'
+  | 'unavailable'
+  | 'failed'
+
+interface TargetReport {
+  status: TargetStatus
+  reason?: string
+  head?: string | null
+  files?: string[]
+}
+
+export interface RepositorySyncResult {
+  ok: true
+  branchHead: { branch: string; head: string | null } | null
+  mainRefForwarded: boolean
+  conflict: { files: string[] } | null
+  refused: string[]
+  targets: {
+    checkout: TargetReport & { branch: string | null }
+    main: TargetReport
+  }
+}
+
+function errorText(error: unknown): string {
+  return String(error instanceof Error ? error.message : error)
+}
+
+function configuredRepoPath(config: ClickVibeConfig, repoKey: string): string | null {
+  const configured = config.repos[repoKey]
+  if (!configured) return null
+  const repoPath = resolve(expandHome(configured))
+  return existsSync(repoPath) ? repoPath : null
+}
+
+export async function readConfiguredRepositoryAdvance(
+  ctx: Context,
+  config: ClickVibeConfig,
+  repoKey: string,
+  fetchedAt: number | null,
+): Promise<RepositoryAdvanceSignal | null> {
+  const repoPath = configuredRepoPath(config, repoKey)
+  if (!repoPath) return null
+  const facts = await readRepositoryGitFacts(ctx, repoPath)
+  return { ...deriveRepositoryAdvance(facts), fetchedAt }
+}
+
+export async function syncConfiguredRepository(
+  ctx: Context,
+  payload: unknown,
+): Promise<RepositorySyncResult | { ok: false; error: string }> {
+  const repoKey = String((payload as { repoKey?: unknown } | undefined)?.repoKey ?? '').trim()
+  const config = await loadConfig()
+  const repoPath = configuredRepoPath(config, repoKey)
+  if (!repoKey || !repoPath) return { ok: false, error: `未配置或无法访问项目 ${repoKey || '(空)'}` }
+
+  try {
+    await runCommand(ctx, 'git fetch origin --prune', {
+      workdir: repoPath,
+      timeoutMs: 60_000,
+      sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: repoPath },
+    })
+  } catch (error) {
+    return { ok: false, error: `同步失败:无法 fetch origin:${errorText(error)}` }
+  }
+
+  const facts = await readRepositorySyncGitFacts(ctx, repoPath)
+  const decision = decideRepositorySync(facts)
+  const remoteRef = `origin/${facts.defaultBranch}`
+  const refused: string[] = []
+  let branchHead: RepositorySyncResult['branchHead'] = null
+  let conflict: RepositorySyncResult['conflict'] = null
+  let checkout: RepositorySyncResult['targets']['checkout'] = {
+    branch: facts.checkoutBranch,
+    status: 'unchanged',
+  }
+
+  if (decision.checkout === 'detached') {
+    const reason = '当前 checkout 不在任何分支上(detached HEAD),无法安全同步'
+    refused.push(reason)
+    checkout = { branch: null, status: 'refused', reason }
+  } else if (decision.checkout === 'dirty') {
+    const reason = '当前 checkout 有未提交改动,请先提交或清理后再同步;不会自动 stash 或覆盖改动'
+    refused.push(reason)
+    checkout = { branch: facts.checkoutBranch, status: 'refused', reason }
+  } else if (decision.checkout === 'unavailable') {
+    const reason = '无法读取当前 checkout 状态或与远端默认分支比较,未执行同步'
+    refused.push(reason)
+    checkout = { branch: facts.checkoutBranch, status: 'unavailable', reason }
+  } else if (decision.checkout === 'fast-forward' || decision.checkout === 'merge') {
+    try {
+      await mergeRepositoryCheckout(ctx, repoPath, remoteRef, decision.checkout === 'fast-forward')
+      const head = await readWorktreeHead(ctx, repoPath)
+      branchHead = { branch: facts.checkoutBranch as string, head }
+      checkout = {
+        branch: facts.checkoutBranch,
+        status: decision.checkout === 'fast-forward' ? 'fast-forwarded' : 'merged',
+        head,
+      }
+    } catch (error) {
+      if (decision.checkout === 'merge' && (await hasMergeConflict(ctx, repoPath))) {
+        const files = await listConflictFiles(ctx, repoPath)
+        const reason =
+          '合并冲突现场已保留;请在主仓库 workspace 让 agent 处理(附加说明:先同步最新代码并解决冲突),或手动解决后继续'
+        conflict = { files }
+        checkout = { branch: facts.checkoutBranch, status: 'conflict', files, reason }
+      } else {
+        const reason = `当前 checkout 同步失败:${errorText(error)}`
+        refused.push(reason)
+        checkout = { branch: facts.checkoutBranch, status: 'failed', reason }
+      }
+    }
+  }
+
+  let main: RepositorySyncResult['targets']['main']
+  let mainRefForwarded = false
+  if (decision.main === 'checked-out') {
+    main = { status: 'checked-out', reason: '本地 main 正由当前 checkout 目标处理' }
+  } else if (decision.main === 'unavailable') {
+    main = { status: 'unavailable', reason: '本地 main 或远端默认分支不可比较,未移动 ref' }
+  } else if (decision.main === 'diverged') {
+    const reason = `本地 main 与 ${remoteRef} 已分叉,拒绝移动 ref`
+    refused.push(reason)
+    main = { status: 'diverged', reason }
+  } else if (decision.main === 'fast-forward') {
+    try {
+      await forwardLocalMain(ctx, repoPath, remoteRef)
+      mainRefForwarded = true
+      main = { status: 'fast-forwarded' }
+    } catch (error) {
+      const reason = `本地 main 快进失败:${errorText(error)}`
+      refused.push(reason)
+      main = { status: 'failed', reason }
+    }
+  } else {
+    main = { status: 'unchanged' }
+  }
+
+  return { ok: true, branchHead, mainRefForwarded, conflict, refused, targets: { checkout, main } }
+}

--- a/tests/repository-sync-policy.test.ts
+++ b/tests/repository-sync-policy.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { deriveRepositoryAdvance, decideRepositorySync } from '../src/workflow/repository-sync-policy.ts'
+
+test('repository advance exposes only comparable remote-default lag', () => {
+  assert.deepEqual(
+    deriveRepositoryAdvance({
+      defaultBranch: 'main',
+      checkoutBranch: 'feature/x',
+      main: { behind: 4, ahead: 0 },
+      checkout: { behind: 2, ahead: 1 },
+    }),
+    {
+      defaultBranch: 'main',
+      remoteRef: 'origin/main',
+      mainBehind: 4,
+      checkoutBranch: 'feature/x',
+      checkoutBehind: 2,
+    },
+  )
+  assert.equal(
+    deriveRepositoryAdvance({
+      defaultBranch: 'main',
+      checkoutBranch: 'main',
+      main: { behind: 0, ahead: 0 },
+      checkout: { behind: 0, ahead: 0 },
+    }).checkoutBehind,
+    null,
+  )
+})
+
+test('repository sync policy distinguishes ff, merge, refusal and independent main movement', () => {
+  assert.deepEqual(
+    decideRepositorySync({
+      defaultBranch: 'main',
+      checkoutBranch: 'feature/x',
+      dirty: false,
+      main: { behind: 3, ahead: 0 },
+      checkout: { behind: 2, ahead: 0 },
+    }),
+    { checkout: 'fast-forward', main: 'fast-forward' },
+  )
+  assert.deepEqual(
+    decideRepositorySync({
+      defaultBranch: 'main',
+      checkoutBranch: 'feature/x',
+      dirty: false,
+      main: { behind: 1, ahead: 1 },
+      checkout: { behind: 2, ahead: 1 },
+    }),
+    { checkout: 'merge', main: 'diverged' },
+  )
+  assert.deepEqual(
+    decideRepositorySync({
+      defaultBranch: 'main',
+      checkoutBranch: 'feature/x',
+      dirty: true,
+      main: { behind: 3, ahead: 0 },
+      checkout: { behind: 2, ahead: 0 },
+    }),
+    { checkout: 'dirty', main: 'fast-forward' },
+  )
+  assert.deepEqual(
+    decideRepositorySync({
+      defaultBranch: 'main',
+      checkoutBranch: null,
+      dirty: false,
+      main: { behind: 3, ahead: 0 },
+      checkout: null,
+    }),
+    { checkout: 'detached', main: 'fast-forward' },
+  )
+})
+
+test('checked-out default branch owns the local main update', () => {
+  assert.deepEqual(
+    decideRepositorySync({
+      defaultBranch: 'main',
+      checkoutBranch: 'main',
+      dirty: false,
+      main: { behind: 2, ahead: 0 },
+      checkout: { behind: 2, ahead: 0 },
+    }),
+    { checkout: 'fast-forward', main: 'checked-out' },
+  )
+})

--- a/tests/repository-sync-routes.test.ts
+++ b/tests/repository-sync-routes.test.ts
@@ -1,0 +1,227 @@
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { createServer, request, type RequestListener } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { apply } from '../src/index.ts'
+import { repositoryFreshness } from '../src/infra/runtime.ts'
+
+interface Scenario {
+  branch: string | null
+  dirty?: boolean
+  main?: { behind: number; ahead: number } | null
+  checkout?: { behind: number; ahead: number } | null
+  conflict?: boolean
+}
+
+interface ShellResult {
+  exitCode: number
+  stdout: { text: string }
+  stderr: { text: string }
+}
+
+const shellResult = (text = '', exitCode = 0): ShellResult => ({
+  exitCode,
+  stdout: { text },
+  stderr: { text: exitCode === 0 ? '' : text },
+})
+
+function fakeShell(scenario: Scenario, commands: string[]) {
+  return async (spec: { command: string }): Promise<ShellResult> => {
+    const command = spec.command
+    commands.push(command)
+    if (command === 'git fetch origin --prune') return shellResult()
+    if (command === 'git symbolic-ref --quiet --short refs/remotes/origin/HEAD') return shellResult('origin/main')
+    if (command === 'git branch --show-current') return shellResult(scenario.branch ?? '')
+    if (command === 'git status --porcelain') return shellResult(scenario.dirty ? ' M local.txt' : '')
+    if (command.includes('git rev-list --left-right --count') && /\.\.\.'?main'?$/.test(command)) {
+      return scenario.main ? shellResult(`${scenario.main.behind} ${scenario.main.ahead}`) : shellResult('missing', 1)
+    }
+    if (command.includes('git rev-list --left-right --count') && /\.\.\.'?HEAD'?$/.test(command)) {
+      return scenario.checkout
+        ? shellResult(`${scenario.checkout.behind} ${scenario.checkout.ahead}`)
+        : shellResult('missing', 1)
+    }
+    if (/^git merge --ff-only '?origin\/main'?$/.test(command)) return shellResult('fast-forwarded')
+    if (/^git merge --no-edit '?origin\/main'?$/.test(command)) {
+      return scenario.conflict ? shellResult('CONFLICT', 1) : shellResult('merged')
+    }
+    if (/^git branch -f main '?origin\/main'?$/.test(command)) return shellResult('branch main updated')
+    if (/^git rev-parse --short '?HEAD'?$/.test(command)) return shellResult('abc1234')
+    if (/^git rev-parse --short '?MERGE_HEAD'?$/.test(command)) {
+      return scenario.conflict ? shellResult('def5678') : shellResult('missing', 1)
+    }
+    if (command === 'git diff --name-only --diff-filter=U') return shellResult('src/a.ts\nREADME.md')
+    throw new Error(`unexpected shell command: ${command}`)
+  }
+}
+
+function createHandler(run: (spec: { command: string; workdir?: string }) => Promise<unknown>): RequestListener {
+  let handler: RequestListener | null = null
+  apply({
+    webServer: {
+      register(route: { handler: RequestListener }) {
+        handler = route.handler
+        return () => {}
+      },
+    },
+    shell: {
+      resolve(spec: unknown) {
+        return spec
+      },
+      run,
+      start() {
+        throw new Error('shell start is not used')
+      },
+    },
+  } as never)
+  assert.ok(handler)
+  return handler
+}
+
+async function post(listener: RequestListener, method: 'state' | 'sync', body: unknown) {
+  const server = createServer(listener)
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  assert.ok(address && typeof address === 'object')
+  try {
+    return await new Promise<{ status: number; body: Record<string, unknown> }>((resolve, reject) => {
+      const payload = JSON.stringify(body)
+      const req = request(
+        {
+          host: '127.0.0.1',
+          port: address.port,
+          path: `/clickvibe/api/${method}`,
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'content-length': Buffer.byteLength(payload),
+            origin: `http://127.0.0.1:${address.port}`,
+            'x-clickvibe-request': '1',
+          },
+        },
+        (response) => {
+          const chunks: Buffer[] = []
+          response.on('data', (chunk: Buffer) => chunks.push(chunk))
+          response.on('end', () =>
+            resolve({
+              status: response.statusCode ?? 0,
+              body: JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>,
+            }),
+          )
+        },
+      )
+      req.on('error', reject)
+      req.end(payload)
+    })
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+  }
+}
+
+async function withConfiguredRepo(
+  scenario: Scenario,
+  run: (handler: RequestListener, commands: string[]) => Promise<void>,
+) {
+  const previousHome = process.env.HOME
+  const home = await mkdtemp(join(tmpdir(), 'clickvibe-repo-sync-'))
+  const repo = join(home, 'repo')
+  const commands: string[] = []
+  process.env.HOME = home
+  repositoryFreshness.clear()
+  try {
+    await mkdir(join(home, '.clickvibe'), { recursive: true })
+    await mkdir(repo)
+    await writeFile(join(home, '.clickvibe', 'config.yaml'), `repos:\n  o/r: ${repo}\n`)
+    await run(createHandler(fakeShell(scenario, commands)), commands)
+  } finally {
+    repositoryFreshness.clear()
+    process.env.HOME = previousHome
+    await rm(home, { recursive: true, force: true })
+  }
+}
+
+test('/state reports repository default and checkout lag after the shared fetch gate', async () => {
+  await withConfiguredRepo(
+    { branch: 'feature/x', main: { behind: 4, ahead: 0 }, checkout: { behind: 2, ahead: 1 } },
+    async (handler) => {
+      const result = await post(handler, 'state', { repoKey: 'o/r' })
+      assert.equal(result.status, 200)
+      assert.deepEqual(result.body.repoAdvance, {
+        defaultBranch: 'main',
+        remoteRef: 'origin/main',
+        mainBehind: 4,
+        checkoutBranch: 'feature/x',
+        checkoutBehind: 2,
+        fetchedAt: (result.body.freshness as { lastSuccessAt: number }).lastSuccessAt,
+      })
+    },
+  )
+})
+
+test('/sync repoKey fast-forwards checkout and local main independently', async () => {
+  await withConfiguredRepo(
+    { branch: 'feature/x', main: { behind: 3, ahead: 0 }, checkout: { behind: 2, ahead: 0 } },
+    async (handler, commands) => {
+      const result = await post(handler, 'sync', { repoKey: 'o/r' })
+      assert.equal(result.status, 200)
+      assert.equal(result.body.mainRefForwarded, true)
+      assert.deepEqual(result.body.branchHead, { branch: 'feature/x', head: 'abc1234' })
+      assert.ok(commands.some((command) => command.includes('git merge --ff-only')))
+      assert.ok(commands.some((command) => command.includes('git branch -f main')))
+    },
+  )
+})
+
+test('/sync dirty checkout refuses it but still forwards unowned local main', async () => {
+  await withConfiguredRepo(
+    { branch: 'feature/x', dirty: true, main: { behind: 3, ahead: 0 }, checkout: { behind: 2, ahead: 0 } },
+    async (handler, commands) => {
+      const result = await post(handler, 'sync', { repoKey: 'o/r' })
+      assert.equal(result.status, 200)
+      assert.match(String((result.body.refused as string[])[0]), /未提交改动/)
+      assert.equal(result.body.mainRefForwarded, true)
+      assert.equal(
+        commands.some((command) => command.startsWith('git merge ')),
+        false,
+      )
+      assert.ok(commands.some((command) => command.includes('git branch -f main')))
+    },
+  )
+})
+
+test('/sync detached checkout refuses it but still reports the main target', async () => {
+  await withConfiguredRepo({ branch: null, main: { behind: 0, ahead: 0 }, checkout: null }, async (handler) => {
+    const result = await post(handler, 'sync', { repoKey: 'o/r' })
+    assert.equal(result.status, 200)
+    assert.match(String((result.body.refused as string[])[0]), /不在任何分支/)
+    assert.equal((result.body.targets as { main: { status: string } }).main.status, 'unchanged')
+  })
+})
+
+test('/sync creates a real merge for a clean diverged checkout', async () => {
+  await withConfiguredRepo(
+    { branch: 'feature/x', main: { behind: 0, ahead: 0 }, checkout: { behind: 2, ahead: 1 } },
+    async (handler, commands) => {
+      const result = await post(handler, 'sync', { repoKey: 'o/r' })
+      assert.equal(result.status, 200)
+      assert.deepEqual(result.body.branchHead, { branch: 'feature/x', head: 'abc1234' })
+      assert.ok(commands.some((command) => command.includes('git merge --no-edit')))
+      assert.equal((result.body.targets as { checkout: { status: string } }).checkout.status, 'merged')
+    },
+  )
+})
+
+test('/sync preserves a diverged merge conflict and returns files plus agent guidance', async () => {
+  await withConfiguredRepo(
+    { branch: 'feature/x', main: { behind: 0, ahead: 0 }, checkout: { behind: 2, ahead: 1 }, conflict: true },
+    async (handler) => {
+      const result = await post(handler, 'sync', { repoKey: 'o/r' })
+      assert.equal(result.status, 200)
+      assert.deepEqual(result.body.conflict, { files: ['src/a.ts', 'README.md'] })
+      assert.match(JSON.stringify(result.body), /先同步最新代码并解决冲突/)
+      assert.equal((result.body.targets as { checkout: { status: string } }).checkout.status, 'conflict')
+    },
+  )
+})


### PR DESCRIPTION
## 变更

- 在项目列表头部展示远端默认分支领先本地 main、当前 checkout 落后及上次 fetch 时间
- 扩展现有 /clickvibe/api/sync 支持 repoKey；原 url/worktree 路径保持不变
- checkout 纯落后时 ff-only，分叉时真实 merge；脏树和 detached HEAD 明确拒绝
- merge 冲突保留 MERGE_HEAD 与冲突文件，并返回 agent 处理指引
- checkout 与未检出的本地 main 独立判定、独立报告
- 补充 state model、主仓库 AGENTS 守则及原设计文档

## Review 返工

- 已执行 git fetch origin --prune
- 已将 origin/main @ 7717014 无冲突合入当前分支
- 合并后重新验证原 repoKey 与 url/worktree 两条同步链路

## 验证

- pnpm install --frozen-lockfile
- pnpm run typecheck
- pnpm run build
- pnpm test（242/242）
- pnpm run coverage（line 92.89%，function 88.21%）
- pnpm run check（lint、format、size、layers 全绿）

Closes #67