### PR TITLE
fix: 补充 Agent 日志缺口恢复线索与空错误兜底

### DIFF
--- a/src/agent/agent-stream.ts
+++ b/src/agent/agent-stream.ts
@@ -18,6 +18,21 @@ export interface StatusLine {
   usage?: TokenUsage
 }
 
+export function lossyAgentOutputNotice(read: {
+  lossy: boolean
+  stdoutSpillPath?: string
+  stderrSpillPath?: string
+}): string | null {
+  if (!read.lossy) return null
+  const spillFiles = [
+    read.stdoutSpillPath ? `stdout ${read.stdoutSpillPath}` : '',
+    read.stderrSpillPath ? `stderr ${read.stderrSpillPath}` : '',
+  ].filter(Boolean)
+  return spillFiles.length > 0
+    ? `[clickvibe] 宿主流式缓冲已丢失部分 Agent 输出；可从宿主 spill 文件恢复：${spillFiles.join('；')}`
+    : '[clickvibe] 宿主流式缓冲已丢失部分 Agent 输出；宿主未提供 spill 文件，缺口无法从 ClickVibe 日志恢复'
+}
+
 /** Classify a tool name into a friendly "current action" label. */
 function toolLabel(name: string, args: string): string {
   switch (name) {
@@ -130,7 +145,10 @@ export function parseCodexEvent(line: string): StatusLine[] {
           break
         }
         case 'error':
-          out.push({ kind: 'text', text: `⚠️ ${item.text ?? 'error'}` })
+          out.push({
+            kind: 'text',
+            text: `⚠️ ${item.text?.trim() ? item.text : 'Codex 报告错误，但未提供错误详情'}`,
+          })
           break
         default:
           break

--- a/src/agent/task-supervisor.ts
+++ b/src/agent/task-supervisor.ts
@@ -34,7 +34,7 @@ import {
   TASK_TIMEOUT_MS,
 } from '../infra/runtime.ts'
 import { appendTaskLog, startTaskLog, type IssueWorkflow } from '../infra/state.ts'
-import { type AgentKind, parseAgentChunk } from './agent-stream.ts'
+import { type AgentKind, lossyAgentOutputNotice, parseAgentChunk } from './agent-stream.ts'
 
 /** Start (or restart) a dev task in the live map with status parsing. */
 export function createLiveTask(
@@ -181,9 +181,8 @@ export function attachAgentProcess(
           task.sessionId = parsed.sessionId
         }
       }
-      if (read.lossy) {
-        pushTaskLine(task, '[clickvibe] Agent 原始输出被截断(日志过长)')
-      }
+      const lossNotice = lossyAgentOutputNotice(read)
+      if (lossNotice) pushTaskLine(task, lossNotice)
     }
     const pump = setInterval(() => drain(), 250)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,12 @@ declare module '@deepseek-ai/cordis' {
         status: string
         exitCode: number | null
         readonly done: Promise<void>
-        readOutput(): { delta: string; lossy: boolean }
+        readOutput(): {
+          delta: string
+          lossy: boolean
+          stdoutSpillPath?: string
+          stderrSpillPath?: string
+        }
         kill(): boolean
       }
     }

--- a/tests/agent-stream.test.ts
+++ b/tests/agent-stream.test.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { parseAgentChunk, parseClaudeEvent, parseCodexEvent } from '../src/agent/agent-stream.ts'
+import {
+  lossyAgentOutputNotice,
+  parseAgentChunk,
+  parseClaudeEvent,
+  parseCodexEvent,
+} from '../src/agent/agent-stream.ts'
 
 const longMessage = `/Users/example/project\n  ${'x'.repeat(5000)}\n/tmp/clickvibe-worktree`
 
@@ -48,6 +53,30 @@ test('codex preserves complete reasoning, commands, errors and tool arguments', 
     )[0].text,
     `🔧 执行命令: ${toolArguments}`,
   )
+})
+
+test('codex error items without useful text identify the reporting agent', () => {
+  for (const text of [undefined, '', '   ']) {
+    assert.deepEqual(parseCodexEvent(JSON.stringify({ type: 'item.completed', item: { type: 'error', text } })), [
+      { kind: 'text', text: '⚠️ Codex 报告错误，但未提供错误详情' },
+    ])
+  }
+})
+
+test('lossy agent output notice explains the host buffer gap and spill recovery paths', () => {
+  assert.equal(
+    lossyAgentOutputNotice({
+      lossy: true,
+      stdoutSpillPath: '/private/tmp/dsh/stdout.log',
+      stderrSpillPath: '/private/tmp/dsh/stderr.log',
+    }),
+    '[clickvibe] 宿主流式缓冲已丢失部分 Agent 输出；可从宿主 spill 文件恢复：stdout /private/tmp/dsh/stdout.log；stderr /private/tmp/dsh/stderr.log',
+  )
+  assert.equal(
+    lossyAgentOutputNotice({ lossy: true }),
+    '[clickvibe] 宿主流式缓冲已丢失部分 Agent 输出；宿主未提供 spill 文件，缺口无法从 ClickVibe 日志恢复',
+  )
+  assert.equal(lossyAgentOutputNotice({ lossy: false }), null)
 })
 
 test('codex preserves command output whitespace as one complete event', () => {


### PR DESCRIPTION
## 变更

- read.lossy 明确标注为宿主流式缓冲缺口，并展示 stdout/stderr spill 恢复路径；无 spill 文件时明确说明 ClickVibe 日志无法恢复缺口
- Codex error 项缺失或仅含空白文本时，显示可判定的 Codex 错误兜底文案
- 补齐 lossy 有/无恢复路径、非 lossy 和空错误文本测试

## 验证

- pnpm run typecheck
- pnpm run build
- pnpm test（353/353）
- pnpm run coverage（lines 91.63%，functions 87.18%）
- pnpm run lint
- pnpm run check:size
- pnpm run check:layers
- pnpm run format:check

Closes #115