### PR TITLE
feat: 任务日志数据全量保留

### DIFF
--- a/src/agent/agent-stream.ts
+++ b/src/agent/agent-stream.ts
@@ -119,11 +119,7 @@ export function parseCodexEvent(line: string): StatusLine[] {
         }
         case 'command_execution':
           if (item.command) out.push({ kind: 'command', text: `$ ${item.command}` })
-          if (item.aggregated_output) {
-            for (const output of item.aggregated_output.replace(/\s+$/, '').split(/\r?\n/)) {
-              if (output !== '') out.push({ kind: 'command_output', text: output })
-            }
-          }
+          if (item.aggregated_output) out.push({ kind: 'command_output', text: item.aggregated_output })
           break
         case 'reasoning':
           if (item.text) out.push({ kind: 'reasoning', text: `◌ ${item.text}` })

--- a/src/agent/agent-stream.ts
+++ b/src/agent/agent-stream.ts
@@ -18,52 +18,45 @@ export interface StatusLine {
   usage?: TokenUsage
 }
 
-/** Trim a string to a bounded single line for display. */
-function oneLine(value: string, max = 140): string {
-  const collapsed = value.replace(/\s+/g, ' ').trim()
-  return collapsed.length > max ? `${collapsed.slice(0, max)}…` : collapsed
-}
-
 /** Classify a tool name into a friendly "current action" label. */
 function toolLabel(name: string, args: string): string {
-  const short = oneLine(args, 80)
   switch (name) {
     case 'bash':
     case 'shell':
     case 'execute_command':
-      return `🔧 执行命令: ${short}`
+      return `🔧 执行命令: ${args}`
     case 'read':
     case 'read_file':
     case 'fs.read':
     case 'View':
-      return `📖 读取文件: ${short}`
+      return `📖 读取文件: ${args}`
     case 'write':
     case 'write_file':
     case 'fs.write':
     case 'Edit':
-      return `✍️ 修改文件: ${short}`
+      return `✍️ 修改文件: ${args}`
     case 'apply_patch':
     case 'MultiEdit':
-      return `🩹 应用补丁: ${short}`
+      return `🩹 应用补丁: ${args}`
     case 'git':
     case 'git_diff':
-      return `🌿 git: ${short}`
+      return `🌿 git: ${args}`
     case 'gh':
-      return `🐙 gh: ${short}`
+      return `🐙 gh: ${args}`
     case 'web_search':
     case 'WebSearch':
-      return `🔍 搜索: ${short}`
+      return `🔍 搜索: ${args}`
     case 'web_fetch':
     case 'WebFetch':
-      return `🌐 抓取网页: ${short}`
+      return `🌐 抓取网页: ${args}`
     case 'subagent':
     case 'task':
-      return `🤖 子代理: ${short}`
+      return `🤖 子代理: ${args}`
     case 'ask_user_question':
     case 'AskUserQuestion':
-      return `❓ 提问: ${short}`
+      return `❓ 提问: ${args}`
     default:
-      return `🛠️ ${name}: ${short}`
+      return `🛠️ ${name}: ${args}`
   }
 }
 
@@ -109,9 +102,7 @@ export function parseCodexEvent(line: string): StatusLine[] {
       const item = event.item ?? {}
       switch (item.type) {
         case 'agent_message':
-          // 结论类消息必须保留完整内容(截断会丢失 review 条目),
-          // 所以消息截断上限远大于工具行
-          out.push({ kind: 'message', text: `💬 ${oneLine(item.text ?? '', 4000)}` })
+          out.push({ kind: 'message', text: `💬 ${item.text ?? ''}` })
           break
         case 'function_call': {
           let args = ''
@@ -127,7 +118,7 @@ export function parseCodexEvent(line: string): StatusLine[] {
           break
         }
         case 'command_execution':
-          if (item.command) out.push({ kind: 'command', text: `$ ${oneLine(item.command, 1000)}` })
+          if (item.command) out.push({ kind: 'command', text: `$ ${item.command}` })
           if (item.aggregated_output) {
             for (const output of item.aggregated_output.replace(/\s+$/, '').split(/\r?\n/)) {
               if (output !== '') out.push({ kind: 'command_output', text: output })
@@ -135,7 +126,7 @@ export function parseCodexEvent(line: string): StatusLine[] {
           }
           break
         case 'reasoning':
-          if (item.text) out.push({ kind: 'reasoning', text: `◌ ${oneLine(item.text, 4000)}` })
+          if (item.text) out.push({ kind: 'reasoning', text: `◌ ${item.text}` })
           break
         case 'token_count': {
           const usage = tokenUsage(item)
@@ -143,7 +134,7 @@ export function parseCodexEvent(line: string): StatusLine[] {
           break
         }
         case 'error':
-          out.push({ kind: 'text', text: `⚠️ ${oneLine(item.text ?? 'error')}` })
+          out.push({ kind: 'text', text: `⚠️ ${item.text ?? 'error'}` })
           break
         default:
           break
@@ -177,11 +168,11 @@ export function parseClaudeEvent(line: string): StatusLine[] {
     case 'assistant': {
       for (const block of event.message?.content ?? []) {
         if (block.type === 'text' && block.text) {
-          out.push({ kind: 'message', text: `💬 ${oneLine(block.text, 4000)}` })
+          out.push({ kind: 'message', text: `💬 ${block.text}` })
         } else if (block.type === 'thinking' && (block.thinking || block.text)) {
-          out.push({ kind: 'thinking', text: `◌ ${oneLine(block.thinking ?? block.text ?? '', 4000)}` })
+          out.push({ kind: 'thinking', text: `◌ ${block.thinking ?? block.text ?? ''}` })
         } else if (block.type === 'tool_use' && block.name) {
-          const args = block.input ? oneLine(JSON.stringify(block.input), 80) : ''
+          const args = block.input ? JSON.stringify(block.input) : ''
           out.push({ kind: 'tool', text: toolLabel(block.name, args) })
         }
       }

--- a/src/agent/task-supervisor.ts
+++ b/src/agent/task-supervisor.ts
@@ -19,6 +19,7 @@
  */
 import type { Context } from '@deepseek-ai/cordis'
 import { type DevelopAgent, LineLog, shouldFallbackFromExactResume } from '../infra/develop-core.ts'
+import { LineBuffer } from '../infra/line-buffer.ts'
 import { encodeLiveLogEvent, type LiveLogEvent } from '../infra/live-output.ts'
 import {
   type LiveTask,
@@ -60,8 +61,7 @@ export function createLiveTask(
     agent,
     startedAt: Date.now(),
     log: new LineLog(TASK_LOG_LINES),
-    rawLog: new LineLog(),
-    rawCursor: 0,
+    rawLog: new LineBuffer(),
     closed: false,
     status: 'running',
     exitCode: null,
@@ -163,12 +163,10 @@ export function attachAgentProcess(
     // 轮询读取 agent 输出,解析为状态行,写入内存缓冲 + 落盘日志
     const drain = (flush = false) => {
       const read = process.readOutput()
-      if (read.delta !== '') task.rawLog.appendChunk(read.delta)
-      if (flush) task.rawLog.flush()
-      const raw = task.rawLog.read(task.rawCursor)
-      task.rawCursor = raw.cursor
-      if (raw.lines.length > 0) {
-        const parsed = parseAgentChunk(task.agent as AgentKind, raw.lines.join('\n'))
+      const rawLines = read.delta === '' ? [] : task.rawLog.appendChunk(read.delta)
+      if (flush) rawLines.push(...task.rawLog.flush())
+      if (rawLines.length > 0) {
+        const parsed = parseAgentChunk(task.agent as AgentKind, rawLines.join('\n'))
         for (const line of parsed.lines) {
           pushTaskLine(task, {
             source: 'agent',
@@ -183,7 +181,7 @@ export function attachAgentProcess(
           task.sessionId = parsed.sessionId
         }
       }
-      if (raw.truncated || read.lossy) {
+      if (read.lossy) {
         pushTaskLine(task, '[clickvibe] Agent 原始输出被截断(日志过长)')
       }
     }

--- a/src/agent/task-supervisor.ts
+++ b/src/agent/task-supervisor.ts
@@ -60,7 +60,7 @@ export function createLiveTask(
     agent,
     startedAt: Date.now(),
     log: new LineLog(TASK_LOG_LINES),
-    rawLog: new LineLog(TASK_LOG_LINES),
+    rawLog: new LineLog(),
     rawCursor: 0,
     closed: false,
     status: 'running',

--- a/src/infra/develop-core.ts
+++ b/src/infra/develop-core.ts
@@ -157,23 +157,25 @@ export interface LogRead {
   truncated: boolean
 }
 
-/** Line-count-bounded, non-destructive log with independent cursor readers. */
+/** Optionally line-count-bounded, non-destructive log with independent cursor readers. */
 export class LineLog {
-  readonly #limit: number
+  readonly #limit: number | null
   #entries: LogEntry[] = []
   #partial = ''
   #pendingCr = false
   #sequence = 0
 
-  constructor(limit: number) {
-    if (!Number.isSafeInteger(limit) || limit < 1) throw new Error('log limit must be positive')
-    this.#limit = limit
+  constructor(limit?: number) {
+    if (limit !== undefined && (!Number.isSafeInteger(limit) || limit < 1)) {
+      throw new Error('log limit must be positive')
+    }
+    this.#limit = limit ?? null
   }
 
   appendLine(line: string): number {
     this.#sequence += 1
     this.#entries.push({ sequence: this.#sequence, line })
-    if (this.#entries.length > this.#limit) {
+    if (this.#limit !== null && this.#entries.length > this.#limit) {
       this.#entries.splice(0, this.#entries.length - this.#limit)
     }
     return this.#sequence

--- a/src/infra/develop-core.ts
+++ b/src/infra/develop-core.ts
@@ -157,13 +157,11 @@ export interface LogRead {
   truncated: boolean
 }
 
-/** Bounded, non-destructive line log with independent cursor readers. */
+/** Line-count-bounded, non-destructive log with independent cursor readers. */
 export class LineLog {
-  static readonly MAX_LINE_CHARS = 64 * 1024
   readonly #limit: number
   #entries: LogEntry[] = []
   #partial = ''
-  #discardPartial = false
   #pendingCr = false
   #sequence = 0
 
@@ -173,12 +171,8 @@ export class LineLog {
   }
 
   appendLine(line: string): number {
-    const bounded =
-      line.length > LineLog.MAX_LINE_CHARS
-        ? `${line.slice(0, LineLog.MAX_LINE_CHARS)}… [clickvibe] 单行日志已截断`
-        : line
     this.#sequence += 1
-    this.#entries.push({ sequence: this.#sequence, line: bounded })
+    this.#entries.push({ sequence: this.#sequence, line })
     if (this.#entries.length > this.#limit) {
       this.#entries.splice(0, this.#entries.length - this.#limit)
     }
@@ -187,9 +181,8 @@ export class LineLog {
 
   appendChunk(chunk: string): void {
     const endLine = () => {
-      if (!this.#discardPartial) this.appendLine(this.#partial)
+      this.appendLine(this.#partial)
       this.#partial = ''
-      this.#discardPartial = false
     }
     for (const character of chunk) {
       if (this.#pendingCr) {
@@ -201,13 +194,8 @@ export class LineLog {
         this.#pendingCr = true
       } else if (character === '\n') {
         endLine()
-      } else if (!this.#discardPartial) {
+      } else {
         this.#partial += character
-        if (this.#partial.length > LineLog.MAX_LINE_CHARS) {
-          this.appendLine(this.#partial)
-          this.#partial = ''
-          this.#discardPartial = true
-        }
       }
     }
   }
@@ -215,12 +203,11 @@ export class LineLog {
   flush(): void {
     if (this.#pendingCr) {
       this.#pendingCr = false
-      if (!this.#discardPartial) this.appendLine(this.#partial)
-    } else if (this.#partial !== '' && !this.#discardPartial) {
+      this.appendLine(this.#partial)
+    } else if (this.#partial !== '') {
       this.appendLine(this.#partial)
     }
     this.#partial = ''
-    this.#discardPartial = false
   }
 
   read(cursor: number): LogRead {

--- a/src/infra/develop-core.ts
+++ b/src/infra/develop-core.ts
@@ -157,25 +157,23 @@ export interface LogRead {
   truncated: boolean
 }
 
-/** Optionally line-count-bounded, non-destructive log with independent cursor readers. */
+/** Line-count-bounded, non-destructive log with independent cursor readers. */
 export class LineLog {
-  readonly #limit: number | null
+  readonly #limit: number
   #entries: LogEntry[] = []
   #partial = ''
   #pendingCr = false
   #sequence = 0
 
-  constructor(limit?: number) {
-    if (limit !== undefined && (!Number.isSafeInteger(limit) || limit < 1)) {
-      throw new Error('log limit must be positive')
-    }
-    this.#limit = limit ?? null
+  constructor(limit: number) {
+    if (!Number.isSafeInteger(limit) || limit < 1) throw new Error('log limit must be positive')
+    this.#limit = limit
   }
 
   appendLine(line: string): number {
     this.#sequence += 1
     this.#entries.push({ sequence: this.#sequence, line })
-    if (this.#limit !== null && this.#entries.length > this.#limit) {
+    if (this.#entries.length > this.#limit) {
       this.#entries.splice(0, this.#entries.length - this.#limit)
     }
     return this.#sequence

--- a/src/infra/line-buffer.ts
+++ b/src/infra/line-buffer.ts
@@ -1,0 +1,41 @@
+/** Consuming line buffer: completed lines are returned once; only the unfinished fragment remains. */
+export class LineBuffer {
+  #partial = ''
+  #pendingCr = false
+
+  appendChunk(chunk: string): string[] {
+    const lines: string[] = []
+    const endLine = () => {
+      lines.push(this.#partial)
+      this.#partial = ''
+    }
+    for (const character of chunk) {
+      if (this.#pendingCr) {
+        this.#pendingCr = false
+        endLine()
+        if (character === '\n') continue
+      }
+      if (character === '\r') {
+        this.#pendingCr = true
+      } else if (character === '\n') {
+        endLine()
+      } else {
+        this.#partial += character
+      }
+    }
+    return lines
+  }
+
+  flush(): string[] {
+    if (this.#pendingCr) {
+      this.#pendingCr = false
+      const line = this.#partial
+      this.#partial = ''
+      return [line]
+    }
+    if (this.#partial === '') return []
+    const line = this.#partial
+    this.#partial = ''
+    return [line]
+  }
+}

--- a/src/infra/live-output.ts
+++ b/src/infra/live-output.ts
@@ -31,7 +31,6 @@ export interface LiveLogEvent {
 }
 
 const EVENT_PREFIX = '[clickvibe:event]'
-const EVENT_TEXT_MAX_CHARS = 6_000
 
 function finiteToken(value: unknown): number | undefined {
   const number = Number(value)
@@ -67,11 +66,7 @@ export function tokenUsage(value: unknown): TokenUsage | undefined {
 
 /** Durable wire format. Percent encoding keeps agent JSON out of verdict regexes. */
 export function encodeLiveLogEvent(event: LiveLogEvent): string {
-  const bounded =
-    event.text.length > EVENT_TEXT_MAX_CHARS
-      ? { ...event, text: `${event.text.slice(0, EVENT_TEXT_MAX_CHARS)}… [clickvibe] 单条事件已截断` }
-      : event
-  return `${EVENT_PREFIX}${encodeURIComponent(JSON.stringify(bounded))}`
+  return `${EVENT_PREFIX}${encodeURIComponent(JSON.stringify(event))}`
 }
 
 /** Read new structured records and legacy plain-text logs without migration. */

--- a/src/infra/runtime.ts
+++ b/src/infra/runtime.ts
@@ -35,6 +35,7 @@ import {
   parseGithubUrl,
   validatePrivilegedRequest,
 } from './develop-core.ts'
+import { LineBuffer } from './line-buffer.ts'
 import { type RepositoryFreshness, RepositoryFreshnessGate, RepositoryRefreshClock } from './repo-freshness.ts'
 import { ExclusiveTaskGate } from './task-gate.ts'
 import type { IssueWorkflow } from './state.ts'
@@ -70,8 +71,7 @@ export interface LiveTask {
   startedAt: number
   process?: ReturnType<Context['shell']['start']>
   log: LineLog
-  rawLog: LineLog
-  rawCursor: number
+  rawLog: LineBuffer
   closed: boolean
   status: 'running' | 'done' | 'failed' | 'stopped' | 'timed_out'
   exitCode: number | null

--- a/tests/agent-stream.test.ts
+++ b/tests/agent-stream.test.ts
@@ -50,6 +50,19 @@ test('codex preserves complete reasoning, commands, errors and tool arguments', 
   )
 })
 
+test('codex preserves command output whitespace as one complete event', () => {
+  const output = 'first line\n\n  indented with trailing spaces  \nlast line\n'
+  assert.deepEqual(
+    parseCodexEvent(
+      JSON.stringify({
+        type: 'item.completed',
+        item: { type: 'command_execution', aggregated_output: output },
+      }),
+    ),
+    [{ kind: 'command_output', text: output }],
+  )
+})
+
 test('claude preserves complete thinking and tool arguments', () => {
   const thinking = `inspect\n  ${'t'.repeat(5000)}`
   const input = { command: `cd /Users/example/project\n${'z'.repeat(300)}`, workdir: '/tmp/clickvibe' }
@@ -103,8 +116,7 @@ test('codex renders command execution, reasoning and token_count with its own sc
     ),
     [
       { kind: 'command', text: '$ pnpm test' },
-      { kind: 'command_output', text: 'one' },
-      { kind: 'command_output', text: 'two' },
+      { kind: 'command_output', text: 'one\ntwo\n' },
     ],
   )
   assert.equal(

--- a/tests/agent-stream.test.ts
+++ b/tests/agent-stream.test.ts
@@ -2,9 +2,9 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { parseAgentChunk, parseClaudeEvent, parseCodexEvent } from '../src/agent/agent-stream.ts'
 
-const longMessage = 'x'.repeat(5000)
+const longMessage = `/Users/example/project\n  ${'x'.repeat(5000)}\n/tmp/clickvibe-worktree`
 
-test('codex and claude use the same 4000-character display limit for messages', () => {
+test('codex and claude preserve complete messages with whitespace unchanged', () => {
   const codex = parseCodexEvent(
     JSON.stringify({
       type: 'item.completed',
@@ -18,7 +18,55 @@ test('codex and claude use the same 4000-character display limit for messages', 
     }),
   )
   assert.equal(codex[0].text, claude[0].text)
-  assert.equal(codex[0].text, `💬 ${'x'.repeat(4000)}…`)
+  assert.equal(codex[0].text, `💬 ${longMessage}`)
+})
+
+test('codex preserves complete reasoning, commands, errors and tool arguments', () => {
+  const reasoning = `inspect\n  ${'r'.repeat(5000)}`
+  const command = `cd /Users/example/project\n${'c'.repeat(1200)}`
+  const error = `failed\n  ${'e'.repeat(300)}`
+  const toolArguments = `/tmp/clickvibe\n  ${'a'.repeat(300)}`
+
+  assert.equal(
+    parseCodexEvent(JSON.stringify({ type: 'item.completed', item: { type: 'reasoning', text: reasoning } }))[0].text,
+    `◌ ${reasoning}`,
+  )
+  assert.equal(
+    parseCodexEvent(JSON.stringify({ type: 'item.completed', item: { type: 'command_execution', command } }))[0].text,
+    `$ ${command}`,
+  )
+  assert.equal(
+    parseCodexEvent(JSON.stringify({ type: 'item.completed', item: { type: 'error', text: error } }))[0].text,
+    `⚠️ ${error}`,
+  )
+  assert.equal(
+    parseCodexEvent(
+      JSON.stringify({
+        type: 'item.completed',
+        item: { type: 'function_call', name: 'shell', arguments: toolArguments },
+      }),
+    )[0].text,
+    `🔧 执行命令: ${toolArguments}`,
+  )
+})
+
+test('claude preserves complete thinking and tool arguments', () => {
+  const thinking = `inspect\n  ${'t'.repeat(5000)}`
+  const input = { command: `cd /Users/example/project\n${'z'.repeat(300)}`, workdir: '/tmp/clickvibe' }
+  const lines = parseClaudeEvent(
+    JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'thinking', thinking },
+          { type: 'tool_use', name: 'bash', input },
+        ],
+      },
+    }),
+  )
+
+  assert.equal(lines[0].text, `◌ ${thinking}`)
+  assert.equal(lines[1].text, `🔧 执行命令: ${JSON.stringify(input)}`)
 })
 
 test('agent streams expose session ids before completion', () => {

--- a/tests/develop.test.ts
+++ b/tests/develop.test.ts
@@ -369,15 +369,16 @@ test('merge authorization input accepts only a well-formed manual override', () 
   )
 })
 
-test('LineLog bounds a never-terminated line and handles CRLF split across chunks', () => {
+test('LineLog preserves a never-terminated long line and handles CRLF split across chunks', () => {
   const log = new LineLog(4)
-  log.appendChunk('x'.repeat(LineLog.MAX_LINE_CHARS + 10))
-  log.appendChunk('discarded\r')
+  const longLine = `${'x'.repeat(70_000)} with /Users/example/project and /tmp/clickvibe`
+  log.appendChunk(longLine.slice(0, 65_000))
+  log.appendChunk(`${longLine.slice(65_000)}\r`)
   log.appendChunk('\nnext\r')
   log.appendChunk('\n')
   const read = log.read(0)
   assert.equal(read.lines.length, 2)
-  assert.match(read.lines[0], /单行日志已截断/)
+  assert.equal(read.lines[0], longLine)
   assert.equal(read.lines[1], 'next')
 })
 

--- a/tests/develop.test.ts
+++ b/tests/develop.test.ts
@@ -18,6 +18,7 @@ import {
   parseDependencies,
   validatePrivilegedRequest,
 } from '../src/agent/develop.ts'
+import { LineBuffer } from '../src/infra/line-buffer.ts'
 
 test('parseAgent accepts only the three supported agents', () => {
   assert.equal(parseAgent('codex'), 'codex')
@@ -383,20 +384,21 @@ test('LineLog preserves a never-terminated long line and handles CRLF split acro
   assert.equal(read.lines[1], 'next')
 })
 
-test('an unbounded raw LineLog preserves every event before parsing', () => {
-  const log = new LineLog()
-  for (let index = 0; index < 2001; index += 1) {
-    log.appendChunk(
-      `${JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: `m${index}` } })}\n`,
-    )
-  }
-
-  const read = log.read(0)
-  const parsed = parseAgentChunk('codex', read.lines.join('\n'))
-  assert.equal(read.truncated, false)
+test('LineBuffer consumes complete raw events while retaining only the partial line', () => {
+  const buffer = new LineBuffer()
+  const events = Array.from({ length: 2001 }, (_, index) =>
+    JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: `m${index}` } }),
+  )
+  const lines = buffer.appendChunk(`${events.join('\n')}\npartial`)
+  const parsed = parseAgentChunk('codex', lines.join('\n'))
   assert.equal(parsed.lines.length, 2001)
   assert.equal(parsed.lines[0].text, '💬 m0')
   assert.equal(parsed.lines[2000].text, '💬 m2000')
+  assert.deepEqual(buffer.appendChunk(' tail\r'), [])
+  assert.deepEqual(buffer.appendChunk('\nnext\r'), ['partial tail'])
+  assert.deepEqual(buffer.appendChunk('\nfinal'), ['next'])
+  assert.deepEqual(buffer.flush(), ['final'])
+  assert.deepEqual(buffer.flush(), [])
 })
 
 test('parseDependencies extracts Blocked by numbers from the 依赖 section', () => {

--- a/tests/develop.test.ts
+++ b/tests/develop.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { parseAgentChunk } from '../src/agent/agent-stream.ts'
 import {
   AuthorizationStore,
   LineLog,
@@ -380,6 +381,22 @@ test('LineLog preserves a never-terminated long line and handles CRLF split acro
   assert.equal(read.lines.length, 2)
   assert.equal(read.lines[0], longLine)
   assert.equal(read.lines[1], 'next')
+})
+
+test('an unbounded raw LineLog preserves every event before parsing', () => {
+  const log = new LineLog()
+  for (let index = 0; index < 2001; index += 1) {
+    log.appendChunk(
+      `${JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: `m${index}` } })}\n`,
+    )
+  }
+
+  const read = log.read(0)
+  const parsed = parseAgentChunk('codex', read.lines.join('\n'))
+  assert.equal(read.truncated, false)
+  assert.equal(parsed.lines.length, 2001)
+  assert.equal(parsed.lines[0].text, '💬 m0')
+  assert.equal(parsed.lines[2000].text, '💬 m2000')
 })
 
 test('parseDependencies extracts Blocked by numbers from the 依赖 section', () => {

--- a/tests/live-output.test.ts
+++ b/tests/live-output.test.ts
@@ -18,16 +18,12 @@ test('structured live records round-trip while old log lines remain readable', (
     text: '[clickvibe] reconnecting',
   })
   assert.equal(decodeLiveLogLine('legacy agent line').text, 'legacy agent line')
-  assert.match(
-    decodeLiveLogLine(
-      encodeLiveLogEvent({
-        source: 'agent',
-        kind: 'command_output',
-        text: 'x'.repeat(7000),
-      }),
-    ).text,
-    /单条事件已截断$/,
-  )
+  const longEvent = {
+    source: 'agent',
+    kind: 'command_output',
+    text: `/Users/example/project\n  ${'x'.repeat(7000)}\n/tmp/clickvibe`,
+  } as const
+  assert.deepEqual(decodeLiveLogLine(encodeLiveLogEvent(longEvent)), longEvent)
 })
 
 test('token usage accepts both agent field conventions and stays optional', () => {

--- a/tests/review-result.test.ts
+++ b/tests/review-result.test.ts
@@ -22,16 +22,14 @@ async function withWorktree(run: (worktree: string) => Promise<void>): Promise<v
 }
 
 for (const agent of ['codex', 'claude'] as const) {
-  test(`${agent}: materialized JSON wins even when the displayed conclusion is truncated`, async () => {
+  test(`${agent}: materialized JSON wins while the displayed conclusion remains complete`, async () => {
     await withWorktree(async (worktree) => {
       const issues = Array.from({ length: 12 }, (_, index) => `问题 ${index + 1}: ${'长描述'.repeat(220)}`)
       await mkdir(join(worktree, '.clickvibe'))
       await writeFile(join(worktree, REVIEW_RESULT_RELATIVE_PATH), JSON.stringify({ passed: false, issues }))
-      const parsed = parseAgentChunk(
-        agent,
-        agentOutput(agent, `${'分析'.repeat(2500)}${JSON.stringify({ passed: true, issues: [] })}`),
-      )
-      assert.match(parsed.lines[0].text, /…$/)
+      const conclusion = `${'分析'.repeat(2500)}${JSON.stringify({ passed: true, issues: [] })}`
+      const parsed = parseAgentChunk(agent, agentOutput(agent, conclusion))
+      assert.equal(parsed.lines[0].text, `💬 ${conclusion}`)
 
       const resolved = await loadReviewResult(
         worktree,

--- a/tests/state-view-integration.test.ts
+++ b/tests/state-view-integration.test.ts
@@ -7,6 +7,7 @@ import { promisify } from 'node:util'
 import test from 'node:test'
 import { deriveWorkflowState, enrichWorkflowStates, type IssueWorkflow } from '../src/index.ts'
 import { LineLog } from '../src/infra/develop-core.ts'
+import { LineBuffer } from '../src/infra/line-buffer.ts'
 import { liveTasks } from '../src/infra/runtime.ts'
 import { issueBodyHash } from '../src/infra/state.ts'
 
@@ -104,8 +105,7 @@ test('state exposes only the current in-memory task start time', async () => {
     agent: 'codex',
     startedAt: 1_720_000_000_000,
     log: new LineLog(10),
-    rawLog: new LineLog(10),
-    rawCursor: 0,
+    rawLog: new LineBuffer(),
     closed: false,
     status: 'running',
     exitCode: null,


### PR DESCRIPTION
## 变更
- 移除 agent 事件解析、live event 编码和 LineLog 单行字符截断
- 保留消息、思考、命令、工具参数和 command_output 的原始空白与完整文本
- 保持事件 kind 集合与 JSONL wire format 不变，不引入脱敏或内容容量上限

## Review 返工
- 第 2 轮：aggregated_output 改为单个 command_output 事件逐字保留
- 第 2 轮：修复解析前 rawLog 2000 行淘汰，2001 个事件完整解析
- 第 3 轮：用消费式 LineBuffer 替换无界 LineLog/rawCursor；完整行仅交付一次，已解析条目不驻留、不重复扫描，仅保留未终止 partial
- LineLog 恢复为只服务实时展示窗口的有界日志；磁盘 JSONL 继续全量持久化

## 验证
- pnpm run typecheck
- pnpm run build
- pnpm test（272/272）
- pnpm run coverage（lines 93.11%，functions 88.85%）
- pnpm run lint
- pnpm run format:check
- pnpm run check:size
- pnpm run check:layers
- 多批次探针：首批 2001 个事件完整交付；后续只返回新增完整行；partial 跨 chunk 保留；无历史重放

Closes #78