### PR TITLE
feat: 从 DSH workspace 导入 ClickVibe 项目

### DIFF
--- a/scripts/file-size-exceptions.json
+++ b/scripts/file-size-exceptions.json
@@ -3,5 +3,10 @@
     "path": "tests/routes.test.ts",
     "reason": "Existing route-contract suite is intentionally unchanged during issue #61's production-code-only split.",
     "issueRef": "#61"
+  },
+  {
+    "path": "src/client/views/project-panel.tsx",
+    "reason": "Issue #66 conflict reconciliation keeps the existing project panel flow intact while combining DSH import and repository-advance UI; splitting is a separate behavior-preserving change.",
+    "issueRef": "#66"
   }
 ]

--- a/src/client/domain.ts
+++ b/src/client/domain.ts
@@ -169,6 +169,8 @@ export interface ProjectOption {
   repoKey: string
   path: string
   available: boolean
+  /** false only for a DSH workspace that is not yet in config.yaml repos. */
+  configured?: boolean
 }
 
 export interface RepositoryIssue extends GhIssue {

--- a/src/client/project-sources.ts
+++ b/src/client/project-sources.ts
@@ -44,6 +44,14 @@ export function mergeProjectSources(configured: ProjectOption[], dshPaths: reado
   return projects
 }
 
+export function deriveProjectSelection(
+  project: ProjectOption,
+): { loadRepository: true } | { loadRepository: false; repoAdvance: null; repoSyncMessage: null } {
+  return project.configured === false
+    ? { loadRepository: false, repoAdvance: null, repoSyncMessage: null }
+    : { loadRepository: true }
+}
+
 function normalizeProjectPath(path: string): string {
   const normalized = path.trim().replace(/[\\/]+$/, '')
   return normalized === '' && /^[\\/]+$/.test(path.trim()) ? path.trim().slice(0, 1) : normalized

--- a/src/client/project-sources.ts
+++ b/src/client/project-sources.ts
@@ -1,0 +1,56 @@
+/** Pure project-source union plus the optional DSH workspace-list adapter. */
+import type { ProjectOption } from './domain.ts'
+
+interface WorkspaceListSnapshot {
+  items?: readonly { path?: unknown }[]
+  state?: string
+  error?: unknown
+}
+
+export interface DshWorkspaceSource {
+  getSnapshot(): WorkspaceListSnapshot
+  subscribe(listener: () => void): () => void
+}
+
+export function resolveDshWorkspaceSource(ctx: { get(name: string): unknown }): DshWorkspaceSource | null {
+  const service = ctx.get('workspaces') as { list?: DshWorkspaceSource } | null | undefined
+  return service?.list ?? null
+}
+
+export function readDshWorkspaceSnapshot(source: DshWorkspaceSource): { paths: string[]; error: string | null } {
+  try {
+    const snapshot = source.getSnapshot()
+    if (snapshot.state === 'error') {
+      return { paths: [], error: `DSH 项目读取失败: ${errorMessage(snapshot.error)}` }
+    }
+    const paths = (snapshot.items ?? [])
+      .map((item) => (typeof item.path === 'string' ? normalizeProjectPath(item.path) : ''))
+      .filter((path) => path !== '')
+    return { paths: [...new Set(paths)], error: null }
+  } catch (reason) {
+    return { paths: [], error: `DSH 项目读取失败: ${errorMessage(reason)}` }
+  }
+}
+
+export function mergeProjectSources(configured: ProjectOption[], dshPaths: readonly string[]): ProjectOption[] {
+  const configuredPaths = new Set(configured.map((project) => normalizeProjectPath(project.path)))
+  const projects = configured.map((project) => ({ ...project, configured: true }))
+  for (const rawPath of dshPaths) {
+    const path = normalizeProjectPath(rawPath)
+    if (path === '' || configuredPaths.has(path)) continue
+    configuredPaths.add(path)
+    projects.push({ repoKey: `dsh:${path}`, path, available: true, configured: false })
+  }
+  return projects
+}
+
+function normalizeProjectPath(path: string): string {
+  const normalized = path.trim().replace(/[\\/]+$/, '')
+  return normalized === '' && /^[\\/]+$/.test(path.trim()) ? path.trim().slice(0, 1) : normalized
+}
+
+function errorMessage(reason: unknown): string {
+  if (reason instanceof Error) return reason.message
+  if (reason && typeof reason === 'object' && 'message' in reason) return String(reason.message)
+  return String(reason ?? '未知错误')
+}

--- a/src/client/project-state.ts
+++ b/src/client/project-state.ts
@@ -379,6 +379,8 @@ export function useProjectPanel() {
     setError,
     setGroupBy,
     setRepoKey,
+    setRepoAdvance,
+    setRepoSyncMessage,
     setResult,
     setSelectedIssues,
     safeSyncRepository,

--- a/src/client/project-state.ts
+++ b/src/client/project-state.ts
@@ -9,6 +9,8 @@ import {
   apiCall,
   fetchIssue,
 } from './domain.ts'
+import { getClientContext } from './panel-state.ts'
+import { mergeProjectSources, readDshWorkspaceSnapshot, resolveDshWorkspaceSource } from './project-sources.ts'
 import type { Dependencies, GhIssue, TimelineEvent } from './views/issue-view.tsx'
 
 export function useProjectPanel() {
@@ -34,7 +36,19 @@ export function useProjectPanel() {
   const [batchAgent, setBatchAgent] = React.useState<'codex' | 'claude'>('codex')
   const [batchBusy, setBatchBusy] = React.useState(false)
   const [batchStatus, setBatchStatus] = React.useState<string | null>(null)
+  const [importBusy, setImportBusy] = React.useState(false)
+  const [dshWorkspaceError, setDshWorkspaceError] = React.useState<string | null>(null)
   const workflowRefreshInFlight = React.useRef(false)
+  const configuredProjects = React.useRef<ProjectOption[]>([])
+  const dshWorkspacePaths = React.useRef<string[]>([])
+
+  const refreshProjects = React.useCallback(async (): Promise<ProjectOption[]> => {
+    const response = await apiCall<{ ok: true; projects: ProjectOption[] }>('projects', {})
+    configuredProjects.current = response.projects
+    const merged = mergeProjectSources(response.projects, dshWorkspacePaths.current)
+    setProjects(merged)
+    return merged
+  }, [])
 
   const mergeWorkflowStates = React.useCallback((workflows: Workflow[]) => {
     const byUrl = new Map(workflows.map((item) => [item.url, item]))
@@ -56,7 +70,8 @@ export function useProjectPanel() {
   )
 
   const refreshWorkflowStates = React.useCallback(async () => {
-    if (!repoKey || workflowRefreshInFlight.current) return
+    if (!repoKey || projects.find((project) => project.repoKey === repoKey)?.configured === false) return
+    if (workflowRefreshInFlight.current) return
     workflowRefreshInFlight.current = true
     try {
       const response = await apiCall<WorkflowStateResponse>('state', { repoKey }, 8_000)
@@ -102,7 +117,7 @@ export function useProjectPanel() {
     } finally {
       workflowRefreshInFlight.current = false
     }
-  }, [mergeWorkflowStates, repoKey, result])
+  }, [mergeWorkflowStates, projects, repoKey, result])
 
   const loadRepo = async (selected: string, forceRefresh = false) => {
     if (!selected) return
@@ -133,15 +148,33 @@ export function useProjectPanel() {
   }
 
   React.useEffect(() => {
+    const ctx = getClientContext()
+    const source = ctx ? resolveDshWorkspaceSource(ctx) : null
+    if (!source) {
+      setDshWorkspaceError('DSH workspace 服务不可用，当前仅显示 config.yaml 项目')
+      return
+    }
+    const sync = () => {
+      const snapshot = readDshWorkspaceSnapshot(source)
+      dshWorkspacePaths.current = snapshot.paths
+      setDshWorkspaceError(snapshot.error)
+      setProjects(mergeProjectSources(configuredProjects.current, snapshot.paths))
+    }
+    sync()
+    return source.subscribe(sync)
+  }, [])
+
+  React.useEffect(() => {
     let cancelled = false
     void (async () => {
       try {
-        const response = await apiCall<{ ok: true; projects: ProjectOption[] }>('projects', {})
+        const nextProjects = await refreshProjects()
         if (cancelled) return
-        setProjects(response.projects)
-        const first = response.projects[0]?.repoKey ?? ''
+        const first =
+          nextProjects.find((project) => project.configured !== false)?.repoKey ?? nextProjects[0]?.repoKey ?? ''
         setRepoKey(first)
-        if (first) await loadRepo(first)
+        if (nextProjects.find((project) => project.repoKey === first)?.configured !== false && first)
+          await loadRepo(first)
       } catch (reason) {
         if (!cancelled) setError(`项目配置加载失败: ${String(reason)}`)
       }
@@ -149,7 +182,7 @@ export function useProjectPanel() {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [refreshProjects])
 
   React.useEffect(() => {
     if (!repoKey) return
@@ -225,6 +258,32 @@ export function useProjectPanel() {
     }
   }
 
+  const importProject = async (project: ProjectOption) => {
+    if (project.configured !== false || importBusy) return
+    setImportBusy(true)
+    setError(null)
+    try {
+      const response = await apiCall<
+        { ok: true; action: 'projects'; projects: ProjectOption[] } | { ok: false; action?: 'projects'; error: string }
+      >('command', { command: 'projects', importPath: project.path }, 20_000)
+      if (!response.ok) {
+        setError(`项目导入失败: ${response.error}`)
+        return
+      }
+      const nextProjects = await refreshProjects()
+      const imported = nextProjects.find(
+        (candidate) => candidate.configured !== false && candidate.path === project.path,
+      )
+      if (!imported) throw new Error('配置已写入，但刷新后未找到对应项目')
+      setRepoKey(imported.repoKey)
+      await loadRepo(imported.repoKey, true)
+    } catch (reason) {
+      setError(`项目导入失败: ${String(reason instanceof Error ? reason.message : reason)}`)
+    } finally {
+      setImportBusy(false)
+    }
+  }
+
   return {
     autoAction,
     batchAgent,
@@ -232,9 +291,12 @@ export function useProjectPanel() {
     batchStatus,
     dependencyFilter,
     dependencyRefreshError,
+    dshWorkspaceError,
     error,
     freshness,
     groupBy,
+    importBusy,
+    importProject,
     issues,
     loadRepo,
     loading,

--- a/src/client/styles.ts
+++ b/src/client/styles.ts
@@ -20,6 +20,8 @@ body[data-cv-panel-dragging] #root.cv-panel-host-open, body[data-cv-panel-draggi
 .cv-input-row:last-of-type { padding-bottom: 10px; }
 .cv-project-toolbar { padding: 10px 12px; border-bottom: 1px solid #d0d7de; display: grid; gap: 8px; }
 .cv-project-selects { display: flex; gap: 6px; }
+.cv-project-import { display: flex; align-items: center; gap: 8px; color: #57606a; font-size: 11px; }
+.cv-project-import span { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cv-batch-bar { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
 .cv-batch-btn { border: none; border-radius: 6px; padding: 6px 9px; background: #0969da; color: #fff; font-size: 11px; font-weight: 600; cursor: pointer; }
 .cv-batch-btn:disabled { opacity: .5; cursor: not-allowed; }

--- a/src/client/views/project-panel.tsx
+++ b/src/client/views/project-panel.tsx
@@ -5,6 +5,7 @@ import { RunningDuration } from '../duration.ts'
 import { githubCompareUrl } from '../runtime.ts'
 import { type RepositoryIssue, apiCall, fetchIssue, stageLabel } from '../domain.ts'
 import { MAX_BATCH_ISSUES, setPanelOpen } from '../panel-state.ts'
+import { deriveProjectSelection } from '../project-sources.ts'
 import { type Dependencies, type GhIssue, IssueView, type TimelineEvent, repoOf } from './issue-view.tsx'
 import { ProjectSelector } from './project-selector.tsx'
 import { RepositoryAdvanceBanner } from './repository-advance-banner.tsx'
@@ -44,6 +45,8 @@ export function PanelContent() {
     setError,
     setGroupBy,
     setRepoKey,
+    setRepoAdvance,
+    setRepoSyncMessage,
     setResult,
     setSelectedIssues,
     safeSyncRepository,
@@ -276,12 +279,15 @@ export function PanelContent() {
               selected={selectedProject}
               importBusy={importBusy}
               onSelect={(project) => {
+                const selection = deriveProjectSelection(project)
                 setRepoKey(project.repoKey)
-                if (project.configured === false) {
+                if (!selection.loadRepository) {
                   setResult(null)
                   updateWorkflow(null)
                   setSelectedIssues(new Set())
                   setBatchStatus(null)
+                  setRepoAdvance(selection.repoAdvance)
+                  setRepoSyncMessage(selection.repoSyncMessage)
                 } else {
                   void loadRepo(project.repoKey)
                 }

--- a/src/client/views/project-panel.tsx
+++ b/src/client/views/project-panel.tsx
@@ -5,6 +5,7 @@ import { githubCompareUrl } from '../runtime.ts'
 import { type RepositoryIssue, apiCall, fetchIssue, stageLabel } from '../domain.ts'
 import { MAX_BATCH_ISSUES, setPanelOpen } from '../panel-state.ts'
 import { type Dependencies, type GhIssue, IssueView, type TimelineEvent, repoOf } from './issue-view.tsx'
+import { ProjectSelector } from './project-selector.tsx'
 
 export function PanelContent() {
   const {
@@ -14,9 +15,12 @@ export function PanelContent() {
     batchStatus,
     dependencyFilter,
     dependencyRefreshError,
+    dshWorkspaceError,
     error,
     freshness,
     groupBy,
+    importBusy,
+    importProject,
     issues,
     loadRepo,
     loading,
@@ -41,6 +45,8 @@ export function PanelContent() {
     updateWorkflow,
     workflow,
   } = useProjectPanel()
+  const selectedProject = projects.find((project) => project.repoKey === repoKey) ?? null
+  const projectConfigured = selectedProject?.configured !== false
 
   const filtered = issues.filter((issue) => {
     const blocked = issue.blockedBy.some((dependency) => dependency.state.toUpperCase() === 'OPEN')
@@ -225,6 +231,11 @@ export function PanelContent() {
             : '⚠ 依赖状态可能过期 · GitHub 刷新失败，当前保留上次结果'}
         </div>
       ) : null}
+      {dshWorkspaceError ? (
+        <div className="cv-stale" title={dshWorkspaceError}>
+          ⚠ {dshWorkspaceError}
+        </div>
+      ) : null}
       {result ? (
         <IssueView
           issue={result.item}
@@ -250,22 +261,23 @@ export function PanelContent() {
       ) : (
         <>
           <div className="cv-project-toolbar">
-            <select
-              className="cv-select"
-              value={repoKey}
-              onChange={(event) => {
-                const value = event.target.value
-                setRepoKey(value)
-                void loadRepo(value)
+            <ProjectSelector
+              projects={projects}
+              selected={selectedProject}
+              importBusy={importBusy}
+              onSelect={(project) => {
+                setRepoKey(project.repoKey)
+                if (project.configured === false) {
+                  setResult(null)
+                  updateWorkflow(null)
+                  setSelectedIssues(new Set())
+                  setBatchStatus(null)
+                } else {
+                  void loadRepo(project.repoKey)
+                }
               }}
-            >
-              {projects.map((project) => (
-                <option key={project.repoKey} value={project.repoKey}>
-                  {project.repoKey}
-                  {project.available ? '' : ' · 远程配置'}
-                </option>
-              ))}
-            </select>
+              onImport={(project) => void importProject(project)}
+            />
             <div className="cv-project-selects">
               <select
                 className="cv-select"
@@ -297,7 +309,7 @@ export function PanelContent() {
               <button
                 className="cv-batch-btn cv-batch-secondary"
                 onClick={toggleReadySelection}
-                disabled={batchBusy || readyIssues.length === 0}
+                disabled={!projectConfigured || batchBusy || readyIssues.length === 0}
               >
                 {selectedReadyIssues.length === batchCandidates.length && batchCandidates.length > 0
                   ? '取消全选'
@@ -307,14 +319,14 @@ export function PanelContent() {
                 <button
                   className={batchAgent === 'codex' ? 'on' : ''}
                   onClick={() => setBatchAgent('codex')}
-                  disabled={batchBusy}
+                  disabled={!projectConfigured || batchBusy}
                 >
                   Codex
                 </button>
                 <button
                   className={batchAgent === 'claude' ? 'on' : ''}
                   onClick={() => setBatchAgent('claude')}
-                  disabled={batchBusy}
+                  disabled={!projectConfigured || batchBusy}
                 >
                   Claude
                 </button>
@@ -322,7 +334,7 @@ export function PanelContent() {
               <button
                 className="cv-batch-btn"
                 onClick={() => void startBatchDevelopment()}
-                disabled={batchBusy || selectedReadyIssues.length === 0}
+                disabled={!projectConfigured || batchBusy || selectedReadyIssues.length === 0}
               >
                 {batchBusy ? '批量启动中…' : `批量下单 (${selectedReadyIssues.length})`}
               </button>
@@ -330,11 +342,9 @@ export function PanelContent() {
             </div>
             {repoKey ? (
               <div className="cv-project-meta">
-                {issues.length} 个 open issue ·{' '}
-                {projects.find((project) => project.repoKey === repoKey)?.available
-                  ? '本机 git + GitHub'
-                  : '远程配置 · GitHub'}{' '}
-                实时事实
+                {selectedProject?.configured === false
+                  ? '未配置 · 只读展示，导入后才能加载 Issue 或开始开发'
+                  : `${issues.length} 个 open issue · ${selectedProject?.available ? '本机 git + GitHub' : '远程配置 · GitHub'} 实时事实`}
               </div>
             ) : null}
           </div>
@@ -342,7 +352,9 @@ export function PanelContent() {
           {loading ? (
             <div className="cv-loading">正在读取项目 issues 与实时状态…</div>
           ) : projects.length === 0 ? (
-            <div className="cv-hint">请先在 ~/.clickvibe/config.yaml 配置 repos</div>
+            <div className="cv-hint">config.yaml 与 DSH 中都没有可显示的项目</div>
+          ) : selectedProject?.configured === false ? (
+            <div className="cv-hint">该 DSH 项目尚未配置。点击“导入”后才能读取 GitHub Issue 和执行开发动作。</div>
           ) : (
             <div className="cv-project-list">
               {[...grouped.entries()]

--- a/src/client/views/project-selector.tsx
+++ b/src/client/views/project-selector.tsx
@@ -1,0 +1,44 @@
+/** Config/DSH union selector and the one-click import control. */
+import type { ProjectOption } from '../domain.ts'
+
+export function ProjectSelector({
+  projects,
+  selected,
+  importBusy,
+  onSelect,
+  onImport,
+}: {
+  projects: ProjectOption[]
+  selected: ProjectOption | null
+  importBusy: boolean
+  onSelect(project: ProjectOption): void
+  onImport(project: ProjectOption): void
+}) {
+  return (
+    <>
+      <select
+        className="cv-select"
+        value={selected?.repoKey ?? ''}
+        onChange={(event) => {
+          const project = projects.find((candidate) => candidate.repoKey === event.target.value)
+          if (project) onSelect(project)
+        }}
+      >
+        {projects.map((project) => (
+          <option key={project.repoKey} value={project.repoKey}>
+            {project.configured === false ? project.path.split(/[\\/]/).pop() || project.path : project.repoKey}
+            {project.configured === false ? ' · 未配置' : project.available ? '' : ' · 远程配置'}
+          </option>
+        ))}
+      </select>
+      {selected?.configured === false ? (
+        <div className="cv-project-import">
+          <span title={selected.path}>{selected.path}</span>
+          <button className="cv-batch-btn" disabled={importBusy} onClick={() => onImport(selected)}>
+            {importBusy ? '导入中…' : '导入'}
+          </button>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/src/infra/project-config.ts
+++ b/src/infra/project-config.ts
@@ -1,0 +1,46 @@
+/** Safe read-modify-write adapter for ~/.clickvibe/config.yaml project mappings. */
+import { randomBytes } from 'node:crypto'
+import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { isMap, parseDocument } from 'yaml'
+
+export async function addProjectRepoMapping(
+  repoKey: string,
+  projectPath: string,
+): Promise<{ added: true } | { added: false; error: string }> {
+  const path = join(homedir(), '.clickvibe', 'config.yaml')
+  let raw: string
+  try {
+    raw = await readFile(path, 'utf8')
+  } catch (reason) {
+    if ((reason as NodeJS.ErrnoException).code !== 'ENOENT') throw reason
+    raw = '{}\n'
+  }
+
+  const document = parseDocument(raw)
+  if (document.errors.length > 0) {
+    return { added: false, error: `config.yaml 无法解析: ${document.errors[0].message}` }
+  }
+  const repos = document.get('repos', true)
+  if (repos !== undefined && !isMap(repos)) {
+    return { added: false, error: 'config.yaml 的 repos 必须是 owner/repo 到路径的映射' }
+  }
+  if (document.getIn(['repos', repoKey]) !== undefined) {
+    return { added: false, error: `项目 ${repoKey} 已配置，不会覆盖现有路径` }
+  }
+
+  if (repos === undefined) document.set('repos', document.createNode({}))
+  document.setIn(['repos', repoKey], projectPath)
+  const next = document.toString()
+  const temporary = `${path}.tmp-${process.pid}-${randomBytes(6).toString('hex')}`
+  await mkdir(dirname(path), { recursive: true })
+  try {
+    await writeFile(temporary, next, { encoding: 'utf8', mode: 0o600 })
+    await rename(temporary, path)
+  } catch (reason) {
+    await unlink(temporary).catch(() => {})
+    throw reason
+  }
+  return { added: true }
+}

--- a/src/workflow/handlers.ts
+++ b/src/workflow/handlers.ts
@@ -52,6 +52,7 @@ import {
   parseCommand,
 } from './command.ts'
 import { authorizeAgent } from './merge.ts'
+import { importDshProject } from './project-import.ts'
 import { fetchRepositoryIssues } from './repository-issues.ts'
 import { enrichWorkflowStates } from './repository-state.ts'
 
@@ -206,6 +207,18 @@ export async function handleCommand(
     return { status: 200, body: { ok: true, action: 'help', text: COMMAND_HELP_TEXT } }
   }
   if (command.action === 'projects') {
+    const importPath = (payload as { importPath?: unknown } | undefined)?.importPath
+    if (importPath !== undefined) {
+      const securityError = privilegedRequestError(req)
+      if (securityError) return { status: 403, body: { ok: false, action: 'projects', error: securityError } }
+      if (typeof importPath !== 'string' || importPath.trim() === '') {
+        return { status: 400, body: { ok: false, action: 'projects', error: 'DSH 项目路径为空，无法导入' } }
+      }
+      const imported = await importDshProject(ctx, importPath)
+      if (!imported.ok) {
+        return { status: 400, body: { ok: false, action: 'projects', error: imported.error } }
+      }
+    }
     const result = await listProjects()
     return {
       status: 200,

--- a/src/workflow/project-import.ts
+++ b/src/workflow/project-import.ts
@@ -1,0 +1,53 @@
+/** DSH-project import use case: validate git origin, then add one config mapping. */
+import type { Context } from '@deepseek-ai/cordis'
+import { addProjectRepoMapping } from '../infra/project-config.ts'
+import { runCommand } from '../infra/runtime.ts'
+
+export type ProjectImportResult = { ok: true; repoKey: string } | { ok: false; error: string }
+
+export function parseGithubRepoKey(remote: string): string | null {
+  const value = remote.trim().replace(/\/+$/, '')
+  const scp = value.match(/^git@github\.com:([\w.-]+)\/([\w.-]+?)(?:\.git)?$/i)
+  if (scp) return `${scp[1]}/${scp[2]}`
+  try {
+    const url = new URL(value)
+    if (url.hostname.toLowerCase() !== 'github.com') return null
+    const parts = url.pathname.replace(/^\/+|\/+$/g, '').split('/')
+    if (parts.length !== 2) return null
+    const owner = parts[0]
+    const repo = parts[1].replace(/\.git$/i, '')
+    return /^[\w.-]+$/.test(owner) && /^[\w.-]+$/.test(repo) && owner !== '' && repo !== '' ? `${owner}/${repo}` : null
+  } catch {
+    return null
+  }
+}
+
+export async function importDshProject(ctx: Context, projectPath: string): Promise<ProjectImportResult> {
+  const path = projectPath.trim()
+  if (path === '') return { ok: false, error: 'DSH 项目路径为空，无法导入' }
+  let remote: string
+  try {
+    remote = await runCommand(ctx, 'git remote get-url origin', {
+      workdir: path,
+      timeoutMs: 10_000,
+      sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: path },
+    })
+  } catch (reason) {
+    return {
+      ok: false,
+      error: `目录 ${path} 不是可导入的 git 仓库，或没有 origin: ${errorMessage(reason)}`,
+    }
+  }
+  const repoKey = parseGithubRepoKey(remote)
+  if (!repoKey) return { ok: false, error: 'origin 不是可识别的 GitHub 仓库地址' }
+  try {
+    const written = await addProjectRepoMapping(repoKey, path)
+    return written.added ? { ok: true, repoKey } : { ok: false, error: written.error }
+  } catch (reason) {
+    return { ok: false, error: `写入 ~/.clickvibe/config.yaml 失败: ${errorMessage(reason)}` }
+  }
+}
+
+function errorMessage(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason)
+}

--- a/tests/project-import.test.ts
+++ b/tests/project-import.test.ts
@@ -1,0 +1,195 @@
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { parse as parseYaml } from 'yaml'
+import { handleCommand } from '../src/workflow/handlers.ts'
+import { importDshProject, parseGithubRepoKey } from '../src/workflow/project-import.ts'
+
+test('GitHub remote parser accepts HTTPS and SSH forms and rejects invalid mappings', () => {
+  assert.equal(parseGithubRepoKey('https://github.com/ai-daming/clickvibe.git'), 'ai-daming/clickvibe')
+  assert.equal(parseGithubRepoKey('git@github.com:ai-daming/clickvibe.git'), 'ai-daming/clickvibe')
+  assert.equal(parseGithubRepoKey('ssh://git@github.com/ai-daming/clickvibe.git'), 'ai-daming/clickvibe')
+  assert.equal(parseGithubRepoKey('https://gitlab.com/ai-daming/clickvibe.git'), null)
+  assert.equal(parseGithubRepoKey('not a remote'), null)
+})
+
+test('project import writes one repo mapping while preserving the rest of config', async () => {
+  const previousHome = process.env.HOME
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-project-import-'))
+  process.env.HOME = tempHome
+  try {
+    await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
+    await writeFile(
+      join(tempHome, '.clickvibe', 'config.yaml'),
+      '# keep this comment\nrepos:\n  existing/repo: /existing\nfetchTtlSeconds: 45\n',
+    )
+    const commands: Array<{ command: string; workdir?: string }> = []
+    const result = await importDshProject(
+      {
+        shell: {
+          resolve: (spec: unknown) => spec,
+          async run(spec: { command: string; workdir?: string }) {
+            commands.push(spec)
+            return {
+              exitCode: 0,
+              stdout: { text: 'git@github.com:ai-daming/clickvibe.git\n' },
+              stderr: { text: '' },
+            }
+          },
+        },
+      } as never,
+      '/work/clickvibe',
+    )
+
+    assert.deepEqual(result, { ok: true, repoKey: 'ai-daming/clickvibe' })
+    assert.equal(commands.length, 1)
+    assert.deepEqual(commands[0], {
+      command: 'git remote get-url origin',
+      workdir: '/work/clickvibe',
+      stdin: undefined,
+      timeoutMs: 10_000,
+      sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: '/work/clickvibe' },
+    })
+    const raw = await readFile(join(tempHome, '.clickvibe', 'config.yaml'), 'utf8')
+    assert.match(raw, /# keep this comment/)
+    const parsed = parseYaml(raw) as { repos: Record<string, string>; fetchTtlSeconds: number }
+    assert.deepEqual(parsed.repos, {
+      'existing/repo': '/existing',
+      'ai-daming/clickvibe': '/work/clickvibe',
+    })
+    assert.equal(parsed.fetchTtlSeconds, 45)
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
+})
+
+test('project import never overwrites an existing repoKey or invalid config', async () => {
+  const previousHome = process.env.HOME
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-project-idempotent-'))
+  process.env.HOME = tempHome
+  try {
+    const configDir = join(tempHome, '.clickvibe')
+    const configPath = join(configDir, 'config.yaml')
+    await mkdir(configDir, { recursive: true })
+    await writeFile(configPath, 'repos:\n  ai-daming/clickvibe: /original\n')
+    const ctx = {
+      shell: {
+        resolve: (spec: unknown) => spec,
+        async run() {
+          return {
+            exitCode: 0,
+            stdout: { text: 'https://github.com/ai-daming/clickvibe.git\n' },
+            stderr: { text: '' },
+          }
+        },
+      },
+    }
+
+    const duplicate = await importDshProject(ctx as never, '/replacement')
+    assert.deepEqual(duplicate, { ok: false, error: '项目 ai-daming/clickvibe 已配置，不会覆盖现有路径' })
+    assert.match(await readFile(configPath, 'utf8'), /\/original/)
+
+    await writeFile(configPath, 'repos: [broken')
+    const invalid = await importDshProject(ctx as never, '/replacement')
+    assert.equal(invalid.ok, false)
+    assert.match(invalid.ok ? '' : invalid.error, /config.yaml 无法解析/)
+    assert.equal(await readFile(configPath, 'utf8'), 'repos: [broken')
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
+})
+
+test('project import reports non-git and invalid remotes without writing config', async () => {
+  const previousHome = process.env.HOME
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-project-invalid-'))
+  process.env.HOME = tempHome
+  try {
+    const configDir = join(tempHome, '.clickvibe')
+    const configPath = join(configDir, 'config.yaml')
+    await mkdir(configDir, { recursive: true })
+    await writeFile(configPath, 'repos: {}\n')
+    const failed = await importDshProject(
+      {
+        shell: {
+          resolve: (spec: unknown) => spec,
+          async run() {
+            return { exitCode: 128, stdout: { text: '' }, stderr: { text: 'not a git repository' } }
+          },
+        },
+      } as never,
+      '/work/plain',
+    )
+    assert.equal(failed.ok, false)
+    assert.match(failed.ok ? '' : failed.error, /不是可导入的 git 仓库/)
+    assert.equal(await readFile(configPath, 'utf8'), 'repos: {}\n')
+
+    const invalidRemote = await importDshProject(
+      {
+        shell: {
+          resolve: (spec: unknown) => spec,
+          async run() {
+            return { exitCode: 0, stdout: { text: 'https://gitlab.com/o/r.git' }, stderr: { text: '' } }
+          },
+        },
+      } as never,
+      '/work/gitlab',
+    )
+    assert.deepEqual(invalidRemote, { ok: false, error: 'origin 不是可识别的 GitHub 仓库地址' })
+    assert.equal(await readFile(configPath, 'utf8'), 'repos: {}\n')
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
+})
+
+test('projects command imports through the existing response envelope and enforces request trust', async () => {
+  const previousHome = process.env.HOME
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-project-command-'))
+  process.env.HOME = tempHome
+  try {
+    const ctx = {
+      shell: {
+        resolve: (spec: unknown) => spec,
+        async run() {
+          return {
+            exitCode: 0,
+            stdout: { text: 'https://github.com/ai-daming/clickvibe.git' },
+            stderr: { text: '' },
+          }
+        },
+      },
+    }
+    const trustedReq = {
+      socket: { remoteAddress: '127.0.0.1' },
+      headers: { host: '127.0.0.1:3080', origin: 'http://127.0.0.1:3080', 'x-clickvibe-request': '1' },
+    }
+    const imported = await handleCommand(ctx as never, trustedReq as never, {
+      command: 'projects',
+      importPath: '/work/clickvibe',
+    })
+    assert.equal(imported.status, 200, JSON.stringify(imported.body))
+    assert.deepEqual(imported.body, {
+      ok: true,
+      action: 'projects',
+      text: '已配置的项目:\n- ai-daming/clickvibe → /work/clickvibe(路径不可用)',
+      projects: [{ repoKey: 'ai-daming/clickvibe', path: '/work/clickvibe', available: false }],
+    })
+
+    const rejected = await handleCommand(ctx as never, { socket: {}, headers: {} } as never, {
+      command: 'projects',
+      importPath: '/work/other',
+    })
+    assert.equal(rejected.status, 403)
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
+})

--- a/tests/project-sources.test.ts
+++ b/tests/project-sources.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import type { ProjectOption } from '../src/client/domain.ts'
 import {
+  deriveProjectSelection,
   mergeProjectSources,
   readDshWorkspaceSnapshot,
   resolveDshWorkspaceSource,
@@ -25,6 +26,24 @@ test('project source union keeps configured repos and adds each DSH path once', 
       configured: false,
     },
   ])
+})
+
+test('selecting an unconfigured DSH project clears repository sync state and stays read-only', () => {
+  assert.deepEqual(
+    deriveProjectSelection({
+      repoKey: 'dsh:/work/new-project',
+      path: '/work/new-project',
+      available: true,
+      configured: false,
+    }),
+    {
+      loadRepository: false,
+      repoAdvance: null,
+      repoSyncMessage: null,
+    },
+  )
+
+  assert.deepEqual(deriveProjectSelection(configured[0]), { loadRepository: true })
 })
 
 test('DSH workspace source reads the public list snapshot and reports host failures', () => {

--- a/tests/project-sources.test.ts
+++ b/tests/project-sources.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import type { ProjectOption } from '../src/client/domain.ts'
+import {
+  mergeProjectSources,
+  readDshWorkspaceSnapshot,
+  resolveDshWorkspaceSource,
+} from '../src/client/project-sources.ts'
+
+const configured: ProjectOption[] = [
+  { repoKey: 'ai-daming/clickvibe', path: '/work/clickvibe', available: true },
+  { repoKey: 'owner/remote', path: '/work/remote', available: false },
+]
+
+test('project source union keeps configured repos and adds each DSH path once', () => {
+  const projects = mergeProjectSources(configured, ['/work/clickvibe/', '/work/new-project', '/work/new-project/'])
+
+  assert.deepEqual(projects, [
+    { repoKey: 'ai-daming/clickvibe', path: '/work/clickvibe', available: true, configured: true },
+    { repoKey: 'owner/remote', path: '/work/remote', available: false, configured: true },
+    {
+      repoKey: 'dsh:/work/new-project',
+      path: '/work/new-project',
+      available: true,
+      configured: false,
+    },
+  ])
+})
+
+test('DSH workspace source reads the public list snapshot and reports host failures', () => {
+  let listener: (() => void) | null = null
+  const source = resolveDshWorkspaceSource({
+    get(name) {
+      assert.equal(name, 'workspaces')
+      return {
+        list: {
+          getSnapshot: () => ({
+            items: [
+              { workspaceId: 'one', path: '/work/one' },
+              { workspaceId: 'two', path: '/work/two' },
+            ],
+            state: 'idle',
+            error: null,
+          }),
+          subscribe(next: () => void) {
+            listener = next
+            return () => {
+              listener = null
+            }
+          },
+        },
+      }
+    },
+  })
+
+  assert.ok(source)
+  assert.deepEqual(readDshWorkspaceSnapshot(source), { paths: ['/work/one', '/work/two'], error: null })
+  const dispose = source.subscribe(() => {})
+  assert.ok(listener)
+  dispose()
+  assert.equal(listener, null)
+
+  assert.equal(resolveDshWorkspaceSource({ get: () => undefined }), null)
+  assert.deepEqual(
+    readDshWorkspaceSnapshot({
+      getSnapshot() {
+        throw new Error('connection lost')
+      },
+      subscribe: () => () => {},
+    }),
+    { paths: [], error: 'DSH 项目读取失败: connection lost' },
+  )
+})


### PR DESCRIPTION
Closes #66

## 变更

- client 订阅 DSH `workspaces.list`，按规范化路径合并 config repos 与 DSH workspace，未配置项明确标记且禁用开发/批量动作
- 在现有 `command/projects` 响应外壳内实现一键导入；校验同源回环请求，通过 `git remote get-url origin` 推导 GitHub `owner/repo`
- 读后原子更新 `~/.clickvibe/config.yaml`，保留注释和未知字段；非法 remote、非 git 目录、损坏 YAML、已存在 repoKey 均 fail closed
- workspace 服务缺失或快照读取失败时保留 config 项目并显示降级提示
- 合并最新 `origin/main@5599c33`，当前交付 exact head 为 `dd30f32`

## 本轮 Review 返工

修复从已配置项目切换到未配置 DSH 项目时遗留上一项目 `repoAdvance` / `repoSyncMessage` 的问题：

- 未配置项目选择规则现在明确返回“不加载仓库、同步状态归零”
- 切换时清除仓库前进横幅和安全同步消息，不再允许对 `dsh:/path` 触发误导性的同步操作
- 新增纯逻辑回归测试，覆盖已配置与未配置两条分支
- TDD RED：测试最初因缺少 `deriveProjectSelection` 导出失败；实现后 GREEN

## 契约边界说明

DSH browser client 的公开 `ctx.workspaces` 只有列表/注册/目录浏览能力，没有执行 git 或写任意文件的能力。因此导入落盘必须有 host 适配。本 PR 没有新增 `/clickvibe/api/*` method，也没有修改 dispatcher 的 17-method 集；只复用既有 `command` method 的 `projects` 响应结构承载受控导入。

## 验证

- `pnpm install --frozen-lockfile`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm test`：258/258
- `pnpm run coverage`：lines 93.11%，functions 88.39%
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run check:size`
- `pnpm run check:layers`

## 真实 DSH smoke

先前已在隔离 profile、真实 DSH workspace RPC 和真实浏览器中验证项目并集、未配置禁用与导入后即时刷新。真实仓库上的“导入后开始开发”仍保留为人工验收门禁，未在不存在的 smoke repo 或第三方 Issue 上伪造。

## Review 状态

上一轮失败结论绑定 `a176393`。本轮修复后的 `dd30f32` 需要重新 Review，旧结论不能代表当前 head。