### PR TITLE
fix: 列表行运行态布局——运行时长归入内容区,动作按钮不换行(issue #83)

### DIFF
--- a/src/client/styles.ts
+++ b/src/client/styles.ts
@@ -39,6 +39,7 @@ body[data-cv-panel-dragging] #root.cv-panel-host-open, body[data-cv-panel-draggi
 .cv-issue-row-main { min-width: 0; }
 .cv-issue-row-title { display: block; color: #0969da; font-size: 12.5px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; cursor: pointer; }
 .cv-issue-row-meta { color: #57606a; font-size: 10.5px; margin-top: 3px; display: flex; gap: 7px; flex-wrap: wrap; }
+.cv-issue-row-main .cv-running-duration { display: block; margin-top: 3px; color: #0969da; font-weight: 600; }
 .cv-row-lag { color: #9a6700; font-weight: 600; }
 .cv-row-contract { color: #cf222e; font-weight: 600; }
 .cv-row-ready { color: #1a7f37; font-weight: 600; }

--- a/src/client/views/project-panel.tsx
+++ b/src/client/views/project-panel.tsx
@@ -446,15 +446,15 @@ export function PanelContent() {
                               }
                             />
                             <span className={`cv-stage cv-stage-${status}`}>{stageLabel(status, issue.workflow)}</span>
-                            {(status === 'developing' || status === 'reviewing') &&
-                            issue.workflow.runStartedAt !== null &&
-                            issue.workflow.runStartedAt !== undefined ? (
-                              <RunningDuration startedAt={issue.workflow.runStartedAt} />
-                            ) : null}
                             <div className="cv-issue-row-main">
                               <span className="cv-issue-row-title" onClick={() => void openIssue(issue)}>
                                 #{issue.number} {issue.title}
                               </span>
+                              {(status === 'developing' || status === 'reviewing') &&
+                              issue.workflow.runStartedAt !== null &&
+                              issue.workflow.runStartedAt !== undefined ? (
+                                <RunningDuration startedAt={issue.workflow.runStartedAt} />
+                              ) : null}
                               <div className="cv-issue-row-meta">
                                 <span>分支: {issue.workflow.branch}</span>
                                 {(derived?.behindBase ?? 0) > 0 ? (


### PR DESCRIPTION
## 目标
修复列表行运行态布局(issue #83):RunningDuration 不再作为 grid 第 5 个子元素挤占内容列并换行动作按钮;时长归入行内容区,grid 固定 4 列。

Closes #83

## 变更
- `src/client/views/project-panel.tsx`:运行时长移入 `.cv-issue-row-main`(标题与 meta 之间),不再产生第 5 个 grid 子元素
- `src/client/styles.ts`:新增行内容区内的时长样式,沿用 DSH 主题 token;4 列 grid 与动作按钮 `white-space: nowrap` 保持固定
- `tests/project-panel-layout.test.ts`:锁定时长 DOM 归属、四列 grid 与动作按钮不换行契约
- 合并最新 `origin/main`(`174d576`)并手工整合同期主题样式改动

## 验证
- typecheck / build / test / coverage / lint / format:check / check:size / check:layers 全绿
- 278 tests passed
- coverage:lines 93.07%, functions 88.03%(阈值 85%)
- [人工待验] 列表页运行/返工/review 行视觉可扫读、空闲行不回归

## 依赖
无