### PR TITLE
feat: 超 5 轮后允许手动新开开发或 review 会话

### DIFF
--- a/docs/plans/2026-08-23-fresh-session-after-round-threshold-design.md
+++ b/docs/plans/2026-08-23-fresh-session-after-round-threshold-design.md
@@ -1,0 +1,17 @@
+# 超轮次后手动新开会话设计
+
+## 范围
+
+当本地事件链已有五次 review 结论、当前进入第六轮时，面板在现有续接动作旁提供“新开开发”或“新开 review”。主按钮、自动模式、worktree、分支、commit、事件链和公开交付历史均保持原语义。事件链缺失、阈值未达到、或没有归属明确的对应 session 时，不显示入口，服务端也拒绝 fresh 请求。
+
+## 数据与授权
+
+`deriveEventRound(events)` 继续是唯一轮次定义。状态派生新增 `freshSession: { round, develop, review }`，其中能力布尔值同时要求 `round > 5` 和 session id 与 agent owner 匹配。客户端只把该能力映射到 `resume/rework/review` 三类续接动作。
+
+新开动作复用 `/resume` 与 `/review`，请求增加 `freshSession: true`。该字段进入一次性授权摘要与 digest，避免同一授权在“续接”和“新开”之间替换。执行时服务端重新检查阈值与 session，防止授权后状态漂移。
+
+## 启动语义
+
+fresh 开发清除旧开发 session 引用，使用 `buildFreshAgentCommand`，并向 `buildResumePrompt` 传入空 session id；现有 prompt 仍从当前需求快照、worktree 和上一轮未通过意见构造 rework 上下文。fresh review 同样不传旧 review session id，使用全新命令；`buildReviewPrompt` 因 session id 为空，不注入上一轮意见复核指令，只要求读取当前 `base...HEAD` 全量 diff。
+
+任务完成仍走原有 `recordDevDelivery` 和 review 事件追加逻辑，因此轮次不重置。

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -24,6 +24,14 @@ export interface LocalReviewEvent {
   note?: string
 }
 
+/** A fresh review keeps requirement discussion but drops prior ClickVibe verdict lists. */
+export function snapshotWithoutReviewFeedback(snapshot: PromptSnapshot): PromptSnapshot {
+  return {
+    ...snapshot,
+    comments: snapshot.comments.filter((comment) => !comment.body.includes('== Review Meta ==')),
+  }
+}
+
 const STAGE_LABEL: Record<PromptStage, string> = {
   develop: '开发',
   review: 'Review',

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -24,7 +24,13 @@ import { githubRest, isGithubRateLimitError } from '../github/rest.ts'
 import { REVIEW_RESULT_RELATIVE_PATH } from '../infra/review-result.ts'
 import { readWorktreeHead } from '../infra/runtime.ts'
 import { type IssueWorkflow, issueBodyHash, saveWorkflow } from '../infra/state.ts'
-import { buildStagePrompt, type PromptSnapshot, type SnapshotFreshness, selectReviewFeedback } from './prompt.ts'
+import {
+  buildStagePrompt,
+  type PromptSnapshot,
+  type SnapshotFreshness,
+  selectReviewFeedback,
+  snapshotWithoutReviewFeedback,
+} from './prompt.ts'
 
 export interface ResolvedPromptSnapshot {
   snapshot: PromptSnapshot
@@ -122,6 +128,7 @@ export async function buildReviewPrompt(
   reviewedHead: string,
   sessionId: string | null = null,
   extraContext = '',
+  freshSession = false,
 ): Promise<string> {
   // 解析 base:PR 有 baseRefName(若记录过),否则尝试 origin/HEAD 主干
   let base = 'origin/main'
@@ -131,9 +138,11 @@ export async function buildReviewPrompt(
   }
   const prUrl = workflow.prNumber ? `https://github.com/${workflow.repoKey}/pull/${workflow.prNumber}` : '未关联'
   const contractHash = issueBodyHash(resolved.snapshot.body)
+  const promptSnapshot = freshSession ? snapshotWithoutReviewFeedback(resolved.snapshot) : resolved.snapshot
   return buildStagePrompt({
     stage: 'review',
     ...resolved,
+    snapshot: promptSnapshot,
     worktree: workflow.worktree,
     status: [
       `分支: ${workflow.branch}`,

--- a/src/client/dev-authorization.ts
+++ b/src/client/dev-authorization.ts
@@ -32,13 +32,15 @@ export function authorizationSummary(input: {
   url: string
   authorizationDigest: string
   preview: AuthorizationPreview
+  freshSession?: boolean
 }): string {
-  const { action, agent, url, authorizationDigest, preview } = input
+  const { action, agent, url, authorizationDigest, preview, freshSession } = input
   if (action === 'develop') {
     return `${agent} 将以高权限开发以下已冻结快照:\n\n${preview.title ?? url}\n更新时间: ${preview.updatedAt || '未知'}\n评论: ${preview.commentCount ?? 0} 条\n快照: ${preview.digest.slice(0, 12)}\n\n确认启动?`
   }
   if (action === 'merge') {
     return `ClickVibe 将执行不可逆的合并与清理:\n\nPR: #${preview.prNumber ?? '?'}\n分支: ${preview.branch ?? '?'}\n策略: ${preview.mergeFlag ?? '--merge'} (merge commit，禁止 squash/rebase)\n清理: ${(preview.cleanup ?? []).join('、')}\n授权: ${authorizationDigest.slice(0, 12)}\n\n确认合并并清理?`
   }
-  return `${agent} 将以高权限执行 ${action}。\n目标: ${url}\n授权: ${preview.digest.slice(0, 12)}\n\n确认启动?`
+  const mode = freshSession ? `全新 ${action} 会话(保留 worktree/分支/commit)` : action
+  return `${agent} 将以高权限执行 ${mode}。\n目标: ${url}\n授权: ${preview.digest.slice(0, 12)}\n\n确认启动?`
 }

--- a/src/client/dev-state.ts
+++ b/src/client/dev-state.ts
@@ -4,6 +4,7 @@ import { type AuthorizationPreview, authorizationSummary, expectedDevelopSnapsho
 import { useDevStream } from './dev-stream.ts'
 import { type MergeGateFailure, type NextAction, OVERRIDE_REASON_MAX, type Workflow, apiCall } from './domain.ts'
 import { githubCompareUrl, latestDevelopmentEvent } from './runtime.ts'
+import { effectiveActionForIssue } from './fresh-session.ts'
 import { type GhIssue } from './views/issue-view.tsx'
 export function useDevSection({
   url,
@@ -50,6 +51,7 @@ export function useDevSection({
     action: 'develop' | 'review' | 'resume' | 'merge',
     agent: 'codex' | 'claude' | null,
     context = '',
+    freshSession = false,
   ): Promise<{
     authorizationId: string
     authorizationDigest: string
@@ -70,6 +72,7 @@ export function useDevSection({
       url,
       ...(agent ? { agent } : {}),
       context,
+      ...(freshSession ? { freshSession: true } : {}),
       ...(action === 'develop' ? { expectedSnapshot } : {}),
     })
     if (!res.ok) {
@@ -83,6 +86,7 @@ export function useDevSection({
       url,
       authorizationDigest: res.authorizationDigest,
       preview: res.preview,
+      freshSession,
     })
     if (!window.confirm(summary)) return null
     return {
@@ -124,14 +128,14 @@ export function useDevSection({
       setBusy(null)
     }
   }
-  const resume = async (context?: string) => {
+  const resume = async (context?: string, freshSession = false) => {
     setBusy('resuming')
     setError(null)
     setLogEvents([])
     setHistoryKind(null)
     try {
       const agent = workflow?.devAgent ?? 'codex'
-      const authorization = await authorize('resume', agent, context ?? '')
+      const authorization = await authorize('resume', agent, context ?? '', freshSession)
       if (!authorization) {
         setBusy(null)
         return
@@ -140,6 +144,7 @@ export function useDevSection({
         url,
         agent,
         ...(context ? { context } : {}),
+        ...(freshSession ? { freshSession: true } : {}),
         ...authorization,
       })
       if (!res.ok) {
@@ -156,13 +161,13 @@ export function useDevSection({
       setBusy(null)
     }
   }
-  const startReview = async (agent: 'codex' | 'claude', context = '') => {
+  const startReview = async (agent: 'codex' | 'claude', context = '', freshSession = false) => {
     setBusy('reviewing')
     setError(null)
     setLogEvents([])
     setHistoryKind(null)
     try {
-      const authorization = await authorize('review', agent, context)
+      const authorization = await authorize('review', agent, context, freshSession)
       if (!authorization) {
         setBusy(null)
         return
@@ -171,6 +176,7 @@ export function useDevSection({
         url,
         agent,
         ...(context ? { context } : {}),
+        ...(freshSession ? { freshSession: true } : {}),
         ...authorization,
       })
       if (!res.ok) {
@@ -354,17 +360,8 @@ export function useDevSection({
       setBusy(null)
     }
   }
-  // 唯一动作:服务端由 git 事实推导;issue 已关闭时本地覆盖为无动作
   const issueClosed = String(issue.state ?? '').toUpperCase() === 'CLOSED'
-  // #5 回归修复:从未开发过(无 workflow 记录)的 OPEN issue,服务端 /api/state
-  // 只枚举已持久化 workflow,不会为其推导 nextAction(恒为 undefined),导致按钮
-  // 缺失。这里按 deriveNextAction 的 idle 分支本地兜底为『开始开发』;
-  // 有 workflow 记录时仍以服务端推导为准。
-  const idleDevelop: NextAction = { kind: 'develop', label: '开始开发', hint: '创建 worktree 并启动 agent 开发' }
-  const effectiveAction: NextAction =
-    issueClosed && nextAction?.kind !== 'cleanup'
-      ? { kind: 'none', label: '无', hint: 'issue 已关闭,无待办动作' }
-      : (nextAction ?? (workflow === null ? idleDevelop : { kind: 'none', label: '无', hint: '等待状态…' }))
+  const effectiveAction = effectiveActionForIssue(issueClosed, nextAction, workflow !== null)
   const runAction = () => {
     const userContext = contextToSubmit(contextText)
     switch (effectiveAction.kind) {
@@ -490,10 +487,12 @@ export function useDevSection({
     showAgentToggle,
     stage,
     startDev,
+    startReview,
     stop,
     streamNotice,
     streamState,
     toggleContext,
+    resume,
     workflowEvents,
   }
 }

--- a/src/client/domain.ts
+++ b/src/client/domain.ts
@@ -78,6 +78,7 @@ export interface Workflow {
     nextAction: NextAction
     status: 'idle' | 'developing' | 'review-ready' | 'reviewing' | 'passed'
     baseBranch: string
+    freshSession: { round: number; develop: boolean; review: boolean }
   }
 }
 

--- a/src/client/fresh-session.ts
+++ b/src/client/fresh-session.ts
@@ -1,0 +1,32 @@
+import type { NextAction, NextActionKind } from './domain.ts'
+
+export interface FreshSessionAvailability {
+  round: number
+  develop: boolean
+  review: boolean
+}
+
+/** Select the secondary entry that belongs beside the current continuation action. */
+export function freshSessionEntry(
+  action: NextActionKind,
+  availability: FreshSessionAvailability | null | undefined,
+): 'develop' | 'review' | null {
+  if ((action === 'resume' || action === 'rework') && availability?.develop) return 'develop'
+  if (action === 'review' && availability?.review) return 'review'
+  return null
+}
+
+/** Preserve the existing client fallback when the server has no persisted workflow yet. */
+export function effectiveActionForIssue(
+  issueClosed: boolean,
+  nextAction: NextAction | undefined,
+  hasWorkflow: boolean,
+): NextAction {
+  if (issueClosed && nextAction?.kind !== 'cleanup') {
+    return { kind: 'none', label: '无', hint: 'issue 已关闭,无待办动作' }
+  }
+  if (nextAction) return nextAction
+  return hasWorkflow
+    ? { kind: 'none', label: '无', hint: '等待状态…' }
+    : { kind: 'develop', label: '开始开发', hint: '创建 worktree 并启动 agent 开发' }
+}

--- a/src/client/views/dev-section.tsx
+++ b/src/client/views/dev-section.tsx
@@ -4,6 +4,8 @@ import { type GhIssue } from './issue-view.tsx'
 import { LiveTerminal } from './live-terminal.tsx'
 import { useDevSection } from '../dev-state.ts'
 import { DeliveryTimeline } from './delivery-timeline.tsx'
+import { contextToSubmit } from '../action-context.ts'
+import { freshSessionEntry } from '../fresh-session.ts'
 
 export function DevSection({
   url,
@@ -48,12 +50,20 @@ export function DevSection({
     showAgentToggle,
     stage,
     startDev,
+    startReview,
     stop,
     streamNotice,
     streamState,
     toggleContext,
+    resume,
     workflowEvents,
   } = useDevSection({ url, issue, workflow, onWorkflow, autoAction, onAutoActionHandled, onDelivered })
+  const freshEntry = freshSessionEntry(effectiveAction.kind, derived?.freshSession)
+  const runFreshSession = () => {
+    const userContext = contextToSubmit(contextText)
+    if (freshEntry === 'develop') void resume(userContext, true)
+    if (freshEntry === 'review') void startReview(agentChoice, userContext, true)
+  }
   return (
     <div className="cv-dev">
       {/* 状态卡:当前状态 + 关键事实 */}
@@ -210,6 +220,16 @@ export function DevSection({
             >
               {busyLabel ?? effectiveAction.label}
             </button>
+            {freshEntry ? (
+              <button
+                className="cv-dev-link"
+                onClick={runFreshSession}
+                disabled={busy !== null}
+                title="放弃旧会话上下文，以当前需求快照和 worktree 状态启动全新会话；Git 产物保持不变"
+              >
+                {freshEntry === 'develop' ? '新开开发' : '新开 review'}
+              </button>
+            ) : null}
             {contextSupported ? (
               <div className="cv-context">
                 <button

--- a/src/infra/develop-core.ts
+++ b/src/infra/develop-core.ts
@@ -237,6 +237,8 @@ export interface AgentAuthorizationInput {
   url: string
   agent: 'codex' | 'claude' | null
   context: string
+  /** Manual choice to abandon the resumable session while preserving git artifacts. */
+  freshSession?: true
   target?: {
     prNumber: string
     branch: string
@@ -357,6 +359,7 @@ export function makeAuthorizationInput(value: {
   url?: unknown
   agent?: unknown
   context?: unknown
+  freshSession?: unknown
   target?: unknown
   override?: unknown
 }): AgentAuthorizationInput {
@@ -368,6 +371,10 @@ export function makeAuthorizationInput(value: {
   if (parsedAgent === 'dryrun') throw new Error('dryrun 不需要高权限授权')
   const url = String(value.url ?? '').trim()
   if (!parseGithubUrl(url)) throw new Error('GitHub URL 无效')
+  const freshSession = value.freshSession === true
+  if (freshSession && action !== 'resume' && action !== 'review') {
+    throw new Error('新开会话只支持 resume 或 review')
+  }
   let target: AgentAuthorizationInput['target']
   if (action === 'merge' && value.target !== undefined) {
     const raw = value.target as Record<string, unknown>
@@ -403,6 +410,7 @@ export function makeAuthorizationInput(value: {
     url,
     agent: parsedAgent,
     context: typeof value.context === 'string' ? value.context.trim() : '',
+    ...(freshSession ? { freshSession: true } : {}),
     ...(target ? { target } : {}),
     ...(override ? { override } : {}),
   }

--- a/src/infra/runtime.ts
+++ b/src/infra/runtime.ts
@@ -155,7 +155,13 @@ export function authorizationInputFromPayload(
   action: AgentAuthorizationInput['action'],
   payload: unknown,
 ): AgentAuthorizationInput {
-  const body = (payload ?? {}) as { url?: unknown; agent?: unknown; context?: unknown; target?: unknown }
+  const body = (payload ?? {}) as {
+    url?: unknown
+    agent?: unknown
+    context?: unknown
+    freshSession?: unknown
+    target?: unknown
+  }
   return makeAuthorizationInput({ ...body, action })
 }
 

--- a/src/workflow/derive.ts
+++ b/src/workflow/derive.ts
@@ -24,6 +24,7 @@ import { type DeriveOptions, hasMergeConflict, readBranch, readRefShort, readRev
 import { liveTasks, readWorktreeHead, runCommand } from '../infra/runtime.ts'
 import { type IssueContractSnapshot, type IssueWorkflow } from '../infra/state.ts'
 import { latestDevelopmentHash } from './delivery-audit.ts'
+import { deriveFreshSessionAvailability, type FreshSessionAvailability } from './fresh-session.ts'
 import {
   deriveNextAction,
   deriveWorkflowStatus,
@@ -69,6 +70,7 @@ export interface WorkflowDerived {
   nextAction: NextAction
   status: 'idle' | 'developing' | 'review-ready' | 'reviewing' | 'passed'
   baseBranch: string
+  freshSession: FreshSessionAvailability
 }
 
 /**
@@ -225,6 +227,11 @@ export async function deriveWorkflowState(
   const nextAction = deriveNextAction(facts)
   const baseBranch = workflowBaseBranch(workflow.baseRef, options.defaultBranch ?? 'main')
   const status = deriveWorkflowStatus(facts)
+  const freshSession = deriveFreshSessionAvailability(
+    events,
+    workflow.devSessionId !== null && workflow.devSessionAgent === workflow.devAgent,
+    workflow.reviewSessionId !== null && workflow.reviewSessionAgent === workflow.reviewAgent,
+  )
 
   return {
     ...workflow,
@@ -264,6 +271,7 @@ export async function deriveWorkflowState(
       nextAction,
       status,
       baseBranch,
+      freshSession,
     },
   }
 }

--- a/src/workflow/fresh-session.ts
+++ b/src/workflow/fresh-session.ts
@@ -1,0 +1,46 @@
+import type { WorkflowEvent } from '../infra/state.ts'
+import { deriveEventRound } from './delivery-audit.ts'
+
+export const FRESH_SESSION_ROUND_THRESHOLD = 5
+
+export interface FreshSessionAvailability {
+  round: number
+  develop: boolean
+  review: boolean
+}
+
+export interface SessionLaunch {
+  sessionId: string | null
+  startsFresh: boolean
+}
+
+/** Fresh sessions are a manual escape hatch beginning with round six. */
+export function canStartFreshSession(round: number): boolean {
+  return Number.isSafeInteger(round) && round > FRESH_SESSION_ROUND_THRESHOLD
+}
+
+/** Keep visibility tied to both event history and an actually resumable session. */
+export function deriveFreshSessionAvailability(
+  events: WorkflowEvent[] | undefined,
+  hasDevelopSession: boolean,
+  hasReviewSession: boolean,
+): FreshSessionAvailability {
+  const round = deriveEventRound(events ?? [])
+  const overThreshold = canStartFreshSession(round)
+  return {
+    round,
+    develop: overThreshold && hasDevelopSession,
+    review: overThreshold && hasReviewSession,
+  }
+}
+
+/** Route an explicit fresh choice away from every previous session id. */
+export function selectSessionLaunch(
+  freshRequested: boolean,
+  ownedSession: { sessionId: string | null; invalid: boolean },
+): SessionLaunch {
+  return {
+    sessionId: freshRequested ? null : ownedSession.sessionId,
+    startsFresh: freshRequested || ownedSession.invalid,
+  }
+}

--- a/src/workflow/resume.ts
+++ b/src/workflow/resume.ts
@@ -40,6 +40,7 @@ import {
   saveWorkflow,
 } from '../infra/state.ts'
 import { recordDevDelivery } from './review-flow.ts'
+import { deriveFreshSessionAvailability, selectSessionLaunch } from './fresh-session.ts'
 import { workflowBaseBranch } from './state-view.ts'
 
 /** Resume (or continue) a dev session with an exact session id; `context`
@@ -49,9 +50,10 @@ export async function resumeDevelop(
   ctx: Context,
   payload: unknown,
 ): Promise<{ ok: true; taskId: string } | { ok: false; error: string }> {
-  const body = (payload ?? {}) as { url?: unknown; context?: unknown }
+  const body = (payload ?? {}) as { url?: unknown; context?: unknown; freshSession?: unknown }
   const url = String(body.url ?? '').trim()
   const extraContext = typeof body.context === 'string' ? body.context.trim() : ''
+  const freshSession = body.freshSession === true
   const parsed = parseUrl(url)
   if (!parsed || parsed.kind !== 'issue') {
     return { ok: false, error: '请输入形如 https://github.com/owner/repo/issues/123 的链接' }
@@ -62,14 +64,30 @@ export async function resumeDevelop(
     return { ok: false, error: '该 issue 尚无开发记录,无法续会话' }
   }
 
+  const availability = deriveFreshSessionAvailability(
+    workflow.events,
+    workflow.devSessionId !== null && workflow.devSessionAgent === workflow.devAgent,
+    workflow.reviewSessionId !== null && workflow.reviewSessionAgent === workflow.reviewAgent,
+  )
+  if (freshSession && !availability.develop) {
+    return { ok: false, error: '当前轮次未超过阈值,或没有可放弃的开发会话' }
+  }
+
   const oldLive = liveTasks.get(workflow.devTaskId)
   if (oldLive && !oldLive.closed) {
     return { ok: true, taskId: oldLive.taskId }
   }
 
   const agent = workflow.devAgent ?? 'codex'
-  const ownedDevSession = resolveSessionForAgent(workflow, 'dev', agent)
-  const sessionId = ownedDevSession.sessionId
+  const ownedDevSession = freshSession
+    ? { sessionId: null, invalid: false }
+    : resolveSessionForAgent(workflow, 'dev', agent)
+  const launch = selectSessionLaunch(freshSession, ownedDevSession)
+  const sessionId = launch.sessionId
+  if (freshSession) {
+    workflow.devSessionId = null
+    workflow.devSessionAgent = null
+  }
   // Reserve synchronously before the snapshot's GitHub awaits. This is the
   // per-workflow invariant preventing double-clicked resume requests from
   // launching multiple agents against the same git worktree.
@@ -100,7 +118,7 @@ export async function resumeDevelop(
   // 用精确会话 id 续会话(不能用 --last/--continue:worktree 里可能有多个
   // agent 会话,--last 续的是"最近那个",不一定是我们这个)。
   // sessionId 缺失时回退 --last/--continue(尽力而为)。
-  const command = ownedDevSession.invalid ? buildFreshAgentCommand(agent) : buildResumeAgentCommand(agent, sessionId)
+  const command = launch.startsFresh ? buildFreshAgentCommand(agent) : buildResumeAgentCommand(agent, sessionId)
   // 续会话前也同步远端(并行开发时 base 会变化)
   try {
     await runCommand(ctx, 'git fetch origin', {
@@ -120,7 +138,12 @@ export async function resumeDevelop(
 
   const prompt = await buildResumePrompt(ctx, workflow, resolvedSnapshot, extraContext, mergePreface, sessionId)
 
-  pushTaskLine(live, `[clickvibe] 恢复 ${agent} 会话${sessionId ? `(${sessionId})` : ''}…`)
+  pushTaskLine(
+    live,
+    freshSession
+      ? `[clickvibe] 新开 ${agent} 开发会话,保留当前 worktree/分支/commit…`
+      : `[clickvibe] 恢复 ${agent} 会话${sessionId ? `(${sessionId})` : ''}…`,
+  )
   attachAgentProcess(
     ctx,
     live,

--- a/src/workflow/review-flow.ts
+++ b/src/workflow/review-flow.ts
@@ -48,6 +48,7 @@ import {
 } from '../infra/state.ts'
 import { buildDevComment, buildReviewComment } from './delivery-comment.ts'
 import { deriveEventRound } from './delivery-audit.ts'
+import { deriveFreshSessionAvailability, selectSessionLaunch } from './fresh-session.ts'
 import { extractGithubCommentId, extractGithubCommentUrl } from './delivery-publication.ts'
 import { type ReviewIssueContract } from './merge-gates.ts'
 import { workflowBaseBranch } from './state-view.ts'
@@ -57,9 +58,10 @@ export async function startReview(
   ctx: Context,
   payload: unknown,
 ): Promise<{ ok: true; taskId: string } | { ok: false; error: string }> {
-  const body = (payload ?? {}) as { url?: unknown; agent?: unknown; context?: unknown }
+  const body = (payload ?? {}) as { url?: unknown; agent?: unknown; context?: unknown; freshSession?: unknown }
   const url = String(body.url ?? '').trim()
   const extraContext = typeof body.context === 'string' ? body.context.trim() : ''
+  const freshSession = body.freshSession === true
   const parsedAgent = parseAgent(body.agent)
   if (parsedAgent === 'dryrun') return { ok: false, error: 'review 不支持 dryrun' }
   const agent: AgentKind = parsedAgent
@@ -92,8 +94,23 @@ export async function startReview(
   if (!existsSync(workflow.worktree)) {
     return { ok: false, error: `worktree 不存在: ${workflow.worktree}` }
   }
-  const ownedReviewSession = resolveSessionForAgent(workflow, 'review', agent)
-  const sessionId = ownedReviewSession.sessionId
+  const availability = deriveFreshSessionAvailability(
+    workflow.events,
+    workflow.devSessionId !== null && workflow.devSessionAgent === workflow.devAgent,
+    workflow.reviewSessionId !== null && workflow.reviewSessionAgent === workflow.reviewAgent,
+  )
+  if (freshSession && !availability.review) {
+    return { ok: false, error: '当前轮次未超过阈值,或没有可放弃的 review 会话' }
+  }
+  const ownedReviewSession = freshSession
+    ? { sessionId: null, invalid: false }
+    : resolveSessionForAgent(workflow, 'review', agent)
+  const launch = selectSessionLaunch(freshSession, ownedReviewSession)
+  const sessionId = launch.sessionId
+  if (freshSession) {
+    workflow.reviewSessionId = null
+    workflow.reviewSessionAgent = null
+  }
   // workflow 校验后、冻结契约/HEAD 等任何 await 之前同步占位。重复请求会立即
   // 复用 taskId,不会重复支付 GitHub 刷新超时,也不会交错清理结论文件并双开 review。
   let reservation: { task: LiveTask; created: boolean }
@@ -176,9 +193,22 @@ export async function startReview(
 
   // 仅续接归属匹配的精确会话;旧状态无 owner 或跨 agent 时直接全新 review。
   const agentCommand = sessionId ? buildResumeAgentCommand(agent, sessionId) : buildFreshAgentCommand(agent)
-  const prompt = await buildReviewPrompt(ctx, workflow, resolvedSnapshot, reviewedHead, sessionId, extraContext)
+  const prompt = await buildReviewPrompt(
+    ctx,
+    workflow,
+    resolvedSnapshot,
+    reviewedHead,
+    sessionId,
+    extraContext,
+    freshSession,
+  )
 
-  pushTaskLine(live, `[clickvibe] 启动 ${agent} review${sessionId ? `(续会话 ${sessionId})` : ''}…`)
+  pushTaskLine(
+    live,
+    freshSession
+      ? `[clickvibe] 新开 ${agent} review 会话,按 base...HEAD 全量审查…`
+      : `[clickvibe] 启动 ${agent} review${sessionId ? `(续会话 ${sessionId})` : ''}…`,
+  )
   attachAgentProcess(
     ctx,
     live,

--- a/tests/dev-authorization.test.ts
+++ b/tests/dev-authorization.test.ts
@@ -31,6 +31,10 @@ test('authorization confirmation copy preserves develop, review and merge detail
   assert.match(authorizationSummary({ ...common, action: 'develop', agent: 'codex' }), /Issue #61/)
   assert.match(authorizationSummary({ ...common, action: 'review', agent: 'claude' }), /claude.*review/s)
   assert.match(
+    authorizationSummary({ ...common, action: 'review', agent: 'claude', freshSession: true }),
+    /全新.*review/s,
+  )
+  assert.match(
     authorizationSummary({
       ...common,
       action: 'merge',

--- a/tests/develop.test.ts
+++ b/tests/develop.test.ts
@@ -70,6 +70,37 @@ test('fresh commands never retry the stale session', () => {
   )
 })
 
+test('fresh-session choice is bound into resume and review authorizations', () => {
+  const resume = makeAuthorizationInput({
+    action: 'resume',
+    url: 'https://github.com/o/r/issues/101',
+    agent: 'codex',
+    freshSession: true,
+  })
+  const review = makeAuthorizationInput({
+    action: 'review',
+    url: 'https://github.com/o/r/issues/101',
+    agent: 'claude',
+    freshSession: true,
+  })
+  assert.equal(resume.freshSession, true)
+  assert.equal(review.freshSession, true)
+  assert.notEqual(authorizationDigest(resume, null), authorizationDigest({ ...resume, freshSession: undefined }, null))
+  const store = new AuthorizationStore()
+  const issued = store.issue(resume, null)
+  assert.equal(store.consume(issued.id, { ...resume, freshSession: undefined }, issued.digest), null)
+  assert.throws(
+    () =>
+      makeAuthorizationInput({
+        action: 'develop',
+        url: 'https://github.com/o/r/issues/101',
+        agent: 'codex',
+        freshSession: true,
+      }),
+    /新开会话只支持 resume 或 review/,
+  )
+})
+
 test('only a quick exact-resume failure before session initialization falls back', () => {
   const rejected = {
     hadExactSessionId: true,

--- a/tests/fresh-session.test.ts
+++ b/tests/fresh-session.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { effectiveActionForIssue, freshSessionEntry } from '../src/client/fresh-session.ts'
+import {
+  FRESH_SESSION_ROUND_THRESHOLD,
+  canStartFreshSession,
+  deriveFreshSessionAvailability,
+  selectSessionLaunch,
+} from '../src/workflow/fresh-session.ts'
+
+const reviewEvents = (count: number) =>
+  Array.from({ length: count }, (_, index) => ({
+    kind: 'review' as const,
+    at: `2026-08-23T0${index}:00:00Z`,
+    verdict: { passed: false, issues: [`issue ${index + 1}`] },
+  }))
+
+test('fresh sessions become available only after five landed review verdicts', () => {
+  assert.equal(FRESH_SESSION_ROUND_THRESHOLD, 5)
+  assert.equal(canStartFreshSession(5), false)
+  assert.equal(canStartFreshSession(6), true)
+
+  assert.deepEqual(deriveFreshSessionAvailability(reviewEvents(4), true, true), {
+    round: 5,
+    develop: false,
+    review: false,
+  })
+  assert.deepEqual(deriveFreshSessionAvailability(reviewEvents(5), true, true), {
+    round: 6,
+    develop: true,
+    review: true,
+  })
+})
+
+test('fresh session entries require a corresponding resumable session', () => {
+  assert.deepEqual(deriveFreshSessionAvailability(reviewEvents(5), false, true), {
+    round: 6,
+    develop: false,
+    review: true,
+  })
+  assert.deepEqual(deriveFreshSessionAvailability(reviewEvents(5), true, false), {
+    round: 6,
+    develop: true,
+    review: false,
+  })
+})
+
+test('client maps fresh entries only beside matching continuation actions', () => {
+  const available = { round: 6, develop: true, review: true }
+  assert.equal(freshSessionEntry('resume', available), 'develop')
+  assert.equal(freshSessionEntry('rework', available), 'develop')
+  assert.equal(freshSessionEntry('review', available), 'review')
+  assert.equal(freshSessionEntry('develop', available), null)
+  assert.equal(freshSessionEntry('merge', available), null)
+  assert.equal(freshSessionEntry('review', { ...available, review: false }), null)
+})
+
+test('client action fallback preserves closed, existing and brand-new issue behavior', () => {
+  const review = { kind: 'review' as const, label: 'Review', hint: 'review now' }
+  assert.deepEqual(effectiveActionForIssue(false, review, true), review)
+  assert.equal(effectiveActionForIssue(true, review, true).kind, 'none')
+  assert.equal(effectiveActionForIssue(false, undefined, false).kind, 'develop')
+  assert.equal(effectiveActionForIssue(false, undefined, true).kind, 'none')
+})
+
+test('fresh and continuation requests split before command and prompt construction', () => {
+  const owned = { sessionId: 'old-session', invalid: false }
+  assert.deepEqual(selectSessionLaunch(false, owned), { sessionId: 'old-session', startsFresh: false })
+  assert.deepEqual(selectSessionLaunch(true, owned), { sessionId: null, startsFresh: true })
+  assert.deepEqual(selectSessionLaunch(false, { sessionId: null, invalid: true }), {
+    sessionId: null,
+    startsFresh: true,
+  })
+})

--- a/tests/prompt.test.ts
+++ b/tests/prompt.test.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { buildStagePrompt, selectReviewFeedback, type PromptSnapshot } from '../src/agent/prompt.ts'
+import {
+  buildStagePrompt,
+  selectReviewFeedback,
+  snapshotWithoutReviewFeedback,
+  type PromptSnapshot,
+} from '../src/agent/prompt.ts'
 
 const snapshot: PromptSnapshot = {
   url: 'https://github.com/o/r/issues/20',
@@ -116,4 +121,16 @@ test('a current passed review never turns resume into rework from old feedback',
     localIssues: [],
   })
   assert.equal(feedback, null)
+})
+
+test('fresh review removes ClickVibe review lists but preserves ordinary requirement comments', () => {
+  const sanitized = snapshotWithoutReviewFeedback({
+    ...snapshot,
+    comments: [
+      { author: 'owner', body: '新增验收要求' },
+      { author: 'bot', body: '== Review Meta ==\n- event: review\n- passed: false\n\n- old issue' },
+    ],
+  })
+  assert.deepEqual(sanitized.comments, [{ author: 'owner', body: '新增验收要求' }])
+  assert.deepEqual(snapshot.comments, [{ author: 'owner', body: '相关评论正文' }])
 })

--- a/tests/state-view-integration.test.ts
+++ b/tests/state-view-integration.test.ts
@@ -121,6 +121,38 @@ test('state exposes only the current in-memory task start time', async () => {
   assert.equal((await deriveWorkflowState(ctx, wf)).runStartedAt, null)
 })
 
+test('state exposes round and only owned continuation sessions as fresh-session capabilities', async () => {
+  const events = Array.from({ length: 5 }, (_, index) => ({
+    kind: 'review' as const,
+    at: `2026-08-23T0${index}:00:00Z`,
+    verdict: { passed: false, issues: [`issue ${index + 1}`] },
+  }))
+  const owned = await deriveWorkflowState(
+    ctx,
+    workflow({
+      events,
+      devAgent: 'codex',
+      devSessionId: 'dev-session',
+      devSessionAgent: 'codex',
+      reviewAgent: 'claude',
+      reviewSessionId: 'review-session',
+      reviewSessionAgent: 'claude',
+    }),
+  )
+  assert.deepEqual(owned.derived.freshSession, { round: 6, develop: true, review: true })
+
+  const staleOwner = await deriveWorkflowState(
+    ctx,
+    workflow({
+      events,
+      devAgent: 'codex',
+      devSessionId: 'legacy-session',
+      devSessionAgent: null,
+    }),
+  )
+  assert.deepEqual(staleOwner.derived.freshSession, { round: 6, develop: false, review: false })
+})
+
 test('state view derives worktree/main/remote hashes, ahead-behind and sync need', async () => {
   const { root, worktree, git, wt, baseA } = await setupRepo()
   try {


### PR DESCRIPTION
## Summary

- derive round-six fresh-session capabilities from landed review verdicts and owned resumable sessions
- add secondary 新开开发 / 新开 review actions while preserving default continuation behavior and Git artifacts
- bind the fresh choice into one-use authorization, rebuild prompts from current state, and strip prior ClickVibe Review Meta lists from explicit fresh reviews

## Verification

- pnpm run typecheck
- pnpm run build
- pnpm test (295 passed)
- pnpm run coverage (lines 93.01%, functions 88.29%)
- pnpm run lint
- pnpm run format:check
- pnpm run check:size
- pnpm run check:layers

## Manual follow-up

- [ ] In the host panel, construct an issue with five landed review verdicts and exercise both fresh buttons to confirm the new session ids and continuous timeline.

Closes #101