### PR TITLE
feat: 任务日志超长内容折叠展示

### DIFF
--- a/docs/plans/2026-08-23-task-log-collapsing-design.md
+++ b/docs/plans/2026-08-23-task-log-collapsing-design.md
@@ -1,0 +1,11 @@
+# Task log collapsing design (Issue #79)
+
+## Scope and approach
+
+The client turns the existing `LiveLogEvent[]` into presentation-only blocks before rendering. Consecutive `command_output` events become one block; every other non-usage event remains an independent block, and usage events remain available to the terminal header without entering the body. Each block keeps a stable id derived from the first source-event position and kind, so appending live events does not remount earlier React rows. The pure transformation never mutates an event or changes the history, SSE, or JSONL contracts.
+
+A second pure helper decides whether a block is long and returns either its complete text or a head preview. A block is long above 20 logical lines or 2,000 characters. Its preview contains at most eight complete leading lines and targets 800 characters; when the first line itself exceeds that target, it remains whole so the preview never cuts through a line. The UI owns only a set of expanded block ids. Long blocks start collapsed, expose their total line count, and can be expanded and collapsed in both embedded and detached terminals. Full and preview text use the terminal's existing pre-wrapped whitespace behavior.
+
+## Verification
+
+Pure tests cover aggregation boundaries, stable ids after append, usage exclusion, exact source-text preservation, logical line counts, line-boundary previews, and short-content passthrough. Component markup checks cover the default collapsed control and direct rendering of short message, action, stage, and system blocks. Typecheck, build, the full test suite, coverage, lint, formatting, layer checks, and size checks remain delivery gates.

--- a/src/client/log-block-view.ts
+++ b/src/client/log-block-view.ts
@@ -1,0 +1,43 @@
+import React from 'react'
+import { buildLogBlocks, collapseLogBlock, toggleExpandedLogBlock } from './log-blocks.ts'
+import type { LiveLogEvent } from './runtime.ts'
+
+export function LogBlocks({ events, taskId }: { events: readonly LiveLogEvent[]; taskId: string | null }) {
+  const [expandedBlocks, setExpandedBlocks] = React.useState<Set<string>>(() => new Set())
+  const blocks = buildLogBlocks(events)
+
+  const toggleBlock = (id: string) => {
+    const expansionId = `${taskId ?? 'history'}:${id}`
+    setExpandedBlocks((current) => toggleExpandedLogBlock(current, expansionId))
+  }
+
+  return blocks.map((block) => {
+    const collapsed = collapseLogBlock(block.text)
+    const expansionId = `${taskId ?? 'history'}:${block.id}`
+    const expanded = collapsed.collapsible && expandedBlocks.has(expansionId)
+    return React.createElement(
+      'div',
+      {
+        key: block.id,
+        className: `cv-terminal-block cv-terminal-line-${block.source === 'system' ? 'system' : block.kind}`,
+      },
+      React.createElement(
+        'div',
+        { className: 'cv-terminal-block-text' },
+        expanded ? collapsed.fullText : collapsed.text,
+      ),
+      collapsed.collapsible
+        ? React.createElement(
+            'button',
+            {
+              type: 'button',
+              className: 'cv-terminal-block-toggle',
+              'aria-expanded': expanded,
+              onClick: () => toggleBlock(block.id),
+            },
+            `${expanded ? '收起' : '展开'} ${collapsed.lineCount} 行`,
+          )
+        : null,
+    )
+  })
+}

--- a/src/client/log-blocks.ts
+++ b/src/client/log-blocks.ts
@@ -1,0 +1,86 @@
+import type { LiveLogEvent, LiveLogKind } from './runtime.ts'
+
+export const COLLAPSED_LOG_LINE_THRESHOLD = 20
+export const COLLAPSED_LOG_CHARACTER_THRESHOLD = 2_000
+const COLLAPSED_LOG_PREVIEW_LINES = 8
+const COLLAPSED_LOG_PREVIEW_CHARACTERS = 800
+
+export interface LogBlock {
+  id: string
+  source: LiveLogEvent['source']
+  agent?: LiveLogEvent['agent']
+  kind: Exclude<LiveLogKind, 'usage'>
+  text: string
+  eventCount: number
+}
+
+export interface CollapsedLogBlock {
+  collapsible: boolean
+  text: string
+  fullText: string
+  lineCount: number
+}
+
+function appendCommandOutput(current: string, next: string): string {
+  if (current === '' || next === '' || current.endsWith('\n') || next.startsWith('\n')) return current + next
+  return `${current}\n${next}`
+}
+
+/** Build body-only presentation blocks without mutating the durable event list. */
+export function buildLogBlocks(events: readonly LiveLogEvent[]): LogBlock[] {
+  const blocks: LogBlock[] = []
+  for (const [index, event] of events.entries()) {
+    if (event.kind === 'usage') continue
+    const previous = blocks.at(-1)
+    if (event.kind === 'command_output' && previous?.kind === 'command_output') {
+      previous.text = appendCommandOutput(previous.text, event.text)
+      previous.eventCount += 1
+      continue
+    }
+    blocks.push({
+      id: `log-${index}-${event.kind}`,
+      source: event.source,
+      agent: event.agent,
+      kind: event.kind,
+      text: event.text,
+      eventCount: 1,
+    })
+  }
+  return blocks
+}
+
+function logicalLines(text: string): string[] {
+  if (text === '') return []
+  const lines = text.split('\n')
+  if (text.endsWith('\n')) lines.pop()
+  return lines
+}
+
+function previewLines(lines: readonly string[]): string {
+  const preview: string[] = []
+  for (const line of lines.slice(0, COLLAPSED_LOG_PREVIEW_LINES)) {
+    const candidateLength = preview.reduce((total, value) => total + value.length, 0) + preview.length + line.length
+    if (preview.length > 0 && candidateLength > COLLAPSED_LOG_PREVIEW_CHARACTERS) break
+    preview.push(line)
+  }
+  return preview.join('\n')
+}
+
+/** Decide presentation only; fullText always retains the exact supplied text. */
+export function collapseLogBlock(text: string): CollapsedLogBlock {
+  const lines = logicalLines(text)
+  const collapsible = lines.length > COLLAPSED_LOG_LINE_THRESHOLD || text.length > COLLAPSED_LOG_CHARACTER_THRESHOLD
+  return {
+    collapsible,
+    text: collapsible ? previewLines(lines) : text,
+    fullText: text,
+    lineCount: lines.length,
+  }
+}
+
+export function toggleExpandedLogBlock(current: ReadonlySet<string>, id: string): Set<string> {
+  const next = new Set(current)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  return next
+}

--- a/src/client/styles.ts
+++ b/src/client/styles.ts
@@ -134,7 +134,10 @@ body[data-cv-panel-dragging] #root.cv-panel-host-open, body[data-cv-panel-draggi
 .cv-terminal-detach { border: 0; border-radius: 4px; padding: 3px 6px; background: #21262d; color: #c9d1d9; cursor: pointer; font: inherit; }
 .cv-terminal-detach:hover { background: #30363d; }
 .cv-dev-log { min-height: 72px; max-height: 200px; overflow: auto; overscroll-behavior: contain; padding: 8px 10px; font: 11px/1.55 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre-wrap; word-break: break-word; scrollbar-color: #30363d #0d1117; }
-.cv-terminal-line { min-height: 1.55em; }
+.cv-terminal-line, .cv-terminal-block { min-height: 1.55em; }
+.cv-terminal-block-text { white-space: pre-wrap; }
+.cv-terminal-block-toggle { margin: 3px 0 5px 12px; padding: 2px 7px; border: 1px solid #30363d; border-radius: 4px; background: #161b22; color: #8b949e; cursor: pointer; font: inherit; }
+.cv-terminal-block-toggle:hover { border-color: #484f58; color: #c9d1d9; background: #21262d; }
 .cv-terminal-line-system { margin: 2px 0; padding: 1px 5px; border-left: 2px solid #58a6ff; color: #79c0ff; background: rgb(56 139 253 / 9%); }
 .cv-terminal-line-stage { color: #d2a8ff; }
 .cv-terminal-line-command { color: #7ee787; font-weight: 600; }

--- a/src/client/views/live-terminal.tsx
+++ b/src/client/views/live-terminal.tsx
@@ -1,3 +1,4 @@
+import { LogBlocks } from '../log-block-view.ts'
 import { formatElapsed, latestTokenUsage, taskStartedAt, type LiveLogEvent } from '../runtime.ts'
 /** Live and detached terminal presentation for one agent task. */
 import React from 'react'
@@ -79,16 +80,7 @@ export function LiveTerminal({
         </button>
       </div>
       <div className="cv-dev-log" ref={logRef} role="log" aria-live="polite" aria-label="实时输出">
-        {events
-          .filter((event) => event.kind !== 'usage')
-          .map((event, index) => (
-            <div
-              key={index}
-              className={`cv-terminal-line cv-terminal-line-${event.source === 'system' ? 'system' : event.kind}`}
-            >
-              {event.text}
-            </div>
-          ))}
+        <LogBlocks events={events} taskId={taskId} />
         {events.length === 0 ? (
           <div className="cv-terminal-line">{streamState === 'history' ? '正在恢复历史…' : '等待 agent 输出…'}</div>
         ) : null}

--- a/tests/client-log-blocks.test.ts
+++ b/tests/client-log-blocks.test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import type { LiveLogEvent } from '../src/client/runtime.ts'
+import {
+  COLLAPSED_LOG_CHARACTER_THRESHOLD,
+  COLLAPSED_LOG_LINE_THRESHOLD,
+  buildLogBlocks,
+  collapseLogBlock,
+  toggleExpandedLogBlock,
+} from '../src/client/log-blocks.ts'
+
+const event = (kind: LiveLogEvent['kind'], text: string, source: LiveLogEvent['source'] = 'agent'): LiveLogEvent => ({
+  source,
+  kind,
+  text,
+})
+
+test('consecutive command output becomes one block while other kinds stay independent', () => {
+  const events = [
+    event('command', '$ first'),
+    event('command_output', 'one\ntwo\n'),
+    event('command_output', 'three'),
+    event('message', 'done'),
+    event('command_output', 'last'),
+  ]
+
+  const blocks = buildLogBlocks(events)
+
+  assert.deepEqual(
+    blocks.map(({ id, kind, text, eventCount }) => ({ id, kind, text, eventCount })),
+    [
+      { id: 'log-0-command', kind: 'command', text: '$ first', eventCount: 1 },
+      { id: 'log-1-command_output', kind: 'command_output', text: 'one\ntwo\nthree', eventCount: 2 },
+      { id: 'log-3-message', kind: 'message', text: 'done', eventCount: 1 },
+      { id: 'log-4-command_output', kind: 'command_output', text: 'last', eventCount: 1 },
+    ],
+  )
+  assert.equal(events[1].text, 'one\ntwo\n')
+  assert.equal(events[2].text, 'three')
+})
+
+test('usage stays out of body blocks and does not split adjacent command output', () => {
+  const blocks = buildLogBlocks([
+    event('command_output', 'one'),
+    { source: 'agent', kind: 'usage', text: 'not body', usage: { totalTokens: 4 } },
+    event('command_output', 'two'),
+  ])
+
+  assert.equal(blocks.length, 1)
+  assert.equal(blocks[0].text, 'one\ntwo')
+  assert.equal(blocks[0].eventCount, 2)
+})
+
+test('block ids stay stable when the live event list appends', () => {
+  const initial = [event('message', 'starting'), event('command_output', 'one')]
+  const before = buildLogBlocks(initial)
+  const after = buildLogBlocks([...initial, event('command_output', 'two'), event('stage', 'finished')])
+
+  assert.equal(after[0].id, before[0].id)
+  assert.equal(after[1].id, before[1].id)
+  assert.equal(after[1].text, 'one\ntwo')
+})
+
+test('long blocks collapse to complete leading lines and report total logical lines', () => {
+  const text = Array.from({ length: COLLAPSED_LOG_LINE_THRESHOLD + 1 }, (_, index) => `line ${index + 1}`).join('\n')
+  const collapsed = collapseLogBlock(text)
+
+  assert.equal(collapsed.collapsible, true)
+  assert.equal(collapsed.lineCount, COLLAPSED_LOG_LINE_THRESHOLD + 1)
+  assert.equal(collapsed.text, Array.from({ length: 8 }, (_, index) => `line ${index + 1}`).join('\n'))
+  assert.equal(collapsed.text.endsWith('\n'), false)
+})
+
+test('character threshold collapses at a line boundary without changing the full text', () => {
+  const first = 'a'.repeat(500)
+  const second = 'b'.repeat(500)
+  const fullText = `${first}\n${second}\n${'c'.repeat(COLLAPSED_LOG_CHARACTER_THRESHOLD)}`
+  const collapsed = collapseLogBlock(fullText)
+
+  assert.equal(collapsed.collapsible, true)
+  assert.equal(collapsed.text, first)
+  assert.equal(fullText.includes(collapsed.text), true)
+  assert.equal(collapsed.fullText, fullText)
+})
+
+test('short text and trailing newlines preserve their display and logical line count', () => {
+  assert.deepEqual(collapseLogBlock('short\n'), {
+    collapsible: false,
+    text: 'short\n',
+    fullText: 'short\n',
+    lineCount: 1,
+  })
+  assert.equal(collapseLogBlock('').lineCount, 0)
+})
+
+test('expanded block state toggles open and closed without mutating the previous set', () => {
+  const initial = new Set<string>()
+  const expanded = toggleExpandedLogBlock(initial, 'task:log-1-command_output')
+  const collapsed = toggleExpandedLogBlock(expanded, 'task:log-1-command_output')
+
+  assert.equal(initial.size, 0)
+  assert.deepEqual([...expanded], ['task:log-1-command_output'])
+  assert.equal(collapsed.size, 0)
+})

--- a/tests/live-terminal-blocks.test.ts
+++ b/tests/live-terminal-blocks.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { LogBlocks } from '../src/client/log-block-view.ts'
+import type { LiveLogEvent } from '../src/client/runtime.ts'
+
+function render(events: LiveLogEvent[]): string {
+  return renderToStaticMarkup(React.createElement(LogBlocks, { events, taskId: null }))
+}
+
+test('terminal defaults a long command-output block to its preview with a line-count toggle', () => {
+  const text = Array.from({ length: 21 }, (_, index) => `output ${index + 1}`).join('\n')
+  const html = render([{ source: 'agent', kind: 'command_output', text }])
+
+  assert.match(html, />展开 21 行</)
+  assert.match(html, /output 1/)
+  assert.doesNotMatch(html, /output 9/)
+  assert.match(html, /cv-terminal-block-text/)
+})
+
+test('terminal keeps short system, stage, command and message events directly visible while hiding usage', () => {
+  const html = render([
+    { source: 'system', kind: 'system', text: '[clickvibe] ready' },
+    { source: 'agent', kind: 'stage', text: 'planning' },
+    { source: 'agent', kind: 'command', text: '$ pnpm test' },
+    { source: 'agent', kind: 'message', text: 'done' },
+    { source: 'agent', kind: 'usage', text: 'hidden usage', usage: { totalTokens: 10 } },
+  ])
+
+  assert.match(html, /\[clickvibe\] ready/)
+  assert.match(html, /planning/)
+  assert.match(html, /\$ pnpm test/)
+  assert.match(html, /done/)
+  assert.doesNotMatch(html, /hidden usage/)
+  assert.doesNotMatch(html, />展开/)
+})


### PR DESCRIPTION
## Summary
- aggregate consecutive `command_output` events into stable client-side display blocks
- collapse long blocks to line-boundary previews with line counts and expand/collapse controls
- keep usage out of body content and preserve complete event text for live and historical rendering

## Verification
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm test` (296/296)
- `pnpm run coverage` (lines 93.18%, functions 88.04%)
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run check:size`
- `pnpm run check:layers`

Fixes #79