### PR TITLE
feat: 任务日志结构化落盘与跨轮查询

### DIFF
--- a/docs/plans/2026-08-23-task-log-observability-design.md
+++ b/docs/plans/2026-08-23-task-log-observability-design.md
@@ -1,0 +1,48 @@
+# Task log observability design (Issue #58)
+
+## Scope
+
+Move workflow state from the collision-prone flat key layout into
+`~/.clickvibe/state/<owner>/<repo>/issue-<number>/workflow.json`. Keep the
+workflow key as an internal identifier only. Development and review tasks each
+own an immutable JSONL file under the issue directory. Existing poll and SSE
+payloads keep their current cursor semantics.
+
+## Storage model
+
+GitHub coordinates, not `issueKey`, select the issue directory. New workflow
+keys use a base64url encoding of `owner/repo` plus the issue number so distinct
+repositories cannot collide. Existing workflow keys remain readable.
+
+Each task file is named `<UTC-start>--<taskId>.jsonl`. Every record contains
+`ts`, `level`, `kind`, `taskId`, `sequence`, `source`, and `line`. The sequence
+is copied from the in-memory `LineLog` entry, so disk history and live delivery
+share one cursor space. ClickVibe-prefixed lines are stored with
+`source=clickvibe`; the history API maps them back to the existing
+`source=system` client event shape.
+
+Task completion appends a final structured system record carrying status and
+exit code. History aggregation derives start/end timestamps, duration, and the
+final status from the JSONL records. These metrics are additive API data; the
+current client need not render them.
+
+## Compatibility and migration
+
+On state reads, migration scans legacy top-level workflow JSON documents and
+moves each into its repository issue directory. Legacy `dev.log` and
+`review.log` files are converted line-by-line into one JSONL task generation,
+using the workflow's recorded task id when available. A source is removed only
+after its destination is complete. Errors are swallowed so startup continues
+and the unchanged source can be retried later.
+
+`/history?taskId=...` searches persisted task files, allowing older rounds to
+remain queryable after newer tasks replace the workflow's latest task id. The
+legacy `key+kind` query remains an alias for the latest recorded round.
+
+## Verification
+
+Pure tests cover reversible paths and collision-free ids. Storage tests cover
+valid JSONL, source/sequence fidelity, independent rounds, metrics, and legacy
+migration. Existing `LineLog` tests continue to cover partial and oversized
+lines, while route tests lock history lookup and SSE `__historyRequired`
+fallback behavior.

--- a/src/agent/task-supervisor.ts
+++ b/src/agent/task-supervisor.ts
@@ -32,13 +32,13 @@ import {
   TASK_RETENTION_MS,
   TASK_TIMEOUT_MS,
 } from '../infra/runtime.ts'
-import { appendLog } from '../infra/state.ts'
+import { appendTaskLog, startTaskLog, type IssueWorkflow } from '../infra/state.ts'
 import { type AgentKind, parseAgentChunk } from './agent-stream.ts'
 
 /** Start (or restart) a dev task in the live map with status parsing. */
 export function createLiveTask(
   taskId: string,
-  workflowKey: string,
+  workflow: IssueWorkflow,
   kind: LiveTask['kind'],
   agent: DevelopAgent,
   sessionId: string | null,
@@ -54,7 +54,8 @@ export function createLiveTask(
   if (liveTasks.size >= MAX_TASKS) throw new Error('运行中任务过多,请先停止或等待现有任务完成')
   const task: LiveTask = {
     taskId,
-    workflowKey,
+    workflowKey: workflow.key,
+    workflow,
     kind,
     agent,
     log: new LineLog(TASK_LOG_LINES),
@@ -66,10 +67,16 @@ export function createLiveTask(
     sessionId,
   }
   liveTasks.set(taskId, task)
+  void startTaskLog(workflow, kind, taskId)
+  pushTaskLine(task, '[clickvibe] 任务开始')
   return task
 }
 
-export function pushTaskLine(task: LiveTask, value: string | LiveLogEvent): void {
+export function pushTaskLine(
+  task: LiveTask,
+  value: string | LiveLogEvent,
+  completion?: { status: Exclude<LiveTask['status'], 'running'>; exitCode: number | null },
+): void {
   const event: LiveLogEvent =
     typeof value === 'string'
       ? value.startsWith('[clickvibe]')
@@ -77,8 +84,8 @@ export function pushTaskLine(task: LiveTask, value: string | LiveLogEvent): void
         : { source: 'agent', kind: 'text', text: value }
       : value
   const line = encodeLiveLogEvent(event)
-  task.log.appendLine(line)
-  void appendLog(task.workflowKey, task.kind, line)
+  const sequence = task.log.appendLine(line)
+  void appendTaskLog(task.workflow, task.kind, task.taskId, sequence, line, completion)
   notifyTask(task.taskId)
 }
 
@@ -96,9 +103,10 @@ export function finishTask(
   exitCode: number | null,
 ): void {
   if (task.closed) return
-  task.closed = true
   task.status = status
   task.exitCode = exitCode
+  pushTaskLine(task, `[clickvibe] 任务结束:${status},退出码 ${exitCode ?? '未知'}`, { status, exitCode })
+  task.closed = true
   if (task.kind === 'review') reviewTaskGate.release(task.workflowKey, task)
   else resumeTaskGate.release(task.workflowKey, task)
   if (task.timeout) clearTimeout(task.timeout)

--- a/src/infra/develop-core.ts
+++ b/src/infra/develop-core.ts
@@ -172,7 +172,7 @@ export class LineLog {
     this.#limit = limit
   }
 
-  appendLine(line: string): void {
+  appendLine(line: string): number {
     const bounded =
       line.length > LineLog.MAX_LINE_CHARS
         ? `${line.slice(0, LineLog.MAX_LINE_CHARS)}… [clickvibe] 单行日志已截断`
@@ -182,6 +182,7 @@ export class LineLog {
     if (this.#entries.length > this.#limit) {
       this.#entries.splice(0, this.#entries.length - this.#limit)
     }
+    return this.#sequence
   }
 
   appendChunk(chunk: string): void {

--- a/src/infra/runtime.ts
+++ b/src/infra/runtime.ts
@@ -37,6 +37,7 @@ import {
 } from './develop-core.ts'
 import { type RepositoryFreshness, RepositoryFreshnessGate, RepositoryRefreshClock } from './repo-freshness.ts'
 import { ExclusiveTaskGate } from './task-gate.ts'
+import type { IssueWorkflow } from './state.ts'
 
 const MAX_BODY_BYTES = 64 * 1024
 
@@ -62,6 +63,7 @@ export const automaticDependencyValidationClock = new RepositoryRefreshClock()
 export interface LiveTask {
   taskId: string
   workflowKey: string
+  workflow: IssueWorkflow
   kind: 'dev' | 'review'
   agent: DevelopAgent
   process?: ReturnType<Context['shell']['start']>

--- a/src/infra/state-layout.ts
+++ b/src/infra/state-layout.ts
@@ -1,0 +1,88 @@
+import { Buffer } from 'node:buffer'
+import { join, relative, sep } from 'node:path'
+
+export interface WorkflowStorageIdentity {
+  key: string
+  repoKey: string
+  url: string
+}
+
+export interface IssueCoordinates {
+  owner: string
+  repo: string
+  issue: string
+}
+
+const GITHUB_COMPONENT = /^[A-Za-z0-9_.-]+$/
+const ISSUE_NUMBER = /^[1-9]\d*$/
+const TASK_ID = /^[A-Za-z0-9_.-]+$/
+
+function validGithubComponent(value: string): boolean {
+  return GITHUB_COMPONENT.test(value) && value !== '.' && value !== '..'
+}
+
+export function issueCoordinates(workflow: WorkflowStorageIdentity): IssueCoordinates {
+  const slash = workflow.repoKey.indexOf('/')
+  const owner = workflow.repoKey.slice(0, slash)
+  const repo = workflow.repoKey.slice(slash + 1)
+  const match = workflow.url.match(/\/(?:issues|pull)\/(\d+)(?:[/?#]|$)/)
+  const issue = match?.[1] ?? ''
+  if (!validGithubComponent(owner) || !validGithubComponent(repo) || !ISSUE_NUMBER.test(issue)) {
+    throw new Error(`invalid workflow storage identity: ${workflow.repoKey} ${workflow.url}`)
+  }
+  return { owner, repo, issue }
+}
+
+export function issueDirectory(root: string, owner: string, repo: string, issue: string): string {
+  if (!validGithubComponent(owner) || !validGithubComponent(repo) || !ISSUE_NUMBER.test(issue)) {
+    throw new Error('invalid issue coordinates')
+  }
+  return join(root, owner, repo, `issue-${issue}`)
+}
+
+export function parseIssueDirectory(root: string, directory: string): IssueCoordinates | null {
+  const parts = relative(root, directory).split(sep)
+  if (parts.length !== 3) return null
+  const [owner, repo, issuePart] = parts
+  const issue = issuePart.match(/^issue-([1-9]\d*)$/)?.[1] ?? ''
+  if (!validGithubComponent(owner) || !validGithubComponent(repo) || !ISSUE_NUMBER.test(issue)) return null
+  return { owner, repo, issue }
+}
+
+export function workflowPath(root: string, workflow: WorkflowStorageIdentity): string {
+  const { owner, repo, issue } = issueCoordinates(workflow)
+  return join(issueDirectory(root, owner, repo, issue), 'workflow.json')
+}
+
+export function taskStartTimestamp(taskId: string): string {
+  const milliseconds = Number(taskId.match(/^[a-z]+-(\d+)-/)?.[1])
+  const date = Number.isSafeInteger(milliseconds) ? new Date(milliseconds) : new Date(0)
+  return date.toISOString().replace(/[:.]/g, '-')
+}
+
+export function taskLogPath(
+  root: string,
+  workflow: WorkflowStorageIdentity,
+  kind: 'dev' | 'review',
+  taskId: string,
+): string {
+  if (!TASK_ID.test(taskId)) throw new Error('invalid task id')
+  return join(workflowPath(root, workflow), '..', kind, `${taskStartTimestamp(taskId)}--${taskId}.jsonl`)
+}
+
+export function issueKey(repoKey: string, number: string): string {
+  if (!ISSUE_NUMBER.test(number)) throw new Error('invalid issue number')
+  return `issue-${Buffer.from(repoKey, 'utf8').toString('base64url')}-${number}`
+}
+
+export function legacyIssueKey(key: string): string | null {
+  const match = key.match(/^issue-([A-Za-z0-9_-]+)-([1-9]\d*)$/)
+  if (!match) return null
+  try {
+    const repoKey = Buffer.from(match[1], 'base64url').toString('utf8')
+    if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repoKey)) return null
+    return `${repoKey.replace('/', '-')}-${match[2]}`
+  } catch {
+    return null
+  }
+}

--- a/src/infra/state.ts
+++ b/src/infra/state.ts
@@ -1,15 +1,23 @@
-/**
- * clickvibe persistent workflow state.
- *
- * One JSON document per issue under ~/.clickvibe/state/, plus per-issue log
- * files. Survives web restarts and page refreshes so the panel can restore
- * its context (the issue being viewed + its dev/review workflow stage).
- */
+/** Project-scoped workflow state and task-log compatibility facade. */
 import { createHash } from 'node:crypto'
-import { appendFile, mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { appendFile, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { join } from 'node:path'
 import type { DeliveryPublication, PromptSnapshot } from './contracts.ts'
+import { issueKey, legacyIssueKey, taskLogPath, workflowPath, type WorkflowStorageIdentity } from './state-layout.ts'
+import {
+  appendTaskLog as appendTaskLogRecord,
+  appendTaskLogNext,
+  listTaskIds,
+  migrateLegacyLog,
+  readTaskLog as readTaskLogRecords,
+  startTaskLog as createTaskLog,
+  type AppendTaskLogOptions,
+  type TaskLogKind,
+  type TaskLogRead,
+} from './task-log-store.ts'
+
+export { issueKey } from './state-layout.ts'
 
 /** The workflow stage of one issue. */
 export type WorkflowStage =
@@ -200,92 +208,162 @@ export function stateDir(): string {
   return join(homedir(), '.clickvibe', 'state')
 }
 
-/** Derive the state file path for one issue key. */
-export function statePath(key: string): string {
-  return join(stateDir(), `${key}.json`)
+export function statePath(workflow: WorkflowStorageIdentity): string {
+  return workflowPath(stateDir(), workflow)
 }
 
-export function archiveStatePath(key: string): string {
-  return join(stateDir(), 'archive', `${key}.json`)
+export function logPath(workflow: WorkflowStorageIdentity, kind: TaskLogKind, taskId: string): string {
+  return taskLogPath(stateDir(), workflow, kind, taskId)
 }
 
-/** Derive the log file path for one issue's dev/review log. */
-export function logPath(key: string, kind: 'dev' | 'review'): string {
-  return join(stateDir(), key, `${kind}.log`)
-}
-
-// Keep every operation for one persistent log in call order. Besides avoiding
-// reordered appendFile completions, this gives /history a real snapshot
-// boundary: writes queued before the read are included, later writes are SSE
-// increments after the returned in-memory cursor.
-const logQueues = new Map<string, Promise<unknown>>()
-
-function enqueueLogOperation<T>(path: string, operation: () => Promise<T>): Promise<T> {
-  const previous = logQueues.get(path) ?? Promise.resolve()
-  const current = previous.catch(() => undefined).then(operation)
-  logQueues.set(path, current)
-  void current
-    .finally(() => {
-      if (logQueues.get(path) === current) logQueues.delete(path)
-    })
-    .catch(() => undefined)
-  return current
-}
-
-/** Load one issue's workflow state; missing file yields a fresh idle record. */
-export async function loadWorkflow(key: string): Promise<IssueWorkflow | null> {
+async function readWorkflowFile(path: string): Promise<IssueWorkflow | null> {
   try {
-    const raw = await readFile(statePath(key), 'utf8')
-    return normalizeWorkflow(JSON.parse(raw) as IssueWorkflow)
+    return normalizeWorkflow(JSON.parse(await readFile(path, 'utf8')) as IssueWorkflow)
   } catch {
     return null
   }
 }
 
-/** Load every stored workflow (for panel restore). */
+function currentKey(workflow: IssueWorkflow): string | null {
+  const number = workflow.url.match(/\/(?:issues|pull)\/(\d+)(?:[/?#]|$)/)?.[1]
+  if (!number) return null
+  try {
+    return issueKey(workflow.repoKey, number)
+  } catch {
+    return null
+  }
+}
+
+async function storedWorkflowFiles(): Promise<string[]> {
+  const root = stateDir()
+  const files: string[] = []
+  try {
+    for (const owner of await readdir(root, { withFileTypes: true })) {
+      if (!owner.isDirectory() || owner.name === 'archive') continue
+      for (const repo of await readdir(join(root, owner.name), { withFileTypes: true })) {
+        if (!repo.isDirectory()) continue
+        for (const issue of await readdir(join(root, owner.name, repo.name), { withFileTypes: true })) {
+          if (issue.isDirectory() && /^issue-[1-9]\d*$/.test(issue.name)) {
+            files.push(join(root, owner.name, repo.name, issue.name, 'workflow.json'))
+          }
+        }
+      }
+    }
+  } catch {
+    return files
+  }
+  return files
+}
+
+async function migrateWorkflowLogs(workflow: IssueWorkflow): Promise<void> {
+  for (const kind of ['dev', 'review'] as const) {
+    const legacy = join(stateDir(), workflow.key, `${kind}.log`)
+    const taskId = kind === 'dev' ? workflow.devTaskId : workflow.reviewTaskId
+    if (!taskId) continue
+    try {
+      await migrateLegacyLog(
+        stateDir(),
+        workflow,
+        kind,
+        taskId,
+        legacy,
+        new Date(workflow.updatedAt || 0).toISOString(),
+      )
+    } catch {
+      // Best effort: leave the source untouched so a later startup can retry.
+    }
+  }
+}
+
+async function migrateLegacyWorkflowFile(path: string): Promise<void> {
+  const workflow = await readWorkflowFile(path)
+  if (!workflow) return
+  const destination = statePath(workflow)
+  try {
+    await mkdir(join(destination, '..'), { recursive: true })
+    try {
+      await writeFile(destination, await readFile(path), { flag: 'wx' })
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
+      const existing = await readWorkflowFile(destination)
+      if (!existing || existing.key !== workflow.key) throw error
+    }
+    await rm(path)
+    await migrateWorkflowLogs(workflow)
+  } catch {
+    // Migration is retryable and must not prevent startup.
+  }
+}
+
+const migrations = new Map<string, Promise<void>>()
+
+async function migrateLegacyState(): Promise<void> {
+  const root = stateDir()
+  const existing = migrations.get(root)
+  if (existing) return existing
+  const migration = (async () => {
+    try {
+      for (const entry of await readdir(root, { withFileTypes: true })) {
+        if (entry.isFile() && entry.name.endsWith('.json')) {
+          await migrateLegacyWorkflowFile(join(root, entry.name))
+        }
+      }
+      const archive = join(root, 'archive')
+      try {
+        for (const entry of await readdir(archive, { withFileTypes: true })) {
+          if (entry.isFile() && entry.name.endsWith('.json')) await migrateLegacyWorkflowFile(join(archive, entry.name))
+        }
+        await rm(archive, { recursive: false }).catch(() => undefined)
+      } catch {
+        // No legacy archive directory.
+      }
+    } catch {
+      // Missing state root or a transient read failure is non-fatal.
+    }
+  })()
+  migrations.set(root, migration)
+  try {
+    await migration
+  } finally {
+    if (migrations.get(root) === migration) migrations.delete(root)
+  }
+}
+
+export async function loadWorkflow(key: string): Promise<IssueWorkflow | null> {
+  await migrateLegacyState()
+  for (const path of await storedWorkflowFiles()) {
+    const workflow = await readWorkflowFile(path)
+    if (workflow && (workflow.key === key || currentKey(workflow) === key || legacyIssueKey(workflow.key) === key)) {
+      await migrateWorkflowLogs(workflow)
+      return workflow.delivery?.status === 'archived' ? null : workflow
+    }
+  }
+  return null
+}
+
 export async function loadAllWorkflows(): Promise<IssueWorkflow[]> {
-  try {
-    const { readdir } = await import('node:fs/promises')
-    const entries = await readdir(stateDir())
-    const workflows: IssueWorkflow[] = []
-    for (const entry of entries) {
-      if (!entry.endsWith('.json')) continue
-      try {
-        const raw = await readFile(join(stateDir(), entry), 'utf8')
-        workflows.push(normalizeWorkflow(JSON.parse(raw) as IssueWorkflow))
-      } catch {
-        // corrupt state file: skip
-      }
+  await migrateLegacyState()
+  const workflows: IssueWorkflow[] = []
+  for (const path of await storedWorkflowFiles()) {
+    const workflow = await readWorkflowFile(path)
+    if (workflow) {
+      await migrateWorkflowLogs(workflow)
+      if (workflow.delivery?.status !== 'archived') workflows.push(workflow)
     }
-    return workflows.sort((a, b) => b.updatedAt - a.updatedAt)
-  } catch {
-    return []
   }
+  return workflows.sort((a, b) => b.updatedAt - a.updatedAt)
 }
 
-/** Load archived terminal workflows for direct URL restoration only. */
 export async function loadAllArchivedWorkflows(): Promise<IssueWorkflow[]> {
-  try {
-    const { readdir } = await import('node:fs/promises')
-    const dir = join(stateDir(), 'archive')
-    const entries = await readdir(dir)
-    const workflows: IssueWorkflow[] = []
-    for (const entry of entries) {
-      if (!entry.endsWith('.json')) continue
-      try {
-        const raw = await readFile(join(dir, entry), 'utf8')
-        workflows.push(normalizeWorkflow(JSON.parse(raw) as IssueWorkflow))
-      } catch {
-        // corrupt archived file: skip
-      }
-    }
-    return workflows.sort((a, b) => b.updatedAt - a.updatedAt)
-  } catch {
-    return []
+  await migrateLegacyState()
+  const workflows: IssueWorkflow[] = []
+  for (const path of await storedWorkflowFiles()) {
+    const workflow = await readWorkflowFile(path)
+    if (workflow?.delivery?.status === 'archived') workflows.push(workflow)
   }
+  return workflows.sort((a, b) => b.updatedAt - a.updatedAt)
 }
 
-/** Persist one issue's workflow state (atomic-ish: write then ignore errors). */
 export async function saveWorkflow(workflow: IssueWorkflow): Promise<void> {
   try {
     await saveWorkflowStrict(workflow)
@@ -294,68 +372,127 @@ export async function saveWorkflow(workflow: IssueWorkflow): Promise<void> {
   }
 }
 
-/** Persist workflow state or surface the failure to transactional callers. */
 export async function saveWorkflowStrict(workflow: IssueWorkflow): Promise<void> {
-  await mkdir(stateDir(), { recursive: true })
+  await mkdir(join(statePath(workflow), '..'), { recursive: true })
   workflow.updatedAt = Date.now()
-  await writeFile(statePath(workflow.key), JSON.stringify(workflow, null, 2), 'utf8')
+  await writeFile(statePath(workflow), JSON.stringify(workflow, null, 2), 'utf8')
 }
 
-/** Persist the final workflow and atomically remove it from the active set. */
 export async function archiveWorkflow(workflow: IssueWorkflow): Promise<void> {
-  await mkdir(join(stateDir(), 'archive'), { recursive: true })
   await saveWorkflowStrict(workflow)
-  await rename(statePath(workflow.key), archiveStatePath(workflow.key))
 }
 
-/** Append one line to an issue's log file (creating the directory). */
+export async function startTaskLog(workflow: IssueWorkflow, kind: TaskLogKind, taskId: string): Promise<void> {
+  try {
+    await createTaskLog(stateDir(), workflow, kind, taskId)
+  } catch {
+    // Log persistence remains best-effort.
+  }
+}
+
+export async function appendTaskLog(
+  workflow: IssueWorkflow,
+  kind: TaskLogKind,
+  taskId: string,
+  sequence: number,
+  line: string,
+  options: AppendTaskLogOptions = {},
+): Promise<void> {
+  try {
+    await appendTaskLogRecord(stateDir(), workflow, kind, taskId, sequence, line, options)
+  } catch {
+    // Log persistence remains best-effort.
+  }
+}
+
+export async function readTaskLog(workflow: IssueWorkflow, kind: TaskLogKind, taskId: string): Promise<TaskLogRead> {
+  return readTaskLogRecords(stateDir(), workflow, kind, taskId)
+}
+
+/** Compatibility append for workflow actions outside a live agent task. */
 export async function appendLog(key: string, kind: 'dev' | 'review', line: string): Promise<void> {
-  const path = logPath(key, kind)
   try {
-    await enqueueLogOperation(path, async () => {
-      await mkdir(dirname(path), { recursive: true })
-      await appendFile(path, `${line}\n`, 'utf8')
-    })
+    const workflow = await loadWorkflow(key)
+    let taskId = kind === 'dev' ? workflow?.devTaskId : workflow?.reviewTaskId
+    if (workflow && !taskId) {
+      taskId = `legacy-${kind}-${Date.now()}`
+      if (kind === 'dev') workflow.devTaskId = taskId
+      else workflow.reviewTaskId = taskId
+      await saveWorkflow(workflow)
+      await migrateWorkflowLogs(workflow)
+    }
+    if (workflow && taskId) {
+      await appendTaskLogNext(stateDir(), workflow, kind, taskId, line)
+      return
+    }
+    const legacyAlias = legacyIssueKey(key)
+    let storageKey = key
+    if (legacyAlias) {
+      try {
+        await readFile(join(stateDir(), legacyAlias, `${kind}.log`), 'utf8')
+        storageKey = legacyAlias
+      } catch {
+        // No legacy alias exists; use the current stable id.
+      }
+    }
+    const legacyPath = join(stateDir(), storageKey, `${kind}.log`)
+    await mkdir(join(legacyPath, '..'), { recursive: true })
+    await appendFile(legacyPath, `${line}\n`, 'utf8')
   } catch {
     // log persistence is best-effort
   }
 }
 
-/** Start a new task generation while preserving full history within that run. */
+/** @deprecated New task generations call startTaskLog with an explicit task id. */
 export async function resetLog(key: string, kind: 'dev' | 'review'): Promise<void> {
-  const path = logPath(key, kind)
-  try {
-    await enqueueLogOperation(path, async () => {
-      await mkdir(dirname(path), { recursive: true })
-      await writeFile(path, '', 'utf8')
-    })
-  } catch {
-    // log persistence is best-effort
-  }
+  const workflow = await loadWorkflow(key)
+  const taskId = kind === 'dev' ? workflow?.devTaskId : workflow?.reviewTaskId
+  if (workflow && taskId) await startTaskLog(workflow, kind, taskId)
 }
 
 /** Read the complete durable log at an ordered snapshot boundary. */
 export async function readLogHistory(key: string, kind: 'dev' | 'review'): Promise<string[]> {
-  const path = logPath(key, kind)
-  try {
-    return await enqueueLogOperation(path, async () => {
-      const raw = await readFile(path, 'utf8')
+  const workflow = await loadWorkflow(key)
+  if (!workflow) {
+    try {
+      const raw = await readFile(join(stateDir(), key, `${kind}.log`), 'utf8')
       const lines = raw.split('\n')
       if (lines.at(-1) === '') lines.pop()
       return lines
-    })
-  } catch {
-    return []
+    } catch {
+      return []
+    }
   }
+  const taskId = kind === 'dev' ? workflow.devTaskId : workflow.reviewTaskId
+  if (!taskId) return []
+  return (await readTaskLog(workflow, kind, taskId)).encodedLines
 }
 
-/** Read a log file's tail; returns up to `limit` last lines. */
 export async function readLogTail(key: string, kind: 'dev' | 'review', limit = 500): Promise<string[]> {
   const lines = await readLogHistory(key, kind)
   return lines.slice(Math.max(0, lines.length - limit))
 }
 
-/** Derive a stable issue key from repo + number (safe for filenames). */
-export function issueKey(repoKey: string, number: string): string {
-  return `${repoKey.replace(/[^A-Za-z0-9_.-]/g, '-')}-${number}`
+export async function findTaskHistory(taskId: string): Promise<{
+  workflow: IssueWorkflow
+  kind: TaskLogKind
+  history: TaskLogRead
+} | null> {
+  for (const workflow of [...(await loadAllWorkflows()), ...(await loadAllArchivedWorkflows())]) {
+    for (const kind of ['dev', 'review'] as const) {
+      if ((await listTaskIds(stateDir(), workflow, kind)).includes(taskId)) {
+        return { workflow, kind, history: await readTaskLog(workflow, kind, taskId) }
+      }
+    }
+  }
+  return null
+}
+
+export async function findWorkflowByIssue(repoKey: string, issue: string): Promise<IssueWorkflow | null> {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repoKey) || !/^[1-9]\d*$/.test(issue)) return null
+  for (const workflow of [...(await loadAllWorkflows()), ...(await loadAllArchivedWorkflows())]) {
+    const number = workflow.url.match(/\/(?:issues|pull)\/(\d+)(?:[/?#]|$)/)?.[1]
+    if (workflow.repoKey === repoKey && number === issue) return workflow
+  }
+  return null
 }

--- a/src/infra/task-log-store.ts
+++ b/src/infra/task-log-store.ts
@@ -1,0 +1,272 @@
+import { appendFile, link, mkdir, readFile, readdir, rm, rmdir, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { decodeLiveLogLine, encodeLiveLogEvent, type LiveLogEvent } from './live-output.ts'
+import { taskLogPath, type WorkflowStorageIdentity } from './state-layout.ts'
+
+export type TaskLogKind = 'dev' | 'review'
+export type TaskExitStatus = 'done' | 'failed' | 'stopped' | 'timed_out'
+
+export interface TaskLogRecord {
+  ts: string
+  level: 'info' | 'error'
+  kind: string
+  taskId: string
+  sequence: number
+  source: 'agent' | 'clickvibe'
+  line: string
+  event?: LiveLogEvent
+  wireLine?: string
+  status?: TaskExitStatus
+  exitCode?: number | null
+}
+
+export interface TaskMetrics {
+  startedAt: string | null
+  endedAt: string | null
+  durationMs: number | null
+  status: TaskExitStatus | 'running' | null
+  exitCode: number | null
+}
+
+export interface TaskLogRead {
+  records: TaskLogRecord[]
+  encodedLines: string[]
+  lines: string[]
+  events: LiveLogEvent[]
+  metrics: TaskMetrics
+}
+
+const logQueues = new Map<string, Promise<unknown>>()
+
+function enqueue<T>(path: string, operation: () => Promise<T>): Promise<T> {
+  const previous = logQueues.get(path) ?? Promise.resolve()
+  const current = previous.catch(() => undefined).then(operation)
+  logQueues.set(path, current)
+  void current
+    .finally(() => {
+      if (logQueues.get(path) === current) logQueues.delete(path)
+    })
+    .catch(() => undefined)
+  return current
+}
+
+function taskRecord(
+  taskId: string,
+  sequence: number,
+  encodedLine: string,
+  options: AppendTaskLogOptions,
+): TaskLogRecord {
+  const event = decodeLiveLogLine(encodedLine)
+  return {
+    ts: options.ts ?? new Date().toISOString(),
+    level: options.level ?? (options.status === 'failed' || options.status === 'timed_out' ? 'error' : 'info'),
+    kind: event.kind,
+    taskId,
+    sequence,
+    source: event.source === 'system' ? 'clickvibe' : 'agent',
+    line: event.text,
+    event,
+    ...(encodedLine === encodeLiveLogEvent(event) ? { wireLine: encodedLine } : {}),
+    ...(options.status ? { status: options.status, exitCode: options.exitCode ?? null } : {}),
+  }
+}
+
+function isTaskLogRecord(value: unknown): value is TaskLogRecord {
+  if (!value || typeof value !== 'object') return false
+  const record = value as Partial<TaskLogRecord>
+  return (
+    typeof record.ts === 'string' &&
+    typeof record.kind === 'string' &&
+    typeof record.taskId === 'string' &&
+    Number.isSafeInteger(record.sequence) &&
+    (record.source === 'agent' || record.source === 'clickvibe') &&
+    typeof record.line === 'string'
+  )
+}
+
+function recordEvent(record: TaskLogRecord): LiveLogEvent {
+  if (record.event && typeof record.event.text === 'string') return record.event
+  return record.source === 'clickvibe'
+    ? { source: 'system', kind: 'system', text: record.line }
+    : { source: 'agent', kind: 'text', text: record.line }
+}
+
+function aggregateMetrics(records: TaskLogRecord[]): TaskMetrics {
+  const first = records[0]
+  const final = [...records].reverse().find((record) => record.status)
+  const started = first ? Date.parse(first.ts) : Number.NaN
+  const ended = final ? Date.parse(final.ts) : Number.NaN
+  return {
+    startedAt: first?.ts ?? null,
+    endedAt: final?.ts ?? null,
+    durationMs: Number.isFinite(started) && Number.isFinite(ended) ? Math.max(0, ended - started) : null,
+    status: final?.status ?? (first ? 'running' : null),
+    exitCode: final?.exitCode ?? null,
+  }
+}
+
+export interface AppendTaskLogOptions {
+  ts?: string
+  level?: 'info' | 'error'
+  status?: TaskExitStatus
+  exitCode?: number | null
+}
+
+export async function startTaskLog(
+  root: string,
+  workflow: WorkflowStorageIdentity,
+  kind: TaskLogKind,
+  taskId: string,
+): Promise<void> {
+  const path = taskLogPath(root, workflow, kind, taskId)
+  await enqueue(path, async () => {
+    await mkdir(dirname(path), { recursive: true })
+    try {
+      await writeFile(path, '', { encoding: 'utf8', flag: 'wx' })
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
+    }
+  })
+}
+
+export async function appendTaskLog(
+  root: string,
+  workflow: WorkflowStorageIdentity,
+  kind: TaskLogKind,
+  taskId: string,
+  sequence: number,
+  encodedLine: string,
+  options: AppendTaskLogOptions = {},
+): Promise<void> {
+  const path = taskLogPath(root, workflow, kind, taskId)
+  const record = taskRecord(taskId, sequence, encodedLine, options)
+  await enqueue(path, async () => {
+    await mkdir(dirname(path), { recursive: true })
+    await appendFile(path, `${JSON.stringify(record)}\n`, 'utf8')
+  })
+}
+
+export async function readTaskLog(
+  root: string,
+  workflow: WorkflowStorageIdentity,
+  kind: TaskLogKind,
+  taskId: string,
+): Promise<TaskLogRead> {
+  const path = taskLogPath(root, workflow, kind, taskId)
+  try {
+    return await enqueue(path, async () => {
+      const raw = await readFile(path, 'utf8')
+      const records: TaskLogRecord[] = []
+      for (const line of raw.split('\n')) {
+        if (line === '') continue
+        try {
+          const parsed: unknown = JSON.parse(line)
+          if (isTaskLogRecord(parsed)) records.push(parsed)
+        } catch {
+          // A crash may leave one partial trailing line; prior valid records remain readable.
+        }
+      }
+      records.sort((a, b) => a.sequence - b.sequence)
+      const events = records.map(recordEvent)
+      return {
+        records,
+        events,
+        lines: events.map((event) => event.text),
+        encodedLines: records.map((record, index) => record.wireLine ?? events[index].text),
+        metrics: aggregateMetrics(records),
+      }
+    })
+  } catch {
+    return {
+      records: [],
+      events: [],
+      lines: [],
+      encodedLines: [],
+      metrics: aggregateMetrics([]),
+    }
+  }
+}
+
+export async function listTaskIds(
+  root: string,
+  workflow: WorkflowStorageIdentity,
+  kind: TaskLogKind,
+): Promise<string[]> {
+  const directory = dirname(taskLogPath(root, workflow, kind, 'probe'))
+  try {
+    const entries = await readdir(directory)
+    return entries
+      .filter((entry) => entry.endsWith('.jsonl') && entry.includes('--'))
+      .map((entry) => entry.slice(entry.indexOf('--') + 2, -'.jsonl'.length))
+      .reverse()
+  } catch {
+    return []
+  }
+}
+
+export async function appendTaskLogNext(
+  root: string,
+  workflow: WorkflowStorageIdentity,
+  kind: TaskLogKind,
+  taskId: string,
+  encodedLine: string,
+  options: AppendTaskLogOptions = {},
+): Promise<void> {
+  const path = taskLogPath(root, workflow, kind, taskId)
+  await enqueue(path, async () => {
+    await mkdir(dirname(path), { recursive: true })
+    let sequence = 1
+    try {
+      const raw = await readFile(path, 'utf8')
+      for (const line of raw.split('\n')) {
+        try {
+          const record: unknown = JSON.parse(line)
+          if (isTaskLogRecord(record)) sequence = Math.max(sequence, record.sequence + 1)
+        } catch {
+          // Ignore a trailing partial record when continuing a best-effort log.
+        }
+      }
+    } catch {
+      // Missing task file is created by appendFile.
+    }
+    await appendFile(path, `${JSON.stringify(taskRecord(taskId, sequence, encodedLine, options))}\n`, 'utf8')
+  })
+}
+
+export async function migrateLegacyLog(
+  root: string,
+  workflow: WorkflowStorageIdentity,
+  kind: TaskLogKind,
+  taskId: string,
+  legacyPath: string,
+  timestamp: string,
+): Promise<void> {
+  const destination = taskLogPath(root, workflow, kind, taskId)
+  const raw = await readFile(legacyPath, 'utf8')
+  const lines = raw.split('\n')
+  if (lines.at(-1) === '') lines.pop()
+  const records = lines.map((line, index) => taskRecord(taskId, index + 1, line, { ts: timestamp }))
+  const serialized = records.map((record) => JSON.stringify(record)).join('\n') + (records.length ? '\n' : '')
+  await mkdir(dirname(destination), { recursive: true })
+  try {
+    const existing = await readFile(destination, 'utf8')
+    if (existing !== serialized) throw new Error('existing task log differs from legacy source')
+    await rm(legacyPath)
+    await rmdir(join(legacyPath, '..')).catch(() => undefined)
+    return
+  } catch {
+    // Destination is absent or incomplete; complete it through an exclusive link.
+  }
+  const temporary = `${destination}.migrating`
+  await writeFile(temporary, serialized, 'utf8')
+  try {
+    await link(temporary, destination)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
+    const existing = await readFile(destination, 'utf8')
+    if (existing !== (await readFile(temporary, 'utf8'))) throw error
+  }
+  await rm(temporary, { force: true })
+  await rm(legacyPath)
+  await rmdir(join(legacyPath, '..')).catch(() => undefined)
+}

--- a/src/workflow/develop-start.ts
+++ b/src/workflow/develop-start.ts
@@ -42,14 +42,7 @@ import {
   runCommand,
   taskId,
 } from '../infra/runtime.ts'
-import {
-  applyDevRunOutcome,
-  type IssueWorkflow,
-  issueKey,
-  loadWorkflow,
-  resetLog,
-  saveWorkflow,
-} from '../infra/state.ts'
+import { applyDevRunOutcome, type IssueWorkflow, issueKey, loadWorkflow, saveWorkflow } from '../infra/state.ts'
 import { deriveAutoDevelopment } from './auto-development.ts'
 import { deriveWorkflowState } from './derive.ts'
 import { checkIssueContract } from './issue-contract.ts'
@@ -208,7 +201,7 @@ export async function startDevelop(
     const taskIdValue = taskId('dryrun')
     let live: LiveTask
     try {
-      live = createLiveTask(taskIdValue, workflow.key, 'dev', agent, null)
+      live = createLiveTask(taskIdValue, workflow, 'dev', agent, null)
     } catch (error) {
       return { ok: false, error: String(error instanceof Error ? error.message : error) }
     }
@@ -244,13 +237,12 @@ export async function startDevelop(
   const taskIdValue = taskId('dev')
   let live: LiveTask
   try {
-    live = createLiveTask(taskIdValue, workflow.key, 'dev', agent, null)
+    live = createLiveTask(taskIdValue, workflow, 'dev', agent, null)
   } catch (error) {
     return { ok: false, error: String(error instanceof Error ? error.message : error) }
   }
-  // Rotate only after both worktree preparation and LiveTask creation succeed;
-  // failed start attempts must not destroy the previous authoritative history.
-  await resetLog(workflow.key, 'dev')
+  // LiveTask creation opened a new immutable JSONL generation. Previous task
+  // files remain queryable and are never truncated.
   workflow.devAgent = agent
   workflow.devTaskId = taskIdValue
   workflow.devInterrupted = false

--- a/src/workflow/resume.ts
+++ b/src/workflow/resume.ts
@@ -36,7 +36,6 @@ import {
   clearStaleSessionId,
   issueKey,
   loadWorkflow,
-  resetLog,
   resolveSessionForAgent,
   saveWorkflow,
 } from '../infra/state.ts'
@@ -78,7 +77,7 @@ export async function resumeDevelop(
   try {
     reservation = resumeTaskGate.reserve(workflow.key, () => {
       const id = taskId('dev')
-      return createLiveTask(id, workflow.key, 'dev', agent, sessionId)
+      return createLiveTask(id, workflow, 'dev', agent, sessionId)
     })
   } catch (error) {
     return { ok: false, error: String(error instanceof Error ? error.message : error) }
@@ -90,7 +89,6 @@ export async function resumeDevelop(
     finishTask(live, 'failed', 1)
     return { ok: false, error: resolvedSnapshot.error }
   }
-  await resetLog(workflow.key, 'dev')
   workflow.devTaskId = live.taskId
   workflow.devInterrupted = false
   workflow.stage = 'developing'

--- a/src/workflow/review-flow.ts
+++ b/src/workflow/review-flow.ts
@@ -41,7 +41,6 @@ import {
   loadWorkflow,
   readLogTail,
   recordSessionId,
-  resetLog,
   resolveSessionForAgent,
   saveWorkflow,
   type WorkflowEvent,
@@ -98,7 +97,7 @@ export async function startReview(
   try {
     reservation = reviewTaskGate.reserve(workflow.key, () => {
       const id = taskId('review')
-      return createLiveTask(id, workflow.key, 'review', agent, sessionId)
+      return createLiveTask(id, workflow, 'review', agent, sessionId)
     })
   } catch (error) {
     return { ok: false, error: String(error instanceof Error ? error.message : error) }
@@ -120,8 +119,6 @@ export async function startReview(
       updatedAt: resolvedSnapshot.snapshot.updatedAt,
     },
   }
-  await resetLog(workflow.key, 'review')
-
   // Review must inspect the branch against current remote refs. Keep review
   // available during an outage, but make the degraded input explicit in its log.
   try {

--- a/src/workflow/task-api.ts
+++ b/src/workflow/task-api.ts
@@ -2,7 +2,15 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import { finishTask, pushTaskLine } from '../agent/task-supervisor.ts'
 import { decodeLiveLogLine, type LiveLogEvent } from '../infra/live-output.ts'
 import { type LiveTask, liveTasks, liveWaiters } from '../infra/runtime.ts'
-import { loadAllWorkflows, loadWorkflow, readLogHistory, saveWorkflow } from '../infra/state.ts'
+import {
+  findTaskHistory,
+  findWorkflowByIssue,
+  type IssueWorkflow,
+  loadWorkflow,
+  readTaskLog,
+  saveWorkflow,
+} from '../infra/state.ts'
+import type { TaskMetrics } from '../infra/task-log-store.ts'
 
 /** Consume incremental dev log/status for one task. */
 export async function pollDevelop(payload: unknown): Promise<
@@ -49,16 +57,14 @@ export async function resolveHistoryTarget(
   key: string
   kind: HistoryKind
   live: LiveTask | null
+  workflow: IssueWorkflow
 } | null> {
   if (taskIdValue !== '') {
     const live = liveTasks.get(taskIdValue) ?? null
-    if (live) return { taskId: taskIdValue, key: live.workflowKey, kind: live.kind, live }
-    const workflow = (await loadAllWorkflows()).find(
-      (item) => item.devTaskId === taskIdValue || item.reviewTaskId === taskIdValue,
-    )
-    if (!workflow) return null
-    const kind: HistoryKind = workflow.reviewTaskId === taskIdValue ? 'review' : 'dev'
-    return { taskId: taskIdValue, key: workflow.key, kind, live: null }
+    if (live) return { taskId: taskIdValue, key: live.workflowKey, kind: live.kind, live, workflow: live.workflow }
+    const stored = await findTaskHistory(taskIdValue)
+    if (!stored) return null
+    return { taskId: taskIdValue, key: stored.workflow.key, kind: stored.kind, live: null, workflow: stored.workflow }
   }
   if (!/^[A-Za-z0-9_.-]+$/.test(requestedKey)) return null
   if (requestedKind !== 'dev' && requestedKind !== 'review') return null
@@ -66,7 +72,7 @@ export async function resolveHistoryTarget(
   if (!workflow) return null
   const storedTaskId = requestedKind === 'dev' ? workflow.devTaskId : workflow.reviewTaskId
   const live = storedTaskId ? (liveTasks.get(storedTaskId) ?? null) : null
-  return { taskId: storedTaskId, key: requestedKey, kind: requestedKind, live }
+  return { taskId: storedTaskId, key: requestedKey, kind: requestedKind, live, workflow }
 }
 
 /** Complete disk history plus the exact cursor where SSE increments begin. */
@@ -80,32 +86,51 @@ export async function getTaskHistory(req: IncomingMessage): Promise<
       events: LiveLogEvent[]
       cursor: number
       active: boolean
+      metrics: TaskMetrics
     }
   | { ok: false; error: string }
 > {
   const url = new URL(req.url ?? '/', 'http://clickvibe.internal')
-  const target = await resolveHistoryTarget(
-    url.searchParams.get('taskId')?.trim() ?? '',
-    url.searchParams.get('key')?.trim() ?? '',
-    url.searchParams.get('kind')?.trim() ?? '',
-  )
+  const taskIdValue = url.searchParams.get('taskId')?.trim() ?? url.searchParams.get('round')?.trim() ?? ''
+  let requestedKey = url.searchParams.get('key')?.trim() ?? ''
+  const owner = url.searchParams.get('owner')?.trim() ?? ''
+  const repo = url.searchParams.get('repo')?.trim() ?? ''
+  const issue = url.searchParams.get('issue')?.trim() ?? ''
+  if (requestedKey === '' && taskIdValue === '') {
+    const workflow = await findWorkflowByIssue(`${owner}/${repo}`, issue)
+    if (workflow) requestedKey = workflow.key
+  }
+  const target = await resolveHistoryTarget(taskIdValue, requestedKey, url.searchParams.get('kind')?.trim() ?? '')
   if (!target) return { ok: false, error: '找不到对应任务历史' }
+  if (owner !== '' || repo !== '' || issue !== '') {
+    const targetIssue = target.workflow.url.match(/\/(?:issues|pull)\/(\d+)(?:[/?#]|$)/)?.[1]
+    if (`${owner}/${repo}` !== target.workflow.repoKey || issue !== targetIssue) {
+      return { ok: false, error: '找不到对应任务历史' }
+    }
+  }
 
   // Capture the live sequence before enqueueing the ordered disk read. No
   // await may occur between these operations: that is the history/SSE fence.
   const cursor = target.live?.log.read(Number.MAX_SAFE_INTEGER).cursor ?? 0
-  const historyPromise = readLogHistory(target.key, target.kind)
-  const lines = await historyPromise
-  const events = lines.map(decodeLiveLogLine)
+  const history = target.taskId
+    ? await readTaskLog(target.workflow, target.kind, target.taskId)
+    : {
+        encodedLines: [],
+        events: [],
+        lines: [],
+        metrics: { startedAt: null, endedAt: null, durationMs: null, status: null, exitCode: null },
+      }
+  const events = history.events
   return {
     ok: true,
     taskId: target.taskId,
     key: target.key,
     kind: target.kind,
-    lines: events.map((event) => event.text),
+    lines: history.lines,
     events,
     cursor,
     active: target.live !== null && !target.live.closed,
+    metrics: history.metrics,
   }
 }
 

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -8,11 +8,13 @@ import { apply, fetchRepositoryIssues } from '../src/index.ts'
 import { encodeLiveLogEvent } from '../src/infra/live-output.ts'
 import {
   appendLog,
+  appendTaskLog,
   issueBodyHash,
   loadAllArchivedWorkflows,
   loadWorkflow,
   readLogHistory,
   saveWorkflow,
+  startTaskLog,
   type IssueWorkflow,
 } from '../src/infra/state.ts'
 
@@ -1321,6 +1323,38 @@ test('/history restores the complete disk log by task id after Host restart', as
     assert.equal(result.body.cursor, 0)
     assert.equal(result.body.active, false)
     assert.equal(result.body.kind, 'dev')
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
+})
+
+test('/history queries an older round by project and issue while binding the round to that issue', async () => {
+  const previousHome = process.env.HOME
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-history-round-'))
+  process.env.HOME = tempHome
+  try {
+    const workflow = interruptedWorkflow('o-r-907', 'https://github.com/o/r/issues/907', join(tempHome, 'worktree'))
+    const older = 'dev-1720000000000-older'
+    const current = 'dev-1720000005000-current'
+    workflow.devTaskId = current
+    await saveWorkflow(workflow)
+    await startTaskLog(workflow, 'dev', older)
+    await appendTaskLog(workflow, 'dev', older, 1, 'older round')
+    await startTaskLog(workflow, 'dev', current)
+    await appendTaskLog(workflow, 'dev', current, 1, 'current round')
+
+    const result = await get(createHandler(), `/clickvibe/api/history?owner=o&repo=r&issue=907&kind=dev&round=${older}`)
+    assert.equal(result.status, 200)
+    assert.deepEqual(result.body.lines, ['older round'])
+    assert.equal(result.body.taskId, older)
+
+    const wrongIssue = await get(
+      createHandler(),
+      `/clickvibe/api/history?owner=o&repo=r&issue=999&kind=dev&round=${older}`,
+    )
+    assert.equal(wrongIssue.status, 404)
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome

--- a/tests/state-layout.test.ts
+++ b/tests/state-layout.test.ts
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict'
+import { appendFile, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { encodeLiveLogEvent } from '../src/infra/live-output.ts'
+import {
+  appendTaskLog,
+  loadWorkflow,
+  readTaskLog,
+  saveWorkflow,
+  startTaskLog,
+  type IssueWorkflow,
+} from '../src/infra/state.ts'
+import { issueDirectory, issueKey, parseIssueDirectory, taskLogPath, workflowPath } from '../src/infra/state-layout.ts'
+
+function fixture(key = issueKey('a-b/c', '7')): IssueWorkflow {
+  return {
+    key,
+    url: 'https://github.com/a-b/c/issues/7',
+    repoKey: 'a-b/c',
+    worktree: '/tmp/c-issue-7',
+    branch: 'c-issue-7',
+    stage: 'developing',
+    devAgent: 'codex',
+    devTaskId: 'dev-1720000000000-first',
+    devSessionId: null,
+    devSessionAgent: null,
+    devInterrupted: false,
+    reviewAgent: null,
+    reviewTaskId: null,
+    reviewSessionId: null,
+    reviewSessionAgent: null,
+    reviewResult: null,
+    prNumber: null,
+    issueState: 'OPEN',
+    baseRef: 'origin/main @ abc',
+    updatedAt: 1,
+    events: [],
+  }
+}
+
+test('project issue paths are reversible and do not depend on collision-prone keys', () => {
+  const root = '/state'
+  assert.equal(issueDirectory(root, 'a-b', 'c', '7'), '/state/a-b/c/issue-7')
+  assert.deepEqual(parseIssueDirectory(root, '/state/a-b/c/issue-7'), {
+    owner: 'a-b',
+    repo: 'c',
+    issue: '7',
+  })
+  assert.equal(parseIssueDirectory(root, '/state/a-b/c/not-an-issue'), null)
+  assert.throws(() => issueDirectory(root, '..', 'c', '7'), /invalid issue coordinates/)
+  assert.throws(() => issueDirectory(root, 'a-b', '..', '7'), /invalid issue coordinates/)
+  assert.notEqual(issueKey('a-b/c', '7'), issueKey('a/b-c', '7'))
+  assert.equal(workflowPath(root, fixture()), '/state/a-b/c/issue-7/workflow.json')
+})
+
+test('task generations append valid structured JSONL independently and aggregate metrics', async () => {
+  const previousHome = process.env.HOME
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-jsonl-'))
+  process.env.HOME = tempHome
+  try {
+    const workflow = fixture()
+    await saveWorkflow(workflow)
+    const first = workflow.devTaskId!
+    const second = 'dev-1720000005000-second'
+    await startTaskLog(workflow, 'dev', first)
+    await appendTaskLog(workflow, 'dev', first, 1, encodeLiveLogEvent({ source: 'agent', kind: 'text', text: 'one' }), {
+      ts: '2026-08-23T00:00:00.000Z',
+    })
+    await appendTaskLog(workflow, 'dev', first, 2, '[clickvibe] complete', {
+      ts: '2026-08-23T00:00:03.250Z',
+      status: 'done',
+      exitCode: 0,
+    })
+    await startTaskLog(workflow, 'dev', second)
+    await appendTaskLog(workflow, 'dev', second, 1, 'two', { ts: '2026-08-23T00:00:05.000Z' })
+
+    const firstRead = await readTaskLog(workflow, 'dev', first)
+    const secondRead = await readTaskLog(workflow, 'dev', second)
+    assert.deepEqual(firstRead.lines, ['one', '[clickvibe] complete'])
+    assert.deepEqual(secondRead.lines, ['two'])
+    assert.deepEqual(firstRead.metrics, {
+      startedAt: '2026-08-23T00:00:00.000Z',
+      endedAt: '2026-08-23T00:00:03.250Z',
+      durationMs: 3250,
+      status: 'done',
+      exitCode: 0,
+    })
+
+    const raw = await readFile(taskLogPath(join(tempHome, '.clickvibe', 'state'), workflow, 'dev', first), 'utf8')
+    const records = raw
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line))
+    assert.equal(records[0].sequence, 1)
+    assert.equal(records[0].source, 'agent')
+    assert.equal(records[1].source, 'clickvibe')
+    assert.ok(records.every((record) => record.taskId === first && typeof record.line === 'string'))
+    await appendFile(taskLogPath(join(tempHome, '.clickvibe', 'state'), workflow, 'dev', first), '{"partial":', 'utf8')
+    assert.deepEqual((await readTaskLog(workflow, 'dev', first)).lines, ['one', '[clickvibe] complete'])
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
+})
+
+test('legacy flat workflow and logs migrate into the project tree without losing lines', async () => {
+  const previousHome = process.env.HOME
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-migrate-'))
+  process.env.HOME = tempHome
+  try {
+    const root = join(tempHome, '.clickvibe', 'state')
+    const workflow = fixture('a-b-c-7')
+    await mkdir(join(root, workflow.key), { recursive: true })
+    await writeFile(join(root, `${workflow.key}.json`), JSON.stringify(workflow), 'utf8')
+    await writeFile(join(root, workflow.key, 'dev.log'), 'first\n[clickvibe] second\n', 'utf8')
+
+    const loaded = await loadWorkflow(workflow.key)
+    assert.equal(loaded?.repoKey, 'a-b/c')
+    const migrated = await readTaskLog(workflow, 'dev', workflow.devTaskId!)
+    assert.deepEqual(migrated.lines, ['first', '[clickvibe] second'])
+    assert.equal(await readFile(workflowPath(root, workflow), 'utf8').then(() => true), true)
+    assert.equal(
+      (await readdir(root)).some((entry) => entry === `${workflow.key}.json` || entry === workflow.key),
+      false,
+    )
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
+})
+
+test('a failed legacy migration does not block reads and retries after the source is repaired', async () => {
+  const previousHome = process.env.HOME
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-migrate-retry-'))
+  process.env.HOME = tempHome
+  try {
+    const root = join(tempHome, '.clickvibe', 'state')
+    const workflow = fixture('legacy-retry-7')
+    const legacyPath = join(root, `${workflow.key}.json`)
+    await mkdir(root, { recursive: true })
+    await writeFile(legacyPath, '{broken', 'utf8')
+    assert.equal(await loadWorkflow(workflow.key), null)
+    await writeFile(legacyPath, JSON.stringify(workflow), 'utf8')
+    assert.equal((await loadWorkflow(workflow.key))?.repoKey, workflow.repoKey)
+    assert.equal(await readFile(workflowPath(root, workflow), 'utf8').then(() => true), true)
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
+})

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -5,11 +5,14 @@ import { join } from 'node:path'
 import test from 'node:test'
 import {
   appendLog,
+  appendTaskLog,
   applyDevRunOutcome,
   clearStaleSessionId,
   readLogHistory,
+  readTaskLog,
   recordSessionId,
-  resetLog,
+  saveWorkflow,
+  startTaskLog,
   resolveSessionForAgent,
   type IssueWorkflow,
 } from '../src/infra/state.ts'
@@ -19,7 +22,15 @@ test('persistent log snapshots preserve append order without truncating history'
   const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-log-order-'))
   process.env.HOME = tempHome
   try {
-    const writes = Array.from({ length: 2100 }, (_, index) => appendLog('o-r-3', 'dev', `line-${index}`))
+    const state = workflow()
+    state.key = 'o-r-3'
+    state.url = 'https://github.com/o/r/issues/3'
+    state.devTaskId = 'dev-1720000000000-order'
+    await saveWorkflow(state)
+    await startTaskLog(state, 'dev', state.devTaskId)
+    const writes = Array.from({ length: 2100 }, (_, index) =>
+      appendTaskLog(state, 'dev', state.devTaskId!, index + 1, `line-${index}`),
+    )
     await Promise.all(writes)
     const lines = await readLogHistory('o-r-3', 'dev')
     assert.equal(lines.length, 2100)
@@ -32,16 +43,26 @@ test('persistent log snapshots preserve append order without truncating history'
   }
 })
 
-test('a new task log generation bounds multi-run growth without truncating the current run', async () => {
+test('a new task log generation preserves the prior run and selects the current run', async () => {
   const previousHome = process.env.HOME
   const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-log-reset-'))
   process.env.HOME = tempHome
   try {
-    await appendLog('o-r-4', 'dev', 'prior run')
-    await resetLog('o-r-4', 'dev')
-    await appendLog('o-r-4', 'dev', 'current one')
-    await appendLog('o-r-4', 'dev', 'current two')
-    assert.deepEqual(await readLogHistory('o-r-4', 'dev'), ['current one', 'current two'])
+    const state = workflow()
+    state.key = 'o-r-4'
+    state.url = 'https://github.com/o/r/issues/4'
+    state.devTaskId = 'dev-1720000000000-prior'
+    await saveWorkflow(state)
+    await startTaskLog(state, 'dev', state.devTaskId)
+    await appendTaskLog(state, 'dev', state.devTaskId, 1, 'prior run')
+    const priorTaskId = state.devTaskId
+    state.devTaskId = 'dev-1720000005000-current'
+    await saveWorkflow(state)
+    await startTaskLog(state, 'dev', state.devTaskId)
+    await appendLog(state.key, 'dev', 'current one')
+    await appendLog(state.key, 'dev', 'current two')
+    assert.deepEqual(await readLogHistory(state.key, 'dev'), ['current one', 'current two'])
+    assert.deepEqual((await readTaskLog(state, 'dev', priorTaskId)).lines, ['prior run'])
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome


### PR DESCRIPTION
## 概要

- 将 workflow 状态迁移到 owner/repo/issue-N 分层目录，issueKey 不再决定物理路径
- dev/review 每轮写入独立 JSONL，保留 LineLog sequence 并记录开始、结束与退出指标
- history 支持 taskId 及 owner/repo/issue/round 查询，保留现有 poll/SSE 和 __historyRequired 语义
- 自动迁移旧平面 workflow 与 dev.log/review.log；失败不阻断且后续可重试

## 验证

- pnpm run typecheck
- pnpm run build
- pnpm test：232 项通过
- pnpm run coverage：lines 92.80%，functions 88.10%
- pnpm run check

## 人工验收

- [ ] 面板实测完整 开发 → review 流程
- [ ] 断网重连及 SSE 续传

Closes #58