### PR TITLE
feat: visualize workflow run durations

### DIFF
--- a/src/agent/task-supervisor.ts
+++ b/src/agent/task-supervisor.ts
@@ -58,6 +58,7 @@ export function createLiveTask(
     workflow,
     kind,
     agent,
+    startedAt: Date.now(),
     log: new LineLog(TASK_LOG_LINES),
     rawLog: new LineLog(TASK_LOG_LINES),
     rawCursor: 0,

--- a/src/client/domain.ts
+++ b/src/client/domain.ts
@@ -37,6 +37,8 @@ export interface Workflow {
   prNumber: string | null
   issueState?: 'OPEN' | 'CLOSED'
   baseRef: string | null
+  /** Present only while this host process still owns the active task. */
+  runStartedAt: number | null
   delivery?: {
     status: 'merged' | 'cleanup-pending' | 'archived'
     mergedAt: string
@@ -99,6 +101,7 @@ export interface NextAction {
 export interface WorkflowEvent {
   kind: 'dev' | 'review' | 'rework' | 'resume' | 'note' | 'merge-override'
   at: string
+  durationMs?: number
   hash?: string
   verdict?: { passed: boolean; issues: string[] }
   issueContract?: { bodyHash: string; updatedAt: string }

--- a/src/client/duration.ts
+++ b/src/client/duration.ts
@@ -1,0 +1,44 @@
+import React from 'react'
+
+type DeliveryKind = 'dev' | 'review' | 'rework' | 'resume' | 'note' | 'merge-override'
+
+/** Fixed-width live counter used by both issue detail and repository rows. */
+export function runningDurationLabel(milliseconds: number): string {
+  const seconds = Math.max(0, Math.floor(milliseconds / 1000))
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+  const remainder = seconds % 60
+  return [hours, minutes, remainder].map((value) => String(value).padStart(2, '0')).join(':')
+}
+
+/** Compact completed-run duration; hour-scale entries intentionally omit seconds. */
+export function deliveryDurationLabel(milliseconds: number): string {
+  const seconds = Math.max(0, Math.floor(milliseconds / 1000))
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+  if (hours > 0) return `${hours}h${String(minutes).padStart(2, '0')}m`
+  if (minutes > 0) return `${minutes}m${String(seconds % 60).padStart(2, '0')}s`
+  return `${seconds}s`
+}
+
+export function RunningDuration({ startedAt, now }: { startedAt: number; now?: number }) {
+  const [current, setCurrent] = React.useState(() => now ?? Date.now())
+
+  React.useEffect(() => {
+    if (now !== undefined) return
+    setCurrent(Date.now())
+    const timer = window.setInterval(() => setCurrent(Date.now()), 1000)
+    return () => window.clearInterval(timer)
+  }, [now, startedAt])
+
+  return React.createElement(
+    'span',
+    { className: 'cv-running-duration' },
+    `正在运行 · 已运行 ${runningDurationLabel(current - startedAt)}`,
+  )
+}
+
+export function DeliveryDuration({ kind, durationMs }: { kind: DeliveryKind; durationMs?: number }) {
+  if ((kind !== 'dev' && kind !== 'rework' && kind !== 'review') || !Number.isFinite(durationMs)) return null
+  return React.createElement('span', { className: 'cv-tl-duration' }, `耗时 ${deliveryDurationLabel(durationMs ?? 0)}`)
+}

--- a/src/client/styles.ts
+++ b/src/client/styles.ts
@@ -139,6 +139,7 @@ body[data-cv-panel-dragging] #root.cv-panel-host-open, body[data-cv-panel-draggi
 .cv-stage-review-ready { background: #fff8c5; color: #9a6700; }
 .cv-stage-reviewing { background: #fbefff; color: #8250df; }
 .cv-stage-passed { background: #dafbe1; color: #1a7f37; }
+.cv-running-duration { color: #57606a; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; white-space: nowrap; }
 .cv-dev-btn.cv-dev-warn { background: #d4a72c; color: #ffffff; }
 .cv-dev-btn.cv-dev-review { background: #8250df; color: #ffffff; }
 .cv-review-fail { display: flex; flex-direction: column; gap: 6px; }
@@ -179,6 +180,7 @@ body[data-cv-panel-dragging] #root.cv-panel-host-open, body[data-cv-panel-draggi
 .cv-override-entry { display: flex; flex-direction: column; gap: 4px; align-items: flex-start; margin: 4px 0; }
 .cv-override-gates { margin: 0; padding-left: 18px; font-size: 11.5px; color: #9a6700; }
 .cv-tl-time { color: #8c959f; }
+.cv-tl-duration { color: #57606a; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 10.5px; }
 .cv-tl-hash { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 10.5px; background: #eff1f3; padding: 0 4px; border-radius: 4px; }
 .cv-tl-verdict { font-weight: 600; }
 .cv-tl-pass { color: #1a7f37; }

--- a/src/client/views/dev-section.tsx
+++ b/src/client/views/dev-section.tsx
@@ -1,4 +1,5 @@
 import { deliveryPublicationLabel } from '../runtime.ts'
+import { DeliveryDuration, RunningDuration } from '../duration.ts'
 import { type Workflow, fmtTime, stageLabel } from '../domain.ts'
 import { type GhIssue } from './issue-view.tsx'
 import { LiveTerminal } from './live-terminal.tsx'
@@ -57,6 +58,11 @@ export function DevSection({
       {/* 状态卡:当前状态 + 关键事实 */}
       <div className="cv-dev-head">
         🚀 开发流程 <span className={`cv-stage cv-stage-${stage}`}>{stageLabel(stage, workflow)}</span>
+        {workflow?.runStartedAt !== null &&
+        workflow?.runStartedAt !== undefined &&
+        (derived?.status === 'developing' || derived?.status === 'reviewing') ? (
+          <RunningDuration startedAt={workflow.runStartedAt} />
+        ) : null}
         {derived?.hasNewCommits ? <span className="cv-stage cv-stage-new">有未 review 的新提交</span> : null}
       </div>
       {workflow?.worktree ? <div className="cv-dev-path">{workflow.worktree}</div> : null}
@@ -307,6 +313,7 @@ export function DevSection({
                           : '备注'}
               </span>
               <span className="cv-tl-time">{fmtTime(ev.at)}</span>
+              <DeliveryDuration kind={ev.kind} durationMs={ev.durationMs} />
               {ev.hash ? <code className="cv-tl-hash">{ev.hash}</code> : null}
               {ev.kind === 'merge-override' ? (
                 <span className="cv-tl-note" title={ev.reason}>

--- a/src/client/views/project-panel.tsx
+++ b/src/client/views/project-panel.tsx
@@ -1,6 +1,7 @@
 /** Project issue-list presentation and navigation. */
 import React from 'react'
 import { useProjectPanel } from '../project-state.ts'
+import { RunningDuration } from '../duration.ts'
 import { githubCompareUrl } from '../runtime.ts'
 import { type RepositoryIssue, apiCall, fetchIssue, stageLabel } from '../domain.ts'
 import { MAX_BATCH_ISSUES, setPanelOpen } from '../panel-state.ts'
@@ -418,6 +419,11 @@ export function PanelContent() {
                               }
                             />
                             <span className={`cv-stage cv-stage-${status}`}>{stageLabel(status, issue.workflow)}</span>
+                            {(status === 'developing' || status === 'reviewing') &&
+                            issue.workflow.runStartedAt !== null &&
+                            issue.workflow.runStartedAt !== undefined ? (
+                              <RunningDuration startedAt={issue.workflow.runStartedAt} />
+                            ) : null}
                             <div className="cv-issue-row-main">
                               <span className="cv-issue-row-title" onClick={() => void openIssue(issue)}>
                                 #{issue.number} {issue.title}

--- a/src/infra/runtime.ts
+++ b/src/infra/runtime.ts
@@ -66,6 +66,8 @@ export interface LiveTask {
   workflow: IssueWorkflow
   kind: 'dev' | 'review'
   agent: DevelopAgent
+  /** In-memory start of this exact run; a resumed run creates a new task/time. */
+  startedAt: number
   process?: ReturnType<Context['shell']['start']>
   log: LineLog
   rawLog: LineLog

--- a/src/infra/state.ts
+++ b/src/infra/state.ts
@@ -82,6 +82,7 @@ export interface IssueWorkflow {
 export interface WorkflowEvent {
   kind: 'dev' | 'review' | 'rework' | 'resume' | 'note' | 'merge-override'
   at: string
+  durationMs?: number
   /** commit hash 短码(dev/review 锚定的提交)。 */
   hash?: string
   /** review 结论(仅 review 事件)。 */

--- a/src/workflow/derive.ts
+++ b/src/workflow/derive.ts
@@ -83,7 +83,7 @@ export async function deriveWorkflowState(
   ctx: Context,
   workflow: IssueWorkflow,
   options: DeriveOptions = {},
-): Promise<IssueWorkflow & { derived: WorkflowDerived }> {
+): Promise<IssueWorkflow & { runStartedAt: number | null; derived: WorkflowDerived }> {
   const workflowPrNumber = workflow.prNumber == null ? null : String(workflow.prNumber)
   const worktree = workflow.worktree
   const exists = existsSync(worktree)
@@ -183,7 +183,13 @@ export async function deriveWorkflowState(
 
   const devLive = workflow.devTaskId ? liveTasks.get(workflow.devTaskId) : undefined
   const reviewLive = workflow.reviewTaskId ? liveTasks.get(workflow.reviewTaskId) : undefined
-  const taskRunning = (devLive !== undefined && !devLive.closed) || (reviewLive !== undefined && !reviewLive.closed)
+  const runningTask =
+    reviewLive !== undefined && !reviewLive.closed
+      ? reviewLive
+      : devLive !== undefined && !devLive.closed
+        ? devLive
+        : null
+  const taskRunning = runningTask !== null
 
   const branchExists = options.branchExists ?? branch !== null
   const worktreeValid = !exists || branch === workflow.branch
@@ -223,6 +229,7 @@ export async function deriveWorkflowState(
   return {
     ...workflow,
     prNumber: options.pr?.number ?? workflowPrNumber,
+    runStartedAt: runningTask?.startedAt ?? null,
     derived: {
       head,
       branch,

--- a/src/workflow/develop-start.ts
+++ b/src/workflow/develop-start.ts
@@ -261,6 +261,7 @@ export async function startDevelop(
       const agentCommand = buildFreshAgentCommand(agent)
 
       attachAgentProcess(ctx, live, agentCommand, workflow.worktree, prompt, async (exitCode, sessionId) => {
+        const durationMs = Math.max(0, Date.now() - live.startedAt)
         pushTaskLine(live, `[clickvibe] ${agent} 结束,退出码 ${exitCode}`)
         const reloaded = await loadWorkflow(workflow.key)
         if (reloaded) {
@@ -277,6 +278,7 @@ export async function startDevelop(
               fixedIssues,
               extraContext !== '' && !firstDevelopment ? 'rework' : 'dev',
               extraContext,
+              durationMs,
             )
           }
           await saveWorkflow(reloaded)

--- a/src/workflow/repository-state.ts
+++ b/src/workflow/repository-state.ts
@@ -46,7 +46,7 @@ export async function enrichWorkflowStates(
   ctx: Context,
   workflows: IssueWorkflow[],
   configOverride?: ClickVibeConfig,
-): Promise<Array<IssueWorkflow & { derived: WorkflowDerived }>> {
+): Promise<Array<IssueWorkflow & { runStartedAt: number | null; derived: WorkflowDerived }>> {
   const config = configOverride ?? (await loadConfig())
   return Promise.all(
     workflows.map(async (workflow) => {

--- a/src/workflow/resume.ts
+++ b/src/workflow/resume.ts
@@ -128,6 +128,7 @@ export async function resumeDevelop(
     workflow.worktree,
     prompt,
     async (exitCode, newSessionId) => {
+      const durationMs = Math.max(0, Date.now() - live.startedAt)
       pushTaskLine(live, `[clickvibe] ${agent} 恢复结束,退出码 ${exitCode}`)
       const reloaded = await loadWorkflow(workflow.key)
       if (reloaded) {
@@ -136,7 +137,7 @@ export async function resumeDevelop(
           // rework 完成:旧的 review 结论已归档到 events,回到"待 review",
           // 不能继续显示"Review 未通过"让用户无限重复点
           const head = await readWorktreeHead(ctx, workflow.worktree)
-          await recordDevDelivery(ctx, reloaded, agent, head, fixedIssues, 'rework', extraContext)
+          await recordDevDelivery(ctx, reloaded, agent, head, fixedIssues, 'rework', extraContext, durationMs)
         }
         await saveWorkflow(reloaded)
       }

--- a/src/workflow/review-flow.ts
+++ b/src/workflow/review-flow.ts
@@ -183,6 +183,7 @@ export async function startReview(
     workflow.worktree,
     prompt,
     async (exitCode, newSessionId) => {
+      const durationMs = Math.max(0, Date.now() - live.startedAt)
       pushTaskLine(live, `[clickvibe] review 结束,退出码 ${exitCode}`)
       if (live.status !== 'done' || exitCode !== 0) {
         const interrupted = await loadWorkflow(workflow.key)
@@ -224,6 +225,7 @@ export async function startReview(
         const event: WorkflowEvent = {
           kind: 'review',
           at: new Date().toISOString(),
+          durationMs,
           hash: reviewedHead,
           verdict: { passed, issues },
           issueContract: reviewIssue.contract,
@@ -288,6 +290,7 @@ export async function recordDevDelivery(
   fixedIssues: string[],
   kind: 'dev' | 'rework',
   userContext = '',
+  durationMs?: number,
 ): Promise<void> {
   if (!workflow.prNumber) {
     const pr = await detectLinkedPr(ctx, workflow.repoKey, workflow.branch)
@@ -296,6 +299,7 @@ export async function recordDevDelivery(
   const event: WorkflowEvent = {
     kind,
     at: new Date().toISOString(),
+    ...(Number.isFinite(durationMs) ? { durationMs: Math.max(0, durationMs ?? 0) } : {}),
     hash: head ?? undefined,
     fixed: fixedIssues.length,
     note: `${agent} 完成开发${kind === 'rework' ? '(按 review 意见返工)' : ''}`,

--- a/tests/client-duration.test.ts
+++ b/tests/client-duration.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import {
+  DeliveryDuration,
+  RunningDuration,
+  deliveryDurationLabel,
+  runningDurationLabel,
+} from '../src/client/duration.ts'
+
+test('running counters always use HH:MM:SS and clamp clock skew to zero', () => {
+  assert.equal(runningDurationLabel(-1), '00:00:00')
+  assert.equal(runningDurationLabel(1_000), '00:00:01')
+  assert.equal(runningDurationLabel(3_724_000), '01:02:04')
+})
+
+test('delivery durations use a compact unit format', () => {
+  assert.equal(deliveryDurationLabel(0), '0s')
+  assert.equal(deliveryDurationLabel(754_000), '12m34s')
+  assert.equal(deliveryDurationLabel(3_724_000), '1h02m')
+})
+
+test('running and delivery duration components render their display contracts', () => {
+  assert.match(
+    renderToStaticMarkup(React.createElement(RunningDuration, { startedAt: 1_000, now: 2_000 })),
+    /正在运行 · 已运行 00:00:01/,
+  )
+  assert.match(
+    renderToStaticMarkup(React.createElement(DeliveryDuration, { kind: 'review', durationMs: 754_000 })),
+    /耗时 12m34s/,
+  )
+  assert.equal(renderToStaticMarkup(React.createElement(DeliveryDuration, { kind: 'note', durationMs: 754_000 })), '')
+})

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -3304,6 +3304,8 @@ test('develop with user context stays a first development and records the note i
     let reloaded = await loadWorkflow('o-r-54')
     assert.equal(reloaded?.events.at(-1)?.kind, 'dev')
     assert.equal(reloaded?.events.at(-1)?.userContext, firstContext)
+    assert.equal(typeof reloaded?.events.at(-1)?.durationMs, 'number')
+    assert.ok((reloaded?.events.at(-1)?.durationMs ?? -1) >= 0)
     // 附加说明只进本地时间线,不进 GitHub 评论。
     assert.equal(comments[0].body.includes(firstContext), false)
 
@@ -3341,6 +3343,7 @@ test('develop with user context stays a first development and records the note i
     reloaded = await loadWorkflow('o-r-54')
     assert.equal(reloaded?.events.at(-1)?.kind, 'rework')
     assert.equal(reloaded?.events.at(-1)?.userContext, secondContext)
+    assert.equal(typeof reloaded?.events.at(-1)?.durationMs, 'number')
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
@@ -3435,6 +3438,7 @@ test('resume (rework) carries the user context next to the review feedback and a
     const reloaded = await loadWorkflow(workflow.key)
     assert.equal(reloaded?.events.at(-1)?.kind, 'rework')
     assert.equal(reloaded?.events.at(-1)?.userContext, userContext)
+    assert.equal(typeof reloaded?.events.at(-1)?.durationMs, 'number')
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
@@ -3542,6 +3546,7 @@ test('review with user context appends it to the prompt and audits it in the rev
     const reloaded = await loadWorkflow(workflow.key)
     assert.equal(reloaded?.events.at(-1)?.kind, 'review')
     assert.equal(reloaded?.events.at(-1)?.userContext, userContext)
+    assert.equal(typeof reloaded?.events.at(-1)?.durationMs, 'number')
     // 附加说明不自动发布为 GitHub 评论。
     const comments = await readLogHistory(workflow.key, 'review')
     assert.equal(

--- a/tests/state-view-integration.test.ts
+++ b/tests/state-view-integration.test.ts
@@ -6,6 +6,8 @@ import { join } from 'node:path'
 import { promisify } from 'node:util'
 import test from 'node:test'
 import { deriveWorkflowState, enrichWorkflowStates, type IssueWorkflow } from '../src/index.ts'
+import { LineLog } from '../src/infra/develop-core.ts'
+import { liveTasks } from '../src/infra/runtime.ts'
 import { issueBodyHash } from '../src/infra/state.ts'
 
 const execFileAsync = promisify(execFile)
@@ -91,6 +93,33 @@ function workflow(overrides: Partial<IssueWorkflow> = {}): IssueWorkflow {
     ...overrides,
   }
 }
+
+test('state exposes only the current in-memory task start time', async () => {
+  const wf = workflow({ stage: 'developing', devTaskId: 'dev-live' })
+  liveTasks.set('dev-live', {
+    taskId: 'dev-live',
+    workflowKey: wf.key,
+    workflow: wf,
+    kind: 'dev',
+    agent: 'codex',
+    startedAt: 1_720_000_000_000,
+    log: new LineLog(10),
+    rawLog: new LineLog(10),
+    rawCursor: 0,
+    closed: false,
+    status: 'running',
+    exitCode: null,
+    sessionId: null,
+  })
+  try {
+    assert.equal((await deriveWorkflowState(ctx, wf)).runStartedAt, 1_720_000_000_000)
+    liveTasks.get('dev-live')!.closed = true
+    assert.equal((await deriveWorkflowState(ctx, wf)).runStartedAt, null)
+  } finally {
+    liveTasks.delete('dev-live')
+  }
+  assert.equal((await deriveWorkflowState(ctx, wf)).runStartedAt, null)
+})
 
 test('state view derives worktree/main/remote hashes, ahead-behind and sync need', async () => {
   const { root, worktree, git, wt, baseA } = await setupRepo()


### PR DESCRIPTION
Closes #57

## Summary
- expose the in-memory start time of the current live task through workflow state
- show shared live counters in issue detail and active repository rows
- persist and render compact durations for completed dev, rework, and review deliveries

## Verification
- pnpm run typecheck
- pnpm run build
- pnpm test (237/237)
- pnpm run coverage (line 92.63%, function 88.07%)
- pnpm run check