### PR TITLE
feat: 交付流水完整审计

### DIFF
--- a/src/client/delivery-timeline.ts
+++ b/src/client/delivery-timeline.ts
@@ -1,0 +1,69 @@
+import type { WorkflowEvent } from './domain.ts'
+
+export type DeliveryTimelineDetail =
+  | { kind: 'review'; issues: string[] }
+  | {
+      kind: 'development'
+      commits: { hash: string; subject: string }[]
+      diffstat: { path: string; insertions: number | null; deletions: number | null }[]
+      taskId?: string
+    }
+  | { kind: 'generic' }
+
+export interface DeliveryTimelineItem {
+  event: WorkflowEvent
+  kindLabel: string
+  summary: string
+  detail: DeliveryTimelineDetail
+}
+
+const KIND_LABELS: Record<WorkflowEvent['kind'], string> = {
+  dev: '开发',
+  rework: '返工',
+  review: 'Review',
+  resume: '恢复',
+  note: '备注',
+  'merge-override': '人工放行',
+}
+
+function agentLabel(agent: WorkflowEvent['agent']): string | null {
+  if (agent === 'codex') return 'Codex'
+  if (agent === 'claude') return 'Claude'
+  return null
+}
+
+export function deriveDeliveryTimelineItem(event: WorkflowEvent): DeliveryTimelineItem {
+  const parts: string[] = []
+  if (event.round !== undefined) parts.push(`第 ${event.round} 轮`)
+  const agent = agentLabel(event.agent)
+  if (agent) parts.push(agent)
+  if (event.stats && (event.kind === 'dev' || event.kind === 'rework' || event.kind === 'resume')) {
+    parts.push(`${event.stats.filesChanged} 文件`, `+${event.stats.insertions}/-${event.stats.deletions}`)
+  }
+  if (event.kind === 'review' && event.verdict) {
+    parts.push(`${event.verdict.issues.length} 条意见`)
+  } else if (
+    (event.kind === 'dev' || event.kind === 'rework' || event.kind === 'resume') &&
+    event.fixed !== undefined
+  ) {
+    parts.push(`处理 ${event.fixed} 条意见`)
+  } else if (event.kind === 'merge-override') {
+    parts.push(
+      `跳过 ${(event.skippedLabels ?? event.skipped ?? []).join('、') || '未知门禁'}`,
+      `操作者 @${event.operator ?? '?'}`,
+    )
+  }
+
+  let detail: DeliveryTimelineDetail = { kind: 'generic' }
+  if (event.kind === 'review') {
+    detail = { kind: 'review', issues: event.verdict?.issues ?? [] }
+  } else if (event.kind === 'dev' || event.kind === 'rework' || event.kind === 'resume') {
+    detail = {
+      kind: 'development',
+      commits: event.stats?.commits ?? [],
+      diffstat: event.stats?.diffstat ?? [],
+      ...(event.taskId ? { taskId: event.taskId } : {}),
+    }
+  }
+  return { event, kindLabel: KIND_LABELS[event.kind], summary: parts.join(' · '), detail }
+}

--- a/src/client/dev-state.ts
+++ b/src/client/dev-state.ts
@@ -3,7 +3,7 @@ import { clearedContext, contextToSubmit, toggledContext } from './action-contex
 import { type AuthorizationPreview, authorizationSummary, expectedDevelopSnapshot } from './dev-authorization.ts'
 import { useDevStream } from './dev-stream.ts'
 import { type MergeGateFailure, type NextAction, OVERRIDE_REASON_MAX, type Workflow, apiCall } from './domain.ts'
-import { githubCompareUrl } from './runtime.ts'
+import { githubCompareUrl, latestDevelopmentEvent } from './runtime.ts'
 import { type GhIssue } from './views/issue-view.tsx'
 export function useDevSection({
   url,
@@ -35,7 +35,7 @@ export function useDevSection({
   const stage = derived?.status ?? workflow?.stage ?? 'idle'
   const nextAction = derived?.nextAction
   const workflowEvents = workflow?.events ?? []
-  const lastDelivery = [...workflowEvents].reverse().find((event) => event.kind === 'dev' || event.kind === 'rework')
+  const lastDelivery = latestDevelopmentEvent(workflowEvents)
   const refresh = async () => {
     const res = await apiCall<{ ok: true; workflows: Workflow[] }>('state', { url })
     if (res.ok) onWorkflow(res.workflows.find((item) => item.url === url) ?? null)

--- a/src/client/dev-state.ts
+++ b/src/client/dev-state.ts
@@ -451,8 +451,7 @@ export function useDevSection({
             : busy === 'developing'
               ? '启动中…'
               : null
-  // 人工放行入口(issue #49):合并尝试被门禁拒绝后(动态),或 review 已通过
-  // 但结论/契约过期、面板停留在「重新 Review」/「无法读取契约」时(静态)。
+  // 人工放行入口(issue #49):门禁拒绝,或 review 已通过但结论/契约过期时。
   const overrideEntryVisible =
     overrideGates !== null ||
     Boolean(
@@ -484,6 +483,7 @@ export function useDevSection({
     mergeWithOverride,
     overrideEntryVisible,
     overrideGates,
+    openStream,
     runAction,
     setAgentChoice,
     setContextText,

--- a/src/client/domain.ts
+++ b/src/client/domain.ts
@@ -100,6 +100,16 @@ export interface WorkflowEvent {
   kind: 'dev' | 'review' | 'rework' | 'resume' | 'note' | 'merge-override'
   at: string
   hash?: string
+  round?: number
+  agent?: 'codex' | 'claude'
+  stats?: {
+    commits: { hash: string; subject: string }[]
+    filesChanged: number
+    insertions: number
+    deletions: number
+    diffstat: { path: string; insertions: number | null; deletions: number | null }[]
+  }
+  taskId?: string
   verdict?: { passed: boolean; issues: string[] }
   issueContract?: { bodyHash: string; updatedAt: string }
   fixed?: number

--- a/src/client/runtime.ts
+++ b/src/client/runtime.ts
@@ -6,7 +6,15 @@
  * workflow/delivery-publication.ts. tests/runtime-contract.test.ts compares
  * both boundaries so a one-sided protocol or label change fails CI.
  */
+import type { WorkflowEvent } from './domain.ts'
+
 export type AgentKind = 'codex' | 'claude'
+
+export function latestDevelopmentEvent(events: WorkflowEvent[]): WorkflowEvent | undefined {
+  return [...events]
+    .reverse()
+    .find((event) => event.kind === 'dev' || event.kind === 'rework' || event.kind === 'resume')
+}
 export type LiveLogKind =
   | 'system'
   | 'stage'

--- a/src/client/styles.ts
+++ b/src/client/styles.ts
@@ -168,7 +168,10 @@ body[data-cv-panel-dragging] #root.cv-panel-host-open, body[data-cv-panel-draggi
 .cv-stage-new { background: #fff8c5; color: #9a6700; }
 .cv-timeline { border-top: 1px solid #d0d7de; padding-top: 6px; display: flex; flex-direction: column; gap: 4px; }
 .cv-timeline-head { font-size: 12px; font-weight: 600; color: #57606a; }
-.cv-tl-row { display: flex; align-items: center; gap: 6px; font-size: 11.5px; flex-wrap: wrap; }
+.cv-tl-row { display: flex; align-items: center; gap: 6px; font-size: 11.5px; }
+.cv-tl-open { flex: 1; min-width: 0; display: flex; align-items: center; gap: 6px; flex-wrap: wrap; padding: 3px 4px; border: 0; border-radius: 4px; background: transparent; color: inherit; font: inherit; text-align: left; cursor: pointer; }
+.cv-tl-open:hover { background: #f6f8fa; }
+.cv-tl-summary { color: #1f2328; font-weight: 600; }
 .cv-tl-kind { display: inline-block; padding: 0 6px; border-radius: 8px; font-size: 10.5px; font-weight: 600; }
 .cv-tl-kind-dev { background: #ddf4ff; color: #0969da; }
 .cv-tl-kind-rework { background: #fff8c5; color: #9a6700; }
@@ -188,6 +191,20 @@ body[data-cv-panel-dragging] #root.cv-panel-host-open, body[data-cv-panel-draggi
 .cv-tl-public:hover { text-decoration: underline; }
 .cv-tl-local { color: #8c959f; }
 .cv-tl-publish-fail { color: #cf222e; font-weight: 600; }
+.cv-audit-backdrop { position: fixed; z-index: 10020; inset: 0; background: rgb(31 35 40 / 28%); }
+.cv-audit-drawer { position: absolute; top: 0; right: 0; bottom: 0; width: min(480px, 92vw); overflow: auto; padding: 18px; background: #fff; box-shadow: -12px 0 36px rgb(31 35 40 / 24%); color: #1f2328; }
+.cv-audit-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; padding-bottom: 12px; border-bottom: 1px solid #d0d7de; }
+.cv-audit-close { border: 0; background: transparent; color: #57606a; font-size: 26px; line-height: 1; cursor: pointer; }
+.cv-audit-summary { margin-top: 12px; padding: 8px 10px; border-radius: 6px; background: #f6f8fa; font-size: 12px; font-weight: 600; }
+.cv-audit-section { margin-top: 16px; font-size: 12px; overflow-wrap: anywhere; }
+.cv-audit-section h4 { margin: 0 0 7px; font-size: 12px; color: #57606a; }
+.cv-audit-muted { color: #8c959f; font-size: 11px; }
+.cv-audit-list { margin: 0; padding-left: 22px; display: flex; flex-direction: column; gap: 7px; }
+.cv-audit-commits code { margin-right: 5px; }
+.cv-audit-diffstat { list-style: none; padding-left: 0; }
+.cv-audit-diffstat li { display: flex; justify-content: space-between; gap: 12px; }
+.cv-audit-diffstat span { overflow-wrap: anywhere; }
+.cv-audit-log { margin-top: 16px; border: 1px solid #0969da; border-radius: 6px; padding: 7px 10px; background: #fff; color: #0969da; font-size: 11px; cursor: pointer; }
 .cv-delivery-summary { font-size: 12px; color: #57606a; background: #f6f8fa; border-radius: 4px; padding: 6px 8px; }
 .cv-review-next { font-size: 12px; font-weight: 600; }
 .cv-state { border: 1px solid #d0d7de; border-radius: 6px; padding: 8px 10px; display: flex; flex-direction: column; gap: 4px; }

--- a/src/client/views/delivery-timeline.tsx
+++ b/src/client/views/delivery-timeline.tsx
@@ -1,0 +1,186 @@
+import React from 'react'
+import { createPortal } from 'react-dom'
+import { deriveDeliveryTimelineItem } from '../delivery-timeline.ts'
+import type { WorkflowEvent } from '../domain.ts'
+import { fmtTime } from '../domain.ts'
+import { deliveryPublicationLabel } from '../runtime.ts'
+
+export function DeliveryTimeline({
+  events,
+  onOpenLog,
+}: {
+  events: WorkflowEvent[]
+  onOpenLog: (taskId: string) => void
+}) {
+  const [selected, setSelected] = React.useState<WorkflowEvent | null>(null)
+  React.useEffect(() => {
+    if (!selected) return
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setSelected(null)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [selected])
+  if (events.length === 0) return null
+  const selectedItem = selected ? deriveDeliveryTimelineItem(selected) : null
+  return (
+    <>
+      <div className="cv-timeline">
+        <div className="cv-timeline-head">📜 交付流水 · 本地事件 / GitHub 评论</div>
+        {[...events].reverse().map((event, index) => {
+          const item = deriveDeliveryTimelineItem(event)
+          return (
+            <div key={`${event.at}-${index}`} className="cv-tl-row">
+              <button type="button" className="cv-tl-open" onClick={() => setSelected(event)}>
+                <span className={`cv-tl-kind cv-tl-kind-${event.kind}`}>{item.kindLabel}</span>
+                <span className="cv-tl-time">{fmtTime(event.at)}</span>
+                {event.hash ? <code className="cv-tl-hash">{event.hash}</code> : null}
+                {item.summary ? <span className="cv-tl-summary">{item.summary}</span> : null}
+                {event.kind === 'review' && event.verdict ? (
+                  <span className={event.verdict.passed ? 'cv-tl-verdict cv-tl-pass' : 'cv-tl-verdict cv-tl-fail'}>
+                    {event.verdict.passed ? '✅ 通过' : `❌ ${event.verdict.issues.length} 个问题`}
+                  </span>
+                ) : null}
+                {event.note ? <span className="cv-tl-note">{event.note}</span> : null}
+              </button>
+              <Publication publication={event.publication} />
+            </div>
+          )
+        })}
+      </div>
+      {selected && selectedItem
+        ? createPortal(
+            <div className="cv-audit-backdrop" role="presentation" onMouseDown={() => setSelected(null)}>
+              <aside
+                className="cv-audit-drawer"
+                role="dialog"
+                aria-modal="true"
+                aria-label={`${selectedItem.kindLabel}流水详情`}
+                onMouseDown={(event) => event.stopPropagation()}
+              >
+                <div className="cv-audit-head">
+                  <div>
+                    <strong>{selectedItem.kindLabel}详情</strong>
+                    <div className="cv-audit-muted">{fmtTime(selected.at)}</div>
+                  </div>
+                  <button
+                    type="button"
+                    className="cv-audit-close"
+                    onClick={() => setSelected(null)}
+                    aria-label="关闭详情"
+                  >
+                    ×
+                  </button>
+                </div>
+                {selectedItem.summary ? <div className="cv-audit-summary">{selectedItem.summary}</div> : null}
+                {selected.hash ? (
+                  <div className="cv-audit-section">
+                    <h4>锚定提交</h4>
+                    <code>{selected.hash}</code>
+                  </div>
+                ) : null}
+                {selectedItem.detail.kind === 'review' ? (
+                  <div className="cv-audit-section">
+                    <h4>当轮 Review 意见全文</h4>
+                    {selectedItem.detail.issues.length > 0 ? (
+                      <ol className="cv-audit-list">
+                        {selectedItem.detail.issues.map((issue, index) => (
+                          <li key={index}>{issue}</li>
+                        ))}
+                      </ol>
+                    ) : (
+                      <div className="cv-audit-muted">本轮无阻塞意见。</div>
+                    )}
+                  </div>
+                ) : selectedItem.detail.kind === 'development' ? (
+                  <>
+                    <div className="cv-audit-section">
+                      <h4>提交列表</h4>
+                      {selectedItem.detail.commits.length > 0 ? (
+                        <ul className="cv-audit-list cv-audit-commits">
+                          {selectedItem.detail.commits.map((commit) => (
+                            <li key={commit.hash}>
+                              <code>{commit.hash}</code> {commit.subject}
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <div className="cv-audit-muted">旧事件未冻结提交列表。</div>
+                      )}
+                    </div>
+                    <div className="cv-audit-section">
+                      <h4>Diffstat</h4>
+                      {selectedItem.detail.diffstat.length > 0 ? (
+                        <ul className="cv-audit-list cv-audit-diffstat">
+                          {selectedItem.detail.diffstat.map((file) => (
+                            <li key={file.path}>
+                              <span>{file.path}</span>
+                              <code>
+                                {file.insertions === null ? 'binary' : `+${file.insertions}/-${file.deletions}`}
+                              </code>
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <div className="cv-audit-muted">旧事件未冻结 diffstat。</div>
+                      )}
+                    </div>
+                    {selectedItem.detail.taskId ? (
+                      <button
+                        type="button"
+                        className="cv-audit-log"
+                        onClick={() => {
+                          onOpenLog(selectedItem.detail.kind === 'development' ? selectedItem.detail.taskId! : '')
+                          setSelected(null)
+                        }}
+                      >
+                        打开该轮日志 · {selectedItem.detail.taskId}
+                      </button>
+                    ) : null}
+                  </>
+                ) : selected.kind === 'merge-override' ? (
+                  <div className="cv-audit-section">
+                    <h4>人工放行</h4>
+                    <div>跳过:{(selected.skippedLabels ?? selected.skipped ?? []).join('、') || '未知门禁'}</div>
+                    <div>操作者:@{selected.operator ?? '?'}</div>
+                    <div>原因:{selected.reason ?? '?'}</div>
+                  </div>
+                ) : null}
+                {selected.userContext ? (
+                  <div className="cv-audit-section">
+                    <h4>用户附加说明</h4>
+                    <div>{selected.userContext}</div>
+                  </div>
+                ) : null}
+                <div className="cv-audit-section">
+                  <h4>GitHub 发布</h4>
+                  <Publication publication={selected.publication} />
+                </div>
+              </aside>
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  )
+}
+
+function Publication({ publication }: { publication: WorkflowEvent['publication'] }) {
+  if (publication?.status === 'posted') {
+    return publication.url ? (
+      <a className="cv-tl-public" href={publication.url} target="_blank" rel="noreferrer">
+        {deliveryPublicationLabel(publication)}
+      </a>
+    ) : (
+      <span className="cv-tl-public">{deliveryPublicationLabel(publication)}</span>
+    )
+  }
+  if (publication?.status === 'failed') {
+    return (
+      <span className="cv-tl-publish-fail" title={publication.error}>
+        {deliveryPublicationLabel(publication)}
+      </span>
+    )
+  }
+  return <span className="cv-tl-local">{deliveryPublicationLabel(publication)}</span>
+}

--- a/src/client/views/dev-section.tsx
+++ b/src/client/views/dev-section.tsx
@@ -1,8 +1,8 @@
-import { deliveryPublicationLabel } from '../runtime.ts'
-import { type Workflow, fmtTime, stageLabel } from '../domain.ts'
+import { type Workflow, stageLabel } from '../domain.ts'
 import { type GhIssue } from './issue-view.tsx'
 import { LiveTerminal } from './live-terminal.tsx'
 import { useDevSection } from '../dev-state.ts'
+import { DeliveryTimeline } from './delivery-timeline.tsx'
 
 export function DevSection({
   url,
@@ -40,6 +40,7 @@ export function DevSection({
     mergeWithOverride,
     overrideEntryVisible,
     overrideGates,
+    openStream,
     runAction,
     setAgentChoice,
     setContextText,
@@ -287,66 +288,7 @@ export function DevSection({
         </details>
       ) : null}
 
-      {/* 交付流水:本地事件与其公开 GitHub 评论状态,按时间倒序 */}
-      {workflowEvents.length > 0 ? (
-        <div className="cv-timeline">
-          <div className="cv-timeline-head">📜 交付流水 · 本地事件 / GitHub 评论</div>
-          {[...workflowEvents].reverse().map((ev, i) => (
-            <div key={i} className="cv-tl-row">
-              <span className={`cv-tl-kind cv-tl-kind-${ev.kind}`}>
-                {ev.kind === 'dev'
-                  ? '开发'
-                  : ev.kind === 'rework'
-                    ? '返工'
-                    : ev.kind === 'review'
-                      ? 'Review'
-                      : ev.kind === 'resume'
-                        ? '恢复'
-                        : ev.kind === 'merge-override'
-                          ? '人工放行'
-                          : '备注'}
-              </span>
-              <span className="cv-tl-time">{fmtTime(ev.at)}</span>
-              {ev.hash ? <code className="cv-tl-hash">{ev.hash}</code> : null}
-              {ev.kind === 'merge-override' ? (
-                <span className="cv-tl-note" title={ev.reason}>
-                  跳过 {(ev.skippedLabels ?? ev.skipped ?? []).join('、')} · 操作者 @{ev.operator ?? '?'} · 原因:
-                  {ev.reason ?? '?'}
-                </span>
-              ) : null}
-              {ev.kind === 'review' && ev.verdict ? (
-                <span className={ev.verdict.passed ? 'cv-tl-verdict cv-tl-pass' : 'cv-tl-verdict cv-tl-fail'}>
-                  {ev.verdict.passed ? '✅ 通过' : `❌ ${ev.verdict.issues.length} 个问题`}
-                </span>
-              ) : null}
-              {(ev.kind === 'dev' || ev.kind === 'rework') && ev.fixed !== undefined ? (
-                <span className="cv-tl-note">修复 {ev.fixed} 个问题</span>
-              ) : null}
-              {ev.note ? <span className="cv-tl-note">{ev.note}</span> : null}
-              {ev.userContext ? (
-                <span className="cv-tl-user-context" title={ev.userContext}>
-                  用户附加说明:{ev.userContext.length > 80 ? `${ev.userContext.slice(0, 80)}…` : ev.userContext}
-                </span>
-              ) : null}
-              {ev.publication?.status === 'posted' ? (
-                ev.publication.url ? (
-                  <a className="cv-tl-public" href={ev.publication.url} target="_blank" rel="noreferrer">
-                    {deliveryPublicationLabel(ev.publication)}
-                  </a>
-                ) : (
-                  <span className="cv-tl-public">{deliveryPublicationLabel(ev.publication)}</span>
-                )
-              ) : ev.publication?.status === 'failed' ? (
-                <span className="cv-tl-publish-fail" title={ev.publication.error}>
-                  {deliveryPublicationLabel(ev.publication)}
-                </span>
-              ) : (
-                <span className="cv-tl-local">{deliveryPublicationLabel(ev.publication)}</span>
-              )}
-            </div>
-          ))}
-        </div>
-      ) : null}
+      <DeliveryTimeline events={workflowEvents} onOpenLog={(taskId) => void openStream(taskId, false)} />
     </div>
   )
 }

--- a/src/infra/contracts.ts
+++ b/src/infra/contracts.ts
@@ -17,6 +17,27 @@ export interface DeliveryPublication {
   error?: string
 }
 
+export interface DeliveryCommit {
+  hash: string
+  subject: string
+}
+
+export interface DeliveryDiffstat {
+  path: string
+  /** Binary files have no meaningful line count. */
+  insertions: number | null
+  deletions: number | null
+}
+
+/** Immutable git facts for one delivery generation. */
+export interface DeliveryStats {
+  commits: DeliveryCommit[]
+  filesChanged: number
+  insertions: number
+  deletions: number
+  diffstat: DeliveryDiffstat[]
+}
+
 export interface IssueContractCheck {
   ok: boolean
   missing: string[]

--- a/src/infra/git.ts
+++ b/src/infra/git.ts
@@ -21,10 +21,65 @@ import type { Context } from '@deepseek-ai/cordis'
 import { shellQuote } from './develop-core.ts'
 import { runCommand } from './runtime.ts'
 import { type IssueContractSnapshot } from './state.ts'
+import type { DeliveryStats } from './contracts.ts'
 
 interface GitCompare {
   behind: number
   ahead: number
+}
+
+/** Freeze commit and per-file numstat facts for fork-point..head. */
+export async function readDeliveryStats(
+  ctx: Context,
+  workdir: string,
+  baseBranch: string,
+  head: string,
+): Promise<DeliveryStats | undefined> {
+  try {
+    const policy = { mode: 'read-only' as const, workspaceRoot: workdir }
+    const execute = async (command: string): Promise<string | null> => {
+      const spec = ctx.shell.resolve({ command, workdir, timeoutMs: 10_000, sandboxPolicy: policy })
+      const result = await ctx.shell.run(spec)
+      return result.exitCode === 0 ? result.stdout.text : null
+    }
+    const base = (await execute(`git merge-base ${shellQuote(`origin/${baseBranch}`)} ${shellQuote(head)}`))?.trim()
+    if (!base) return undefined
+    const range = `${base}..${head}`
+    const [logOutput, numstatOutput] = await Promise.all([
+      execute(`git log --format='%h%x1f%s' ${shellQuote(range)}`),
+      execute(`git diff --numstat --no-renames ${shellQuote(range)}`),
+    ])
+    if (logOutput === null || numstatOutput === null) return undefined
+    const commits = logOutput
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => {
+        const separator = line.indexOf('\u001f')
+        return separator < 0
+          ? { hash: line.trim(), subject: '' }
+          : { hash: line.slice(0, separator), subject: line.slice(separator + 1) }
+      })
+    const diffstat = numstatOutput
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => {
+        const [added, removed, ...pathParts] = line.split('\t')
+        return {
+          path: pathParts.join('\t'),
+          insertions: added === '-' ? null : Number(added),
+          deletions: removed === '-' ? null : Number(removed),
+        }
+      })
+    return {
+      commits,
+      filesChanged: diffstat.length,
+      insertions: diffstat.reduce((total, file) => total + (file.insertions ?? 0), 0),
+      deletions: diffstat.reduce((total, file) => total + (file.deletions ?? 0), 0),
+      diffstat,
+    }
+  } catch {
+    return undefined
+  }
 }
 
 interface PrFactForDerivation {

--- a/src/infra/state.ts
+++ b/src/infra/state.ts
@@ -3,7 +3,7 @@ import { createHash } from 'node:crypto'
 import { appendFile, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import type { DeliveryPublication, PromptSnapshot } from './contracts.ts'
+import type { DeliveryPublication, DeliveryStats, PromptSnapshot } from './contracts.ts'
 import { issueKey, legacyIssueKey, taskLogPath, workflowPath, type WorkflowStorageIdentity } from './state-layout.ts'
 import {
   appendTaskLog as appendTaskLogRecord,
@@ -18,7 +18,6 @@ import {
 } from './task-log-store.ts'
 
 export { issueKey } from './state-layout.ts'
-
 /** The workflow stage of one issue. */
 export type WorkflowStage =
   | 'idle' // 未开始开发
@@ -28,14 +27,12 @@ export type WorkflowStage =
   | 'passed' // review 通过
 
 export type SessionAgent = 'codex' | 'claude'
-
 export interface DeliveryCleanup {
   worktree: boolean
   localBranch: boolean
   remoteBranch: boolean
   issue: boolean
 }
-
 /** Durable, irreversible delivery fact plus the retryable cleanup cursor. */
 export interface WorkflowDelivery {
   status: 'merged' | 'cleanup-pending' | 'archived'
@@ -82,8 +79,11 @@ export interface IssueWorkflow {
 export interface WorkflowEvent {
   kind: 'dev' | 'review' | 'rework' | 'resume' | 'note' | 'merge-override'
   at: string
-  /** commit hash 短码(dev/review 锚定的提交)。 */
-  hash?: string
+  hash?: string // dev/review 锚定 commit 的短码
+  round?: number // Review 结论落地轮次;旧事件缺失时降级展示
+  agent?: SessionAgent // 动作实际使用的 agent 快照
+  stats?: DeliveryStats // fork point..锚定 HEAD 的 git 事实
+  taskId?: string // 结构化任务日志锚点
   /** review 结论(仅 review 事件)。 */
   verdict?: { passed: boolean; issues: string[] }
   /** review 启动时冻结的 Issue 验收契约。旧事件缺失时按过期处理。 */

--- a/src/workflow/delivery-audit.ts
+++ b/src/workflow/delivery-audit.ts
@@ -1,0 +1,6 @@
+import type { WorkflowEvent } from '../infra/state.ts'
+
+/** A review verdict closes one round; all work until the next verdict shares the next round. */
+export function deriveEventRound(events: WorkflowEvent[], _kind: WorkflowEvent['kind']): number {
+  return events.filter((event) => event.kind === 'review' && event.verdict !== undefined).length + 1
+}

--- a/src/workflow/delivery-audit.ts
+++ b/src/workflow/delivery-audit.ts
@@ -1,6 +1,21 @@
 import type { WorkflowEvent } from '../infra/state.ts'
 
 /** A review verdict closes one round; all work until the next verdict shares the next round. */
-export function deriveEventRound(events: WorkflowEvent[], _kind: WorkflowEvent['kind']): number {
+export function deriveEventRound(events: WorkflowEvent[]): number {
   return events.filter((event) => event.kind === 'review' && event.verdict !== undefined).length + 1
+}
+
+/** Resume deliveries are development facts too and must advance the reviewed-HEAD projection. */
+export function latestDevelopmentHash(events: WorkflowEvent[]): string | undefined {
+  return [...events]
+    .reverse()
+    .find(
+      (event) =>
+        event.hash !== undefined && (event.kind === 'dev' || event.kind === 'rework' || event.kind === 'resume'),
+    )?.hash
+}
+
+/** Keep event classification aligned with the existing develop-prompt context contract. */
+export function deriveDevelopmentEventKind(firstDevelopment: boolean, extraContext: string): 'dev' | 'rework' {
+  return !firstDevelopment && extraContext !== '' ? 'rework' : 'dev'
 }

--- a/src/workflow/delivery-comment.ts
+++ b/src/workflow/delivery-comment.ts
@@ -17,6 +17,7 @@ export interface ReviewCommentInput {
   issues: string[]
   agent: 'codex' | 'claude'
   round: number
+  fixedRound?: number
   stats?: DeliveryStats
   at: string
 }
@@ -66,9 +67,13 @@ export function buildReviewComment(input: ReviewCommentInput): string {
     : [
         `## ❌ ClickVibe Review 发现问题(${input.issues.length} 条)`,
         '',
-        ...input.issues.map((issue) => `- ${issue}`),
+        ...input.issues.map((issue) =>
+          input.fixedRound === undefined ? `- ${issue}` : `- [已于第 ${input.fixedRound} 轮修复] ${issue}`,
+        ),
         '',
-        '下一步:请重新开发并处理上述问题。',
+        input.fixedRound === undefined
+          ? '下一步:请重新开发并处理上述问题。'
+          : `第 ${input.fixedRound} 轮修复已交付，请 Review 当前提交。`,
       ]
   return [
     '== Review Meta ==',
@@ -78,6 +83,7 @@ export function buildReviewComment(input: ReviewCommentInput): string {
     `- passed: ${input.passed}`,
     `- next: ${input.passed ? 'merge' : 'rework'}`,
     `- round: ${input.round}`,
+    ...(input.fixedRound === undefined ? [] : [`- fixed-round: ${input.fixedRound}`]),
     `- stats: ${statsMeta(input.stats)}`,
     `- agent: ${input.agent}`,
     `- at: ${input.at}`,

--- a/src/workflow/delivery-comment.ts
+++ b/src/workflow/delivery-comment.ts
@@ -1,8 +1,12 @@
+import type { DeliveryStats } from '../infra/contracts.ts'
+
 export interface DevCommentInput {
   commit: string
   issueNumber: string
   fixedIssues: string[]
   agent: 'codex' | 'claude'
+  round: number
+  stats?: DeliveryStats
   at: string
 }
 
@@ -12,7 +16,15 @@ export interface ReviewCommentInput {
   passed: boolean
   issues: string[]
   agent: 'codex' | 'claude'
+  round: number
+  stats?: DeliveryStats
   at: string
+}
+
+function statsMeta(stats: DeliveryStats | undefined): string {
+  return stats
+    ? `commits=${stats.commits.length} filesChanged=${stats.filesChanged} insertions=${stats.insertions} deletions=${stats.deletions}`
+    : 'unavailable'
 }
 
 export function buildDevComment(input: DevCommentInput): string {
@@ -21,7 +33,7 @@ export function buildDevComment(input: DevCommentInput): string {
       ? [
           `已处理上一轮 Review 的 ${input.fixedIssues.length} 个问题:`,
           '',
-          ...input.fixedIssues.map((issue) => `- ${issue}`),
+          ...input.fixedIssues.map((issue) => `- [已于第 ${input.round} 轮修复] ${issue}`),
         ]
       : ['已完成本轮 Issue 需求实现。']
   return [
@@ -31,6 +43,8 @@ export function buildDevComment(input: DevCommentInput): string {
     `- issue: #${input.issueNumber}`,
     `- fixed: ${input.fixedIssues.length}`,
     '- next: review',
+    `- round: ${input.round}`,
+    `- stats: ${statsMeta(input.stats)}`,
     `- agent: ${input.agent}`,
     `- at: ${input.at}`,
     '',
@@ -63,6 +77,8 @@ export function buildReviewComment(input: ReviewCommentInput): string {
     `- issue: #${input.issueNumber}`,
     `- passed: ${input.passed}`,
     `- next: ${input.passed ? 'merge' : 'rework'}`,
+    `- round: ${input.round}`,
+    `- stats: ${statsMeta(input.stats)}`,
     `- agent: ${input.agent}`,
     `- at: ${input.at}`,
     '',

--- a/src/workflow/delivery-publication.ts
+++ b/src/workflow/delivery-publication.ts
@@ -15,6 +15,11 @@ export function extractGithubCommentUrl(output: string): string | undefined {
     .find((line) => GITHUB_COMMENT_URL.test(line))
 }
 
+export function extractGithubCommentId(url: string): string | undefined {
+  if (!GITHUB_COMMENT_URL.test(url)) return undefined
+  return url.match(/#issuecomment-(\d+)$/)?.[1]
+}
+
 /** Keep publication wording in one tested place for the delivery timeline UI. */
 export function deliveryPublicationLabel(publication: DeliveryPublication | undefined): string {
   if (!publication) return '本地事件'

--- a/src/workflow/derive.ts
+++ b/src/workflow/derive.ts
@@ -23,6 +23,7 @@ import type { Context } from '@deepseek-ai/cordis'
 import { type DeriveOptions, hasMergeConflict, readBranch, readRefShort, readRevCount } from '../infra/git.ts'
 import { liveTasks, readWorktreeHead, runCommand } from '../infra/runtime.ts'
 import { type IssueContractSnapshot, type IssueWorkflow } from '../infra/state.ts'
+import { latestDevelopmentHash } from './delivery-audit.ts'
 import {
   deriveNextAction,
   deriveWorkflowStatus,
@@ -88,11 +89,10 @@ export async function deriveWorkflowState(
   const worktree = workflow.worktree
   const exists = existsSync(worktree)
   const events = workflow.events ?? []
-  let lastDevHash: string | null = null
+  const lastDevHash = latestDevelopmentHash(events) ?? null
   let lastReviewHash: string | null = null
   let lastReviewContract: IssueContractSnapshot | null = null
   for (const ev of events) {
-    if (ev.kind === 'dev' || ev.kind === 'rework') lastDevHash = ev.hash ?? lastDevHash
     if (ev.kind === 'review') {
       lastReviewHash = ev.hash ?? lastReviewHash
       lastReviewContract = ev.issueContract ?? null
@@ -150,7 +150,7 @@ export async function deriveWorkflowState(
     }
   }
 
-  // 有新提交 = worktree HEAD 不在已记录的任何 dev/rework 事件哈希里
+  // 有新提交 = worktree HEAD 不等于最近一次 dev/rework/resume 交付哈希
   const hasNewCommits = head !== null && lastDevHash !== null && head !== lastDevHash
   // worktree 落后远端基线(origin/main 或远端同名分支)→ 需要同步
   const needsSync = behindBase > 0 || (behindUpstream ?? 0) > 0

--- a/src/workflow/develop-start.ts
+++ b/src/workflow/develop-start.ts
@@ -193,7 +193,9 @@ export async function startDevelop(
   workflow.issueState = 'OPEN'
   if (launchSnapshot) workflow.issueSnapshot = launchSnapshot.snapshot
   // 首次开工 = 本地无任何开发/返工交付记录;带附加说明也不得误判为返工(issue #54)。
-  const firstDevelopment = !workflow.events.some((event) => event.kind === 'dev' || event.kind === 'rework')
+  const firstDevelopment = !workflow.events.some(
+    (event) => event.kind === 'dev' || event.kind === 'rework' || event.kind === 'resume',
+  )
 
   if (agent === 'dryrun') {
     // A safety probe is not a new durable development generation: never
@@ -275,8 +277,9 @@ export async function startDevelop(
               agent,
               head,
               fixedIssues,
-              extraContext !== '' && !firstDevelopment ? 'rework' : 'dev',
+              firstDevelopment ? 'dev' : 'rework',
               extraContext,
+              live.taskId,
             )
           }
           await saveWorkflow(reloaded)

--- a/src/workflow/develop-start.ts
+++ b/src/workflow/develop-start.ts
@@ -44,6 +44,7 @@ import {
 } from '../infra/runtime.ts'
 import { applyDevRunOutcome, type IssueWorkflow, issueKey, loadWorkflow, saveWorkflow } from '../infra/state.ts'
 import { deriveAutoDevelopment } from './auto-development.ts'
+import { deriveDevelopmentEventKind } from './delivery-audit.ts'
 import { deriveWorkflowState } from './derive.ts'
 import { checkIssueContract } from './issue-contract.ts'
 import { firstDevelopmentFor } from './repository-state.ts'
@@ -278,7 +279,7 @@ export async function startDevelop(
               agent,
               head,
               fixedIssues,
-              firstDevelopment ? 'dev' : 'rework',
+              deriveDevelopmentEventKind(firstDevelopment, extraContext),
               extraContext,
               live.taskId,
               durationMs,

--- a/src/workflow/resume.ts
+++ b/src/workflow/resume.ts
@@ -136,7 +136,7 @@ export async function resumeDevelop(
           // rework 完成:旧的 review 结论已归档到 events,回到"待 review",
           // 不能继续显示"Review 未通过"让用户无限重复点
           const head = await readWorktreeHead(ctx, workflow.worktree)
-          await recordDevDelivery(ctx, reloaded, agent, head, fixedIssues, 'rework', extraContext)
+          await recordDevDelivery(ctx, reloaded, agent, head, fixedIssues, 'resume', extraContext, live.taskId)
         }
         await saveWorkflow(reloaded)
       }

--- a/src/workflow/review-flow.ts
+++ b/src/workflow/review-flow.ts
@@ -48,7 +48,7 @@ import {
 } from '../infra/state.ts'
 import { buildDevComment, buildReviewComment } from './delivery-comment.ts'
 import { deriveEventRound } from './delivery-audit.ts'
-import { extractGithubCommentUrl } from './delivery-publication.ts'
+import { extractGithubCommentId, extractGithubCommentUrl } from './delivery-publication.ts'
 import { type ReviewIssueContract } from './merge-gates.ts'
 import { workflowBaseBranch } from './state-view.ts'
 
@@ -221,7 +221,7 @@ export async function startReview(
       const { passed, issues } = resolved.result
       const reloaded = await loadWorkflow(workflow.key)
       if (reloaded) {
-        const round = deriveEventRound(reloaded.events, 'review')
+        const round = deriveEventRound(reloaded.events)
         const stats = await readDeliveryStats(
           ctx,
           reloaded.worktree,
@@ -313,7 +313,7 @@ export async function recordDevDelivery(
     const pr = await detectLinkedPr(ctx, workflow.repoKey, workflow.branch)
     if (pr) workflow.prNumber = pr
   }
-  const round = deriveEventRound(workflow.events, kind)
+  const round = deriveEventRound(workflow.events)
   const stats = head
     ? await readDeliveryStats(ctx, workflow.worktree, workflowBaseBranch(workflow.baseRef), head)
     : undefined
@@ -343,6 +343,45 @@ export async function recordDevDelivery(
     at: event.at,
   })
   await publishDeliveryComment(ctx, workflow, event, body)
+  if (fixedIssues.length > 0 && kind !== 'dev') await markPreviousReviewFixed(ctx, workflow, round, agent)
+}
+
+async function markPreviousReviewFixed(
+  ctx: Context,
+  workflow: IssueWorkflow,
+  fixedRound: number,
+  fallbackAgent: 'codex' | 'claude',
+): Promise<void> {
+  const reviewEvent = [...workflow.events]
+    .reverse()
+    .find((candidate) => candidate.kind === 'review' && candidate.verdict?.passed === false)
+  if (!reviewEvent?.verdict) return
+  const commentUrl = reviewEvent.publication?.url ?? workflow.reviewResult?.commentUrl
+  const commentId = commentUrl ? extractGithubCommentId(commentUrl) : undefined
+  if (!commentId) return
+  const issueNumber = parseUrl(workflow.url)?.number ?? 'unknown'
+  const body = buildReviewComment({
+    commit: reviewEvent.hash ?? 'unknown',
+    issueNumber,
+    passed: false,
+    issues: reviewEvent.verdict.issues,
+    agent: reviewEvent.agent ?? workflow.reviewAgent ?? fallbackAgent,
+    round: reviewEvent.round ?? Math.max(1, fixedRound - 1),
+    fixedRound,
+    stats: reviewEvent.stats,
+    at: reviewEvent.at,
+  })
+  try {
+    await runCommand(
+      ctx,
+      `gh api ${shellQuote(`repos/${workflow.repoKey}/issues/comments/${commentId}`)} --method PATCH --input -`,
+      { stdin: JSON.stringify({ body }), timeoutMs: 30000 },
+    )
+    await appendLog(workflow.key, 'dev', `[clickvibe] 已标注上一轮 Review 评论:第 ${fixedRound} 轮已修复`)
+  } catch (error) {
+    const message = String(error instanceof Error ? error.message : error).slice(0, 500)
+    await appendLog(workflow.key, 'dev', `[clickvibe] Review 评论修复标注失败(不影响交付): ${message}`)
+  }
 }
 
 /** Publish a public delivery node without pretending a failed write succeeded. */

--- a/src/workflow/review-flow.ts
+++ b/src/workflow/review-flow.ts
@@ -28,6 +28,7 @@ import { githubRest } from '../github/rest.ts'
 import { approvePassedReview } from '../github/review-approval.ts'
 import { buildFreshAgentCommand, buildResumeAgentCommand, parseAgent, shellQuote } from '../infra/develop-core.ts'
 import { decodeLiveLogLine } from '../infra/live-output.ts'
+import { readDeliveryStats } from '../infra/git.ts'
 import { clearReviewResultFile, loadReviewResult, REVIEW_RESULT_RELATIVE_PATH } from '../infra/review-result.ts'
 import { type LiveTask, parseUrl, readWorktreeHead, reviewTaskGate, runCommand, taskId } from '../infra/runtime.ts'
 import {
@@ -46,8 +47,10 @@ import {
   type WorkflowEvent,
 } from '../infra/state.ts'
 import { buildDevComment, buildReviewComment } from './delivery-comment.ts'
+import { deriveEventRound } from './delivery-audit.ts'
 import { extractGithubCommentUrl } from './delivery-publication.ts'
 import { type ReviewIssueContract } from './merge-gates.ts'
+import { workflowBaseBranch } from './state-view.ts'
 
 /** Start a review task on the dev branch with codex/claude. */
 export async function startReview(
@@ -217,6 +220,13 @@ export async function startReview(
       const { passed, issues } = resolved.result
       const reloaded = await loadWorkflow(workflow.key)
       if (reloaded) {
+        const round = deriveEventRound(reloaded.events, 'review')
+        const stats = await readDeliveryStats(
+          ctx,
+          reloaded.worktree,
+          workflowBaseBranch(reloaded.baseRef),
+          reviewedHead,
+        )
         reloaded.reviewResult = { passed, issues }
         reloaded.stage = passed ? 'passed' : 'review-ready' // 有问题 → 可回开发(rework)
         // 记录 review 会话 id(供下次 review 续会话)
@@ -225,6 +235,10 @@ export async function startReview(
           kind: 'review',
           at: new Date().toISOString(),
           hash: reviewedHead,
+          round,
+          agent,
+          ...(stats ? { stats } : {}),
+          taskId: live.taskId,
           verdict: { passed, issues },
           issueContract: reviewIssue.contract,
           note: `${agent} review${passed ? ' 通过' : ` 发现 ${issues.length} 个问题`}`,
@@ -239,6 +253,8 @@ export async function startReview(
           passed,
           issues,
           agent,
+          round,
+          stats,
           at: event.at,
         })
         await publishDeliveryComment(ctx, reloaded, event, body)
@@ -286,17 +302,26 @@ export async function recordDevDelivery(
   agent: 'codex' | 'claude',
   head: string | null,
   fixedIssues: string[],
-  kind: 'dev' | 'rework',
+  kind: 'dev' | 'rework' | 'resume',
   userContext = '',
+  taskIdValue?: string,
 ): Promise<void> {
   if (!workflow.prNumber) {
     const pr = await detectLinkedPr(ctx, workflow.repoKey, workflow.branch)
     if (pr) workflow.prNumber = pr
   }
+  const round = deriveEventRound(workflow.events, kind)
+  const stats = head
+    ? await readDeliveryStats(ctx, workflow.worktree, workflowBaseBranch(workflow.baseRef), head)
+    : undefined
   const event: WorkflowEvent = {
     kind,
     at: new Date().toISOString(),
     hash: head ?? undefined,
+    round,
+    agent,
+    ...(stats ? { stats } : {}),
+    ...(taskIdValue ? { taskId: taskIdValue } : {}),
     fixed: fixedIssues.length,
     note: `${agent} 完成开发${kind === 'rework' ? '(按 review 意见返工)' : ''}`,
     // 用户附加说明只进本地事件时间线,不进 GitHub 评论(issue #54)。
@@ -309,6 +334,8 @@ export async function recordDevDelivery(
     issueNumber,
     fixedIssues,
     agent,
+    round,
+    stats,
     at: event.at,
   })
   await publishDeliveryComment(ctx, workflow, event, body)

--- a/tests/delivery-audit.test.ts
+++ b/tests/delivery-audit.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { deriveEventRound } from '../src/workflow/delivery-audit.ts'
+import { deriveDevelopmentEventKind, deriveEventRound, latestDevelopmentHash } from '../src/workflow/delivery-audit.ts'
 
 test('delivery rounds advance only when a review verdict lands', () => {
   const events = [
@@ -9,20 +9,37 @@ test('delivery rounds advance only when a review verdict lands', () => {
     { kind: 'resume', at: '2026-08-23T03:00:00Z', round: 2 },
   ] as const
 
-  assert.equal(deriveEventRound([], 'dev'), 1)
-  assert.equal(deriveEventRound([...events], 'rework'), 2)
-  assert.equal(deriveEventRound([...events], 'review'), 2)
+  assert.equal(deriveEventRound([]), 1)
+  assert.equal(deriveEventRound([...events]), 2)
+  assert.equal(latestDevelopmentHash([...events]), undefined)
 })
 
 test('legacy review events without round still advance the manual workflow round', () => {
   assert.equal(
-    deriveEventRound(
-      [
-        { kind: 'review', at: '2026-08-23T02:00:00Z', verdict: { passed: false, issues: ['旧意见'] } },
-        { kind: 'note', at: '2026-08-23T02:30:00Z', note: 'manual' },
-      ],
-      'resume',
-    ),
+    deriveEventRound([
+      { kind: 'review', at: '2026-08-23T02:00:00Z', verdict: { passed: false, issues: ['旧意见'] } },
+      { kind: 'note', at: '2026-08-23T02:30:00Z', note: 'manual' },
+    ]),
     2,
   )
+})
+
+test('resume is a development delivery and no-review restarts stay dev events', () => {
+  assert.equal(
+    latestDevelopmentHash([
+      { kind: 'dev', at: '2026-08-23T01:00:00Z', hash: 'abc123' },
+      { kind: 'resume', at: '2026-08-23T02:00:00Z', hash: 'def456' },
+    ]),
+    'def456',
+  )
+  assert.equal(
+    latestDevelopmentHash([
+      { kind: 'dev', at: '2026-08-23T01:00:00Z', hash: 'abc123' },
+      { kind: 'resume', at: '2026-08-23T02:00:00Z' },
+    ]),
+    'abc123',
+  )
+  assert.equal(deriveDevelopmentEventKind(true, ''), 'dev')
+  assert.equal(deriveDevelopmentEventKind(false, ''), 'dev')
+  assert.equal(deriveDevelopmentEventKind(false, '按 Review 意见返工'), 'rework')
 })

--- a/tests/delivery-audit.test.ts
+++ b/tests/delivery-audit.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { deriveEventRound } from '../src/workflow/delivery-audit.ts'
+
+test('delivery rounds advance only when a review verdict lands', () => {
+  const events = [
+    { kind: 'dev', at: '2026-08-23T01:00:00Z', round: 1 },
+    { kind: 'review', at: '2026-08-23T02:00:00Z', verdict: { passed: false, issues: ['竞态'] }, round: 1 },
+    { kind: 'resume', at: '2026-08-23T03:00:00Z', round: 2 },
+  ] as const
+
+  assert.equal(deriveEventRound([], 'dev'), 1)
+  assert.equal(deriveEventRound([...events], 'rework'), 2)
+  assert.equal(deriveEventRound([...events], 'review'), 2)
+})
+
+test('legacy review events without round still advance the manual workflow round', () => {
+  assert.equal(
+    deriveEventRound(
+      [
+        { kind: 'review', at: '2026-08-23T02:00:00Z', verdict: { passed: false, issues: ['旧意见'] } },
+        { kind: 'note', at: '2026-08-23T02:30:00Z', note: 'manual' },
+      ],
+      'resume',
+    ),
+    2,
+  )
+})

--- a/tests/delivery-comment.test.ts
+++ b/tests/delivery-comment.test.ts
@@ -93,3 +93,19 @@ test('failed review comment lists every issue and points to rework', () => {
   assert.match(body, /- 竞态\n- 缺测试/)
   assert.match(body, /下一步:请重新开发并处理上述问题。/)
 })
+
+test('failed review comment can be updated to mark every issue fixed in a later round', () => {
+  const body = buildReviewComment({
+    commit: '3fb7db6',
+    issueNumber: '20',
+    passed: false,
+    issues: ['竞态', '缺测试'],
+    agent: 'claude',
+    round: 1,
+    fixedRound: 2,
+    at: '2026-08-22T10:00:00Z',
+  })
+  assert.match(body, /- fixed-round: 2/)
+  assert.match(body, /- \[已于第 2 轮修复\] 竞态\n- \[已于第 2 轮修复\] 缺测试/)
+  assert.match(body, /第 2 轮修复已交付，请 Review 当前提交。/)
+})

--- a/tests/delivery-comment.test.ts
+++ b/tests/delivery-comment.test.ts
@@ -8,6 +8,8 @@ test('dev comment starts with the standard flat meta block and lists fixed revie
     issueNumber: '20',
     fixedIssues: ['修复竞态', '补充失败测试'],
     agent: 'codex',
+    round: 2,
+    stats: { commits: [], filesChanged: 3, insertions: 18, deletions: 4, diffstat: [] },
     at: '2026-08-22T09:00:00.000Z',
   })
   assert.equal(
@@ -19,6 +21,8 @@ test('dev comment starts with the standard flat meta block and lists fixed revie
       '- issue: #20',
       '- fixed: 2',
       '- next: review',
+      '- round: 2',
+      '- stats: commits=0 filesChanged=3 insertions=18 deletions=4',
       '- agent: codex',
       '- at: 2026-08-22T09:00:00.000Z',
       '',
@@ -30,8 +34,8 @@ test('dev comment starts with the standard flat meta block and lists fixed revie
       '',
       '已处理上一轮 Review 的 2 个问题:',
       '',
-      '- 修复竞态',
-      '- 补充失败测试',
+      '- [已于第 2 轮修复] 修复竞态',
+      '- [已于第 2 轮修复] 补充失败测试',
       '',
       '下一步:请 Review 当前提交。',
     ].join('\n'),
@@ -44,9 +48,10 @@ test('initial dev delivery has fixed zero and still includes a delivery summary'
     issueNumber: '20',
     fixedIssues: [],
     agent: 'claude',
+    round: 1,
     at: '2026-08-22T09:00:00Z',
   })
-  assert.match(body, /- fixed: 0\n- next: review\n- agent: claude/)
+  assert.match(body, /- fixed: 0\n- next: review\n- round: 1\n- stats: unavailable\n- agent: claude/)
   assert.match(body, /### 本次交付摘要\n\n已完成本轮 Issue 需求实现。/)
 })
 
@@ -57,10 +62,19 @@ test('passed review comment points to merge', () => {
     passed: true,
     issues: [],
     agent: 'codex',
+    round: 1,
+    stats: {
+      commits: [{ hash: '3fb7db6', subject: 'ship' }],
+      filesChanged: 1,
+      insertions: 2,
+      deletions: 0,
+      diffstat: [],
+    },
     at: '2026-08-22T10:00:00Z',
   })
   assert.ok(body.startsWith('== Review Meta ==\n- event: review'))
   assert.match(body, /- passed: true\n- next: merge/)
+  assert.match(body, /- next: merge\n- round: 1\n- stats: commits=1 filesChanged=1 insertions=2 deletions=0/)
   assert.match(body, /✅ ClickVibe Review 通过/)
   assert.match(body, /下一步:可合并当前提交。/)
 })
@@ -72,6 +86,7 @@ test('failed review comment lists every issue and points to rework', () => {
     passed: false,
     issues: ['竞态', '缺测试'],
     agent: 'claude',
+    round: 1,
     at: '2026-08-22T10:00:00Z',
   })
   assert.match(body, /- passed: false\n- next: rework/)

--- a/tests/delivery-publication.test.ts
+++ b/tests/delivery-publication.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { deliveryPublicationLabel, extractGithubCommentUrl } from '../src/workflow/delivery-publication.ts'
+import {
+  deliveryPublicationLabel,
+  extractGithubCommentId,
+  extractGithubCommentUrl,
+} from '../src/workflow/delivery-publication.ts'
 
 test('comment URL extraction selects the first valid GitHub comment URL amid extra output', () => {
   assert.equal(
@@ -20,6 +24,12 @@ test('comment URL extraction rejects non-comment and non-GitHub URLs', () => {
   assert.equal(extractGithubCommentUrl('https://example.com/o/r/pull/35#issuecomment-123'), undefined)
   assert.equal(extractGithubCommentUrl('https://github.com/o/r/pull/35'), undefined)
   assert.equal(extractGithubCommentUrl('warning only'), undefined)
+})
+
+test('comment ID extraction accepts issue and pull comment URLs only', () => {
+  assert.equal(extractGithubCommentId('https://github.com/o/r/pull/35#issuecomment-123'), '123')
+  assert.equal(extractGithubCommentId('https://github.com/o/r/issues/35#issuecomment-456'), '456')
+  assert.equal(extractGithubCommentId('https://example.com/o/r/pull/35#issuecomment-123'), undefined)
 })
 
 test('failed publication renders the explicit GitHub failure label', () => {

--- a/tests/delivery-timeline.test.ts
+++ b/tests/delivery-timeline.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { deriveDeliveryTimelineItem } from '../src/client/delivery-timeline.ts'
+
+test('dev timeline projection exposes frozen summary, diffstat and log anchor', () => {
+  const item = deriveDeliveryTimelineItem({
+    kind: 'rework',
+    at: '2026-08-23T03:00:00Z',
+    hash: 'def456',
+    round: 2,
+    agent: 'codex',
+    fixed: 2,
+    taskId: 'dev-123-token',
+    stats: {
+      commits: [{ hash: 'def456', subject: '修复竞态' }],
+      filesChanged: 2,
+      insertions: 14,
+      deletions: 3,
+      diffstat: [{ path: 'src/a.ts', insertions: 14, deletions: 3 }],
+    },
+  })
+
+  assert.equal(item.kindLabel, '返工')
+  assert.equal(item.summary, '第 2 轮 · Codex · 2 文件 · +14/-3 · 处理 2 条意见')
+  assert.equal(item.detail.kind, 'development')
+  assert.deepEqual(item.detail.commits, [{ hash: 'def456', subject: '修复竞态' }])
+  assert.equal(item.detail.taskId, 'dev-123-token')
+})
+
+test('review projection preserves historical issue text and legacy events degrade safely', () => {
+  const review = deriveDeliveryTimelineItem({
+    kind: 'review',
+    at: '2026-08-23T02:00:00Z',
+    round: 1,
+    agent: 'claude',
+    verdict: { passed: false, issues: ['竞态条件', '缺少失败测试'] },
+  })
+  assert.equal(review.summary, '第 1 轮 · Claude · 2 条意见')
+  assert.deepEqual(review.detail, { kind: 'review', issues: ['竞态条件', '缺少失败测试'] })
+
+  const passed = deriveDeliveryTimelineItem({
+    kind: 'review',
+    at: '2026-08-23T04:00:00Z',
+    round: 2,
+    agent: 'codex',
+    verdict: { passed: true, issues: [] },
+  })
+  assert.equal(passed.summary, '第 2 轮 · Codex · 0 条意见')
+
+  const legacy = deriveDeliveryTimelineItem({ kind: 'dev', at: '2026-08-22T01:00:00Z', hash: 'old123' })
+  assert.equal(legacy.summary, '')
+  assert.equal(legacy.detail.kind, 'development')
+})

--- a/tests/delivery-timeline.test.ts
+++ b/tests/delivery-timeline.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { deriveDeliveryTimelineItem } from '../src/client/delivery-timeline.ts'
+import { latestDevelopmentEvent } from '../src/client/runtime.ts'
 
 test('dev timeline projection exposes frozen summary, diffstat and log anchor', () => {
   const item = deriveDeliveryTimelineItem({
@@ -50,4 +51,16 @@ test('review projection preserves historical issue text and legacy events degrad
   const legacy = deriveDeliveryTimelineItem({ kind: 'dev', at: '2026-08-22T01:00:00Z', hash: 'old123' })
   assert.equal(legacy.summary, '')
   assert.equal(legacy.detail.kind, 'development')
+})
+
+test('resume delivery remains the latest development summary', () => {
+  const resumed = { kind: 'resume', at: '2026-08-23T03:00:00Z', hash: 'def456', fixed: 2 } as const
+  assert.equal(
+    latestDevelopmentEvent([
+      { kind: 'dev', at: '2026-08-23T01:00:00Z', hash: 'abc123' },
+      { kind: 'review', at: '2026-08-23T02:00:00Z', verdict: { passed: false, issues: ['竞态'] } },
+      resumed,
+    ]),
+    resumed,
+  )
 })

--- a/tests/git-delivery-stats.test.ts
+++ b/tests/git-delivery-stats.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { readDeliveryStats } from '../src/infra/git.ts'
+
+test('delivery stats freeze commits and numstat from the fork point to the anchored head', async () => {
+  const commands: string[] = []
+  const ctx = {
+    shell: {
+      resolve(spec: { command: string }) {
+        commands.push(spec.command)
+        return spec
+      },
+      async run(spec: { command: string }) {
+        if (spec.command.startsWith('git merge-base ')) {
+          return { exitCode: 0, stdout: { text: 'base123\n' }, stderr: { text: '' } }
+        }
+        if (spec.command.startsWith('git log ')) {
+          return {
+            exitCode: 0,
+            stdout: { text: 'abc123\u001f补充测试\ndef456\u001f实现审计\n' },
+            stderr: { text: '' },
+          }
+        }
+        if (spec.command.startsWith('git diff --numstat ')) {
+          return {
+            exitCode: 0,
+            stdout: { text: '10\t2\tsrc/a.ts\n-\t-\tassets/logo.png\n3\t0\tsrc/b.ts\n' },
+            stderr: { text: '' },
+          }
+        }
+        return { exitCode: 1, stdout: { text: '' }, stderr: { text: 'unexpected' } }
+      },
+    },
+  }
+
+  const stats = await readDeliveryStats(ctx as never, '/worktree', 'main', 'head789')
+
+  assert.deepEqual(stats, {
+    commits: [
+      { hash: 'abc123', subject: '补充测试' },
+      { hash: 'def456', subject: '实现审计' },
+    ],
+    filesChanged: 3,
+    insertions: 13,
+    deletions: 2,
+    diffstat: [
+      { path: 'src/a.ts', insertions: 10, deletions: 2 },
+      { path: 'assets/logo.png', insertions: null, deletions: null },
+      { path: 'src/b.ts', insertions: 3, deletions: 0 },
+    ],
+  })
+  assert.equal(commands.length, 3)
+  assert.match(commands[1], /base123\.\.head789/)
+  assert.match(commands[2], /base123\.\.head789/)
+})
+
+test('delivery stats fail soft when the fork point cannot be resolved', async () => {
+  const ctx = {
+    shell: {
+      resolve(spec: { command: string }) {
+        return spec
+      },
+      async run() {
+        return { exitCode: 1, stdout: { text: '' }, stderr: { text: 'missing ref' } }
+      },
+    },
+  }
+  assert.equal(await readDeliveryStats(ctx as never, '/worktree', 'main', 'head789'), undefined)
+})

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -1484,12 +1484,20 @@ test('invalid exact dev session falls back once to a fresh session on the same t
       kind: 'review',
       at: '2026-08-22T00:00:00Z',
       hash: 'old123',
+      round: 1,
+      agent: 'claude',
       verdict: { passed: false, issues: ['修复竞态', '补充失败测试'] },
+      publication: {
+        target: 'pr',
+        status: 'posted',
+        url: 'https://github.com/o/r/pull/29#issuecomment-99',
+      },
     })
     await saveWorkflow(workflow)
     await appendLog(workflow.key, 'dev', 'prior run must be rotated')
     const starts: Array<{ command: string; workdir?: string; prompt: string }> = []
     const comments: Array<{ command: string; body: string }> = []
+    const reviewUpdates: Array<{ command: string; body: string }> = []
     const currentIssue = {
       url: workflow.url,
       title: 'resume issue',
@@ -1506,6 +1514,10 @@ test('invalid exact dev session falls back once to a fresh session on the same t
     ]
     const handler = createHandler(
       async (spec) => {
+        if (spec.command.includes('/issues/comments/99') && spec.command.includes('PATCH')) {
+          reviewUpdates.push({ command: spec.command, body: spec.stdin ?? '' })
+          return { exitCode: 0, stdout: { text: '{}' }, stderr: { text: '' } }
+        }
         const api = githubApi(spec.command, { item: currentIssue, prComments: reviewComments })
         if (api) return api
         if (spec.command === 'git rev-parse --short HEAD')
@@ -1597,6 +1609,9 @@ test('invalid exact dev session falls back once to a fresh session on the same t
     assert.equal(reloaded?.devSessionId, 'new-session')
     assert.equal(reloaded?.devSessionAgent, 'codex')
     assert.equal(comments.length, 1)
+    assert.equal(reviewUpdates.length, 1)
+    assert.match(JSON.parse(reviewUpdates[0].body).body, /- \[已于第 2 轮修复\] 修复竞态/)
+    assert.match(JSON.parse(reviewUpdates[0].body).body, /- \[已于第 2 轮修复\] 补充失败测试/)
     assert.match(comments[0].command, /github\.com\/o\/r\/pull\/29/)
     assert.match(comments[0].body, /^== Dev Meta ==\n- event: dev\n- commit: abc123\n- issue: #917\n- fixed: 2/m)
     assert.match(comments[0].body, /- round: 2\n- stats: commits=1 filesChanged=1 insertions=12 deletions=3/)

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -1479,6 +1479,12 @@ test('invalid exact dev session falls back once to a fresh session on the same t
     await mkdir(worktree, { recursive: true })
     const workflow = interruptedWorkflow('o-r-917', 'https://github.com/o/r/issues/917', worktree)
     workflow.reviewResult = { passed: false, issues: ['修复竞态', '补充失败测试'] }
+    workflow.events.push({
+      kind: 'review',
+      at: '2026-08-22T00:00:00Z',
+      hash: 'old123',
+      verdict: { passed: false, issues: ['修复竞态', '补充失败测试'] },
+    })
     await saveWorkflow(workflow)
     await appendLog(workflow.key, 'dev', 'prior run must be rotated')
     const starts: Array<{ command: string; workdir?: string; prompt: string }> = []
@@ -1503,6 +1509,12 @@ test('invalid exact dev session falls back once to a fresh session on the same t
         if (api) return api
         if (spec.command === 'git rev-parse --short HEAD')
           return { exitCode: 0, stdout: { text: 'abc123' }, stderr: { text: '' } }
+        if (spec.command.startsWith('git merge-base '))
+          return { exitCode: 0, stdout: { text: 'base123\n' }, stderr: { text: '' } }
+        if (spec.command.startsWith('git log '))
+          return { exitCode: 0, stdout: { text: 'abc123\u001f修复 review 意见\n' }, stderr: { text: '' } }
+        if (spec.command.startsWith('git diff --numstat '))
+          return { exitCode: 0, stdout: { text: '12\t3\tsrc/fix.ts\n' }, stderr: { text: '' } }
         if (spec.command.startsWith('gh issue comment')) {
           comments.push({ command: spec.command, body: spec.stdin ?? '' })
           return {
@@ -1586,9 +1598,22 @@ test('invalid exact dev session falls back once to a fresh session on the same t
     assert.equal(comments.length, 1)
     assert.match(comments[0].command, /github\.com\/o\/r\/pull\/29/)
     assert.match(comments[0].body, /^== Dev Meta ==\n- event: dev\n- commit: abc123\n- issue: #917\n- fixed: 2/m)
-    assert.match(comments[0].body, /- 修复竞态\n- 补充失败测试/)
-    assert.equal(reloaded?.events.at(-1)?.publication?.status, 'posted')
-    assert.equal(reloaded?.events.at(-1)?.publication?.target, 'pr')
+    assert.match(comments[0].body, /- round: 2\n- stats: commits=1 filesChanged=1 insertions=12 deletions=3/)
+    assert.match(comments[0].body, /- \[已于第 2 轮修复\] 修复竞态\n- \[已于第 2 轮修复\] 补充失败测试/)
+    const delivery = reloaded?.events.at(-1)
+    assert.equal(delivery?.kind, 'resume')
+    assert.equal(delivery?.round, 2)
+    assert.equal(delivery?.agent, 'codex')
+    assert.equal(delivery?.taskId, resumed.body.taskId)
+    assert.deepEqual(delivery?.stats, {
+      commits: [{ hash: 'abc123', subject: '修复 review 意见' }],
+      filesChanged: 1,
+      insertions: 12,
+      deletions: 3,
+      diffstat: [{ path: 'src/fix.ts', insertions: 12, deletions: 3 }],
+    })
+    assert.equal(delivery?.publication?.status, 'posted')
+    assert.equal(delivery?.publication?.target, 'pr')
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
@@ -1927,6 +1952,12 @@ test('invalid exact review session clears the stale id and falls back to a fresh
         if (api) return api
         if (spec.command === 'git rev-parse --short HEAD')
           return { exitCode: 0, stdout: { text: 'abc123' }, stderr: { text: '' } }
+        if (spec.command.startsWith('git merge-base '))
+          return { exitCode: 0, stdout: { text: 'base123\n' }, stderr: { text: '' } }
+        if (spec.command.startsWith('git log '))
+          return { exitCode: 0, stdout: { text: 'abc123\u001f完成实现\n' }, stderr: { text: '' } }
+        if (spec.command.startsWith('git diff --numstat '))
+          return { exitCode: 0, stdout: { text: '8\t1\tsrc/reviewed.ts\n' }, stderr: { text: '' } }
         if (spec.command.startsWith('gh issue comment')) {
           comments.push({ command: spec.command, body: spec.stdin ?? '' })
           return {
@@ -2019,6 +2050,10 @@ test('invalid exact review session clears the stale id and falls back to a fresh
       bodyHash: issueBodyHash(reviewedBody),
       updatedAt: reviewedUpdatedAt,
     })
+    assert.equal(reloaded?.events.at(-1)?.round, 1)
+    assert.equal(reloaded?.events.at(-1)?.agent, 'codex')
+    assert.equal(reloaded?.events.at(-1)?.taskId, reviewed.body.taskId)
+    assert.equal(reloaded?.events.at(-1)?.stats?.filesChanged, 1)
     assert.ok(completed.delta.some((line) => line.includes('review 结束,退出码 0')))
     assert.ok(completed.delta.some((line) => line.includes('review 结论来源')))
     assert.equal(reloaded?.reviewResult?.commentUrl, 'https://github.com/o/r/pull/29#issuecomment-2')
@@ -3433,7 +3468,7 @@ test('resume (rework) carries the user context next to the review feedback and a
     assert.match(prompts[0], /修复竞态/)
     assert.match(prompts[0], /重点先修竞态,再补并发测试/)
     const reloaded = await loadWorkflow(workflow.key)
-    assert.equal(reloaded?.events.at(-1)?.kind, 'rework')
+    assert.equal(reloaded?.events.at(-1)?.kind, 'resume')
     assert.equal(reloaded?.events.at(-1)?.userContext, userContext)
   } finally {
     if (previousHome === undefined) delete process.env.HOME


### PR DESCRIPTION
Closes #73

## 变更

- WorkflowEvent 在 dev/rework/resume/review 完成时冻结轮次、实际 agent、fork point 到锚定 HEAD 的提交与 diffstat，并关联结构化任务日志。
- GitHub Dev/Review Meta 写入 round 与 stats；返工交付后原位更新失败 Review 评论，逐条标注已于第 N 轮修复。
- 交付流水新增可兼容旧事件的摘要投影和右侧审计抽屉，可查看历史 Review 意见全文、提交列表、逐文件 diffstat、日志与评论发布链接。
- 已合并最新 origin/main，保留并组合后续主线能力。

## Review 返工

- resume 事件纳入服务端 lastDevHash 与客户端最近交付推导，避免交付后持续误报新提交。
- 无 Review 上下文的再次开发继续记录为 dev，事件分类与既有 prompt 契约一致。
- deriveEventRound 移除无效 kind 参数。
- 返工完成后通过原评论 ID 更新失败 Review 评论；更新失败仅写入开发日志，不篡改既有发布成功事实。
- 新增纯函数与路由测试覆盖上述路径。

## 验证

- pnpm install --frozen-lockfile
- pnpm run typecheck
- pnpm run build
- pnpm test（268 passed）
- pnpm run coverage（lines 93.19%，functions 88.81%）
- pnpm run lint
- pnpm run format:check
- pnpm run check:size
- pnpm run check:layers

## 人工验收

- 仍需在加载新 bundle 的 Host 上跑一条含打回返工的 issue，核对两轮历史意见、摘要、日志锚点及失败 Review 评论的修复轮次标注。该人工门禁未由单测替代。