### PR TITLE
fix: 持久化控制器诊断事件

### DIFF
--- a/docs/state-model.md
+++ b/docs/state-model.md
@@ -41,6 +41,8 @@ workflow 每次提交都携带持久化 revision;所有普通写要求 expected 
 
 实现同时输出 `runtimeInstanceId`、PID、模块加载时间和任务 `set/close/delete`、host job 注册、auto-run 判断/异常的结构化诊断。`requestAutoRunReconcile()` 的未知异常记录为 `controller-error`,不再冒充 agent 会话中断。
 
+这些控制器诊断除同步写入 `console.warn` 外,还会 best-effort 追加到持久 JSONL。带有效 `workflowKey` 的事件写入 `~/.clickvibe/state/<owner>/<repo>/issue-<number>/diagnostics.jsonl`;无 workflow 归属或 key 无法解析的事件写入全局 `~/.clickvibe/state/diagnostics.jsonl`。活动文件默认上限为 5 MiB,可在 `~/.clickvibe/config.yaml` 设置 `diagnosticsMaxBytes` 覆盖;追加将超限时,上一段保留为同目录的 `diagnostics.1.jsonl`,再创建新的活动文件。轮转不截断单条事件,所以单条记录大于上限时允许独占一个文件段。诊断落盘失败不影响请求路径或 console 输出。
+
 ## 二、事实分级
 
 | 级别 | 事实 | 来源 | 获取手段 |

--- a/src/agent/task-supervisor.ts
+++ b/src/agent/task-supervisor.ts
@@ -35,8 +35,8 @@ import {
   TASK_RETENTION_MS,
   TASK_TIMEOUT_MS,
 } from '../infra/runtime.ts'
-import { appendTaskLog, startTaskLog, type IssueWorkflow } from '../infra/state.ts'
-import { logTaskDiagnostic } from '../infra/task-diagnostics.ts'
+import { appendTaskLog, type IssueWorkflow, startTaskLog } from '../infra/state.ts'
+import { logTaskDiagnostic, waitForTaskDiagnosticPersistence } from '../infra/task-diagnostics.ts'
 import {
   type AgentKind,
   lossyAgentOutputNotice,
@@ -67,7 +67,10 @@ function persistTask(task: LiveTask, operation: () => Promise<void>): void {
 
 /** Await all best-effort log writes scheduled for one live task before releasing its storage. */
 export async function waitForTaskPersistence(task: LiveTask): Promise<void> {
-  await taskPersistence.get(task)?.catch(() => undefined)
+  await Promise.all([
+    taskPersistence.get(task)?.catch(() => undefined),
+    waitForTaskDiagnosticPersistence(task.workflowKey),
+  ])
 }
 
 function hostJobOutcome(task: LiveTask, status: LiveTask['status']): JobOutcome {

--- a/src/infra/diagnostic-log-store.ts
+++ b/src/infra/diagnostic-log-store.ts
@@ -1,0 +1,73 @@
+import { appendFile, mkdir, rename, rm, stat } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { diagnosticLogPath } from './state-layout.ts'
+
+export const DEFAULT_DIAGNOSTIC_MAX_BYTES = 5 * 1024 * 1024
+
+const queueSymbol = Symbol.for('clickvibe.diagnostic-log-queues')
+const globalQueues = globalThis as typeof globalThis & {
+  [queueSymbol]?: Map<string, Promise<unknown>>
+}
+const existingQueues = globalQueues[queueSymbol]
+const logQueues = existingQueues ?? new Map<string, Promise<unknown>>()
+if (!existingQueues) {
+  globalQueues[queueSymbol] = logQueues
+}
+
+function enqueue<T>(path: string, operation: () => Promise<T>): Promise<T> {
+  const previous = logQueues.get(path) ?? Promise.resolve()
+  const current = previous.catch(() => undefined).then(operation)
+  logQueues.set(path, current)
+  void current
+    .finally(() => {
+      if (logQueues.get(path) === current) logQueues.delete(path)
+    })
+    .catch(() => undefined)
+  return current
+}
+
+function rotatedPath(path: string): string {
+  return path.endsWith('.jsonl') ? `${path.slice(0, -'.jsonl'.length)}.1.jsonl` : `${path}.1`
+}
+
+function configuredMaxBytes(value: unknown): number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? value : DEFAULT_DIAGNOSTIC_MAX_BYTES
+}
+
+async function fileSize(path: string): Promise<number> {
+  try {
+    return (await stat(path)).size
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return 0
+    throw error
+  }
+}
+
+/** Serialize size-check, one-segment rotation, and append for one diagnostic stream. */
+export function appendDiagnosticLine(
+  root: string,
+  workflowKey: unknown,
+  line: string,
+  maxBytes: unknown | Promise<unknown>,
+): Promise<void> {
+  const path = diagnosticLogPath(root, workflowKey)
+  return enqueue(path, async () => {
+    const limit = configuredMaxBytes(await maxBytes)
+    const record = `${line}\n`
+    await mkdir(dirname(path), { recursive: true })
+    const existingBytes = await fileSize(path)
+    if (existingBytes > 0 && existingBytes + Buffer.byteLength(record, 'utf8') > limit) {
+      await rm(rotatedPath(path), { force: true })
+      await rename(path, rotatedPath(path))
+    }
+    await appendFile(path, record, 'utf8')
+  })
+}
+
+/** Drain the current stream, including writes queued while an earlier append was running. */
+export async function waitForDiagnosticLines(root: string, workflowKey: unknown): Promise<void> {
+  const path = diagnosticLogPath(root, workflowKey)
+  while (logQueues.has(path)) {
+    await logQueues.get(path)?.catch(() => undefined)
+  }
+}

--- a/src/infra/runtime.ts
+++ b/src/infra/runtime.ts
@@ -39,8 +39,8 @@ import {
 } from './develop-core.ts'
 import { LineBuffer } from './line-buffer.ts'
 import { type RepositoryFreshness, RepositoryFreshnessGate, RepositoryRefreshClock } from './repo-freshness.ts'
-import { ExclusiveTaskGate } from './task-gate.ts'
 import type { IssueWorkflow, WorkflowTaskLease } from './state.ts'
+import { ExclusiveTaskGate } from './task-gate.ts'
 
 const MAX_BODY_BYTES = 64 * 1024
 
@@ -49,6 +49,8 @@ export interface ClickVibeConfig {
   worktreeRoot: string
   /** Remote-ref refresh interval for read paths. Clamped to 30-60 seconds. */
   fetchTtlSeconds?: number
+  /** Maximum active controller-diagnostic JSONL size before one-segment rotation. */
+  diagnosticsMaxBytes?: number
 }
 
 export const DEFAULT_FETCH_TTL_SECONDS = 45
@@ -131,6 +133,7 @@ export async function loadConfig(): Promise<ClickVibeConfig> {
       repos: parsed?.repos ?? {},
       worktreeRoot: parsed?.worktreeRoot ? expandHome(parsed.worktreeRoot) : join(homedir(), '.clickvibe', 'worktrees'),
       fetchTtlSeconds: parsed?.fetchTtlSeconds,
+      diagnosticsMaxBytes: parsed?.diagnosticsMaxBytes,
     }
   } catch {
     return {

--- a/src/infra/state-layout.ts
+++ b/src/infra/state-layout.ts
@@ -82,6 +82,7 @@ export function parseIssueKey(key: unknown): { owner: string; repo: string; issu
   try {
     const repoKey = Buffer.from(match[1], 'base64url').toString('utf8')
     const slash = repoKey.indexOf('/')
+    if (slash < 0 || repoKey.indexOf('/', slash + 1) !== -1) return null
     const owner = repoKey.slice(0, slash)
     const repo = repoKey.slice(slash + 1)
     if (!validGithubComponent(owner) || !validGithubComponent(repo)) return null

--- a/src/infra/state-layout.ts
+++ b/src/infra/state-layout.ts
@@ -75,14 +75,30 @@ export function issueKey(repoKey: string, number: string): string {
   return `issue-${Buffer.from(repoKey, 'utf8').toString('base64url')}-${number}`
 }
 
-export function legacyIssueKey(key: string): string | null {
+export function parseIssueKey(key: unknown): { owner: string; repo: string; issue: string } | null {
+  if (typeof key !== 'string') return null
   const match = key.match(/^issue-([A-Za-z0-9_-]+)-([1-9]\d*)$/)
   if (!match) return null
   try {
     const repoKey = Buffer.from(match[1], 'base64url').toString('utf8')
-    if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repoKey)) return null
-    return `${repoKey.replace('/', '-')}-${match[2]}`
+    const slash = repoKey.indexOf('/')
+    const owner = repoKey.slice(0, slash)
+    const repo = repoKey.slice(slash + 1)
+    if (!validGithubComponent(owner) || !validGithubComponent(repo)) return null
+    return { owner, repo, issue: match[2] }
   } catch {
     return null
   }
+}
+
+export function diagnosticLogPath(root: string, workflowKey?: unknown): string {
+  const coordinates = parseIssueKey(workflowKey)
+  return coordinates
+    ? join(issueDirectory(root, coordinates.owner, coordinates.repo, coordinates.issue), 'diagnostics.jsonl')
+    : join(root, 'diagnostics.jsonl')
+}
+
+export function legacyIssueKey(key: string): string | null {
+  const coordinates = parseIssueKey(key)
+  return coordinates ? `${coordinates.owner}-${coordinates.repo}-${coordinates.issue}` : null
 }

--- a/src/infra/task-diagnostics.ts
+++ b/src/infra/task-diagnostics.ts
@@ -1,4 +1,8 @@
 import { randomUUID } from 'node:crypto'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { appendDiagnosticLine, DEFAULT_DIAGNOSTIC_MAX_BYTES, waitForDiagnosticLines } from './diagnostic-log-store.ts'
+import { loadConfig } from './runtime.ts'
 
 export const runtimeIdentity = Object.freeze({
   runtimeInstanceId: randomUUID(),
@@ -9,13 +13,24 @@ export const runtimeIdentity = Object.freeze({
 
 /** One structured diagnostic stream correlates task ownership across plugin instances. */
 export function logTaskDiagnostic(event: string, fields: Record<string, unknown>): void {
-  console.warn(
-    JSON.stringify({
-      source: 'clickvibe',
-      event,
-      at: new Date().toISOString(),
-      ...runtimeIdentity,
-      ...fields,
-    }),
+  const record = {
+    source: 'clickvibe',
+    event,
+    at: new Date().toISOString(),
+    ...runtimeIdentity,
+    ...fields,
+  }
+  const line = JSON.stringify(record)
+  console.warn(line)
+  const maxBytes = loadConfig()
+    .then((config) => config.diagnosticsMaxBytes ?? DEFAULT_DIAGNOSTIC_MAX_BYTES)
+    .catch(() => DEFAULT_DIAGNOSTIC_MAX_BYTES)
+  void appendDiagnosticLine(join(homedir(), '.clickvibe', 'state'), fields.workflowKey, line, maxBytes).catch(
+    () => undefined,
   )
+}
+
+/** Await best-effort writes before a task releases or deletes its persistence directory. */
+export function waitForTaskDiagnosticPersistence(workflowKey: unknown): Promise<void> {
+  return waitForDiagnosticLines(join(homedir(), '.clickvibe', 'state'), workflowKey)
 }

--- a/src/infra/task-diagnostics.ts
+++ b/src/infra/task-diagnostics.ts
@@ -1,8 +1,7 @@
 import { randomUUID } from 'node:crypto'
-import { homedir } from 'node:os'
-import { join } from 'node:path'
 import { appendDiagnosticLine, DEFAULT_DIAGNOSTIC_MAX_BYTES, waitForDiagnosticLines } from './diagnostic-log-store.ts'
 import { loadConfig } from './runtime.ts'
+import { stateDir } from './state.ts'
 
 export const runtimeIdentity = Object.freeze({
   runtimeInstanceId: randomUUID(),
@@ -25,12 +24,10 @@ export function logTaskDiagnostic(event: string, fields: Record<string, unknown>
   const maxBytes = loadConfig()
     .then((config) => config.diagnosticsMaxBytes ?? DEFAULT_DIAGNOSTIC_MAX_BYTES)
     .catch(() => DEFAULT_DIAGNOSTIC_MAX_BYTES)
-  void appendDiagnosticLine(join(homedir(), '.clickvibe', 'state'), fields.workflowKey, line, maxBytes).catch(
-    () => undefined,
-  )
+  void appendDiagnosticLine(stateDir(), fields.workflowKey, line, maxBytes).catch(() => undefined)
 }
 
 /** Await best-effort writes before a task releases or deletes its persistence directory. */
 export function waitForTaskDiagnosticPersistence(workflowKey: unknown): Promise<void> {
-  return waitForDiagnosticLines(join(homedir(), '.clickvibe', 'state'), workflowKey)
+  return waitForDiagnosticLines(stateDir(), workflowKey)
 }

--- a/tests/auto-run-recovery.test.ts
+++ b/tests/auto-run-recovery.test.ts
@@ -1,11 +1,11 @@
 import assert from 'node:assert/strict'
-import { commitWorkflowFixture } from './workflow-fixture.ts'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
-import { issueKey, loadWorkflow, type IssueWorkflow } from '../src/infra/state.ts'
+import { type IssueWorkflow, issueKey, loadWorkflow } from '../src/infra/state.ts'
 import { requestAutoRunReconcile } from '../src/workflow/auto-run.ts'
+import { commitWorkflowFixture } from './workflow-fixture.ts'
 
 test('a reconcile exception is preserved as controller-error, never session-interrupted', async () => {
   const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-reconcile-'))
@@ -72,6 +72,23 @@ test('a reconcile exception is preserved as controller-error, never session-inte
     // 证据必须落盘:暂停原因之外,原始错误文本要写进本地事件(#90 事故:两次
     // controller-error 暂停均无法追溯,console 诊断几分钟内被滚动缓冲冲掉)。
     assert.match(observed?.events.at(-1)?.note ?? '', /forced reconcile failure/)
+    const diagnosticPath = join(tempHome, '.clickvibe', 'state', 'owner', 'repo', 'issue-111', 'diagnostics.jsonl')
+    let diagnostics = ''
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      diagnostics = await readFile(diagnosticPath, 'utf8').catch(() => '')
+      if (diagnostics.includes('auto-run-reconcile-error')) break
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    assert.notEqual(diagnostics, '')
+    const reconcileError = diagnostics
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line))
+      .find((record) => record.event === 'auto-run-reconcile-error')
+    assert.equal(reconcileError.errorName, 'Error')
+    assert.equal(reconcileError.errorMessage, 'forced reconcile failure')
+    assert.match(reconcileError.errorStack, /forced reconcile failure/)
+    assert.equal(reconcileError.workflowKey, key)
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome

--- a/tests/state-layout.test.ts
+++ b/tests/state-layout.test.ts
@@ -1,12 +1,20 @@
 import assert from 'node:assert/strict'
-import { commitWorkflowFixture } from './workflow-fixture.ts'
-import { appendFile, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { appendFile, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
 import { encodeLiveLogEvent } from '../src/infra/live-output.ts'
-import { appendTaskLog, loadWorkflow, readTaskLog, startTaskLog, type IssueWorkflow } from '../src/infra/state.ts'
-import { issueDirectory, issueKey, parseIssueDirectory, taskLogPath, workflowPath } from '../src/infra/state-layout.ts'
+import { appendTaskLog, type IssueWorkflow, loadWorkflow, readTaskLog, startTaskLog } from '../src/infra/state.ts'
+import {
+  issueDirectory,
+  issueKey,
+  legacyIssueKey,
+  parseIssueDirectory,
+  parseIssueKey,
+  taskLogPath,
+  workflowPath,
+} from '../src/infra/state-layout.ts'
+import { commitWorkflowFixture } from './workflow-fixture.ts'
 
 function fixture(key = issueKey('a-b/c', '7')): IssueWorkflow {
   return {
@@ -47,6 +55,9 @@ test('project issue paths are reversible and do not depend on collision-prone ke
   assert.throws(() => issueDirectory(root, 'a-b', '..', '7'), /invalid issue coordinates/)
   assert.notEqual(issueKey('a-b/c', '7'), issueKey('a/b-c', '7'))
   assert.equal(workflowPath(root, fixture()), '/state/a-b/c/issue-7/workflow.json')
+  for (const invalid of [issueKey('foo', '7'), issueKey('a/b/c', '7')]) {
+    assert.deepEqual([parseIssueKey(invalid), legacyIssueKey(invalid)], [null, null])
+  }
 })
 
 test('task generations append valid structured JSONL independently and aggregate metrics', async () => {

--- a/tests/task-diagnostics.test.ts
+++ b/tests/task-diagnostics.test.ts
@@ -39,20 +39,10 @@ test('task diagnostics persist the exact console JSON under the owning issue', a
     const raw = await readEventually(path)
     assert.equal(raw, `${warnings[0]}\n`)
     const persisted = JSON.parse(raw)
-    const warned = JSON.parse(warnings[0])
-    assert.deepEqual(persisted, {
-      source: 'clickvibe',
-      event: 'auto-run-reconcile-error',
-      at: warned.at,
-      runtimeInstanceId: warned.runtimeInstanceId,
-      pid: process.pid,
-      loadedAt: warned.loadedAt,
-      modulePath: warned.modulePath,
-      workflowKey: issueKey('owner/repo', '123'),
-      errorName: 'Error',
-      errorMessage: 'forced reconcile failure',
-      errorStack,
-    })
+    assert.equal(persisted.workflowKey, issueKey('owner/repo', '123'))
+    assert.equal(persisted.errorName, 'Error')
+    assert.equal(persisted.errorMessage, 'forced reconcile failure')
+    assert.equal(persisted.errorStack, errorStack)
     await assert.rejects(readFile(join(tempHome, '.clickvibe', 'state', 'diagnostics.jsonl'), 'utf8'), /ENOENT/)
   } finally {
     console.warn = originalWarn
@@ -62,7 +52,7 @@ test('task diagnostics persist the exact console JSON under the owning issue', a
   }
 })
 
-test('global diagnostics rotate at the configured byte limit without truncating records', async () => {
+test('an oversized diagnostic remains complete when the next record rotates it', async () => {
   const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-diagnostics-rotation-'))
   const previousHome = process.env.HOME
   const originalWarn = console.warn
@@ -71,9 +61,9 @@ test('global diagnostics rotate at the configured byte limit without truncating 
   console.warn = (message?: unknown) => warnings.push(String(message))
   try {
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await writeFile(join(tempHome, '.clickvibe', 'config.yaml'), 'diagnosticsMaxBytes: 600\n', 'utf8')
-    logTaskDiagnostic('global-first', { evidence: 'a'.repeat(400) })
-    logTaskDiagnostic('global-second', { evidence: 'b'.repeat(400) })
+    await writeFile(join(tempHome, '.clickvibe', 'config.yaml'), 'diagnosticsMaxBytes: 200\n', 'utf8')
+    logTaskDiagnostic('global-oversized', { workflowKey: issueKey('foo', '7'), evidence: 'a'.repeat(1_000) })
+    logTaskDiagnostic('global-next', { evidence: 'next' })
 
     const path = join(tempHome, '.clickvibe', 'state', 'diagnostics.jsonl')
     const rotatedPath = join(tempHome, '.clickvibe', 'state', 'diagnostics.1.jsonl')
@@ -81,8 +71,8 @@ test('global diagnostics rotate at the configured byte limit without truncating 
     const active = await readEventually(path)
     assert.equal(rotated, `${warnings[0]}\n`)
     assert.equal(active, `${warnings[1]}\n`)
-    assert.equal(JSON.parse(rotated).evidence, 'a'.repeat(400))
-    assert.equal(JSON.parse(active).evidence, 'b'.repeat(400))
+    assert.equal(JSON.parse(rotated).evidence, 'a'.repeat(1_000))
+    assert.equal(JSON.parse(active).evidence, 'next')
   } finally {
     console.warn = originalWarn
     if (previousHome === undefined) delete process.env.HOME

--- a/tests/task-diagnostics.test.ts
+++ b/tests/task-diagnostics.test.ts
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { issueKey } from '../src/infra/state-layout.ts'
+import { logTaskDiagnostic } from '../src/infra/task-diagnostics.ts'
+
+async function readEventually(path: string): Promise<string> {
+  let lastError: unknown
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      return await readFile(path, 'utf8')
+    } catch (error) {
+      lastError = error
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+  }
+  throw lastError
+}
+
+test('task diagnostics persist the exact console JSON under the owning issue', async () => {
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-diagnostics-'))
+  const previousHome = process.env.HOME
+  const originalWarn = console.warn
+  const warnings: string[] = []
+  process.env.HOME = tempHome
+  console.warn = (message?: unknown) => warnings.push(String(message))
+  try {
+    const errorStack = 'Error: forced reconcile failure\n    at reconcileOnce (auto-run.ts:1:1)'
+    logTaskDiagnostic('auto-run-reconcile-error', {
+      workflowKey: issueKey('owner/repo', '123'),
+      errorName: 'Error',
+      errorMessage: 'forced reconcile failure',
+      errorStack,
+    })
+
+    const path = join(tempHome, '.clickvibe', 'state', 'owner', 'repo', 'issue-123', 'diagnostics.jsonl')
+    const raw = await readEventually(path)
+    assert.equal(raw, `${warnings[0]}\n`)
+    const persisted = JSON.parse(raw)
+    const warned = JSON.parse(warnings[0])
+    assert.deepEqual(persisted, {
+      source: 'clickvibe',
+      event: 'auto-run-reconcile-error',
+      at: warned.at,
+      runtimeInstanceId: warned.runtimeInstanceId,
+      pid: process.pid,
+      loadedAt: warned.loadedAt,
+      modulePath: warned.modulePath,
+      workflowKey: issueKey('owner/repo', '123'),
+      errorName: 'Error',
+      errorMessage: 'forced reconcile failure',
+      errorStack,
+    })
+    await assert.rejects(readFile(join(tempHome, '.clickvibe', 'state', 'diagnostics.jsonl'), 'utf8'), /ENOENT/)
+  } finally {
+    console.warn = originalWarn
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
+})
+
+test('global diagnostics rotate at the configured byte limit without truncating records', async () => {
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-diagnostics-rotation-'))
+  const previousHome = process.env.HOME
+  const originalWarn = console.warn
+  const warnings: string[] = []
+  process.env.HOME = tempHome
+  console.warn = (message?: unknown) => warnings.push(String(message))
+  try {
+    await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
+    await writeFile(join(tempHome, '.clickvibe', 'config.yaml'), 'diagnosticsMaxBytes: 600\n', 'utf8')
+    logTaskDiagnostic('global-first', { evidence: 'a'.repeat(400) })
+    logTaskDiagnostic('global-second', { evidence: 'b'.repeat(400) })
+
+    const path = join(tempHome, '.clickvibe', 'state', 'diagnostics.jsonl')
+    const rotatedPath = join(tempHome, '.clickvibe', 'state', 'diagnostics.1.jsonl')
+    const rotated = await readEventually(rotatedPath)
+    const active = await readEventually(path)
+    assert.equal(rotated, `${warnings[0]}\n`)
+    assert.equal(active, `${warnings[1]}\n`)
+    assert.equal(JSON.parse(rotated).evidence, 'a'.repeat(400))
+    assert.equal(JSON.parse(active).evidence, 'b'.repeat(400))
+  } finally {
+    console.warn = originalWarn
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
+})
+
+test('diagnostic persistence failure never escapes logTaskDiagnostic', async () => {
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-diagnostics-failure-'))
+  const previousHome = process.env.HOME
+  const originalWarn = console.warn
+  process.env.HOME = tempHome
+  console.warn = () => undefined
+  try {
+    await writeFile(join(tempHome, '.clickvibe'), 'blocks state directory creation', 'utf8')
+    assert.doesNotThrow(() => logTaskDiagnostic('best-effort', { workflowKey: issueKey('owner/repo', '123') }))
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  } finally {
+    console.warn = originalWarn
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## 变更

- `logTaskDiagnostic` 继续同步输出同一条 console JSON，并 best-effort 追加到持久 JSONL
- 有效 workflow key 路由到 issue 目录，无归属或非法 key 路由到全局诊断文件
- `diagnosticsMaxBytes` 控制活动文件大小，默认 5 MiB，保留一个 `diagnostics.1.jsonl` 轮转段
- 同一路径的检查、轮转、追加经共享队列串行化；任务持久化 drain 同时等待诊断写
- controller-error 回归验证可从文件恢复 errorName、errorMessage 与完整 stack

## Review round 1 返工

- `parseIssueKey` 强制 base64url 解码结果恰好包含一个 `/`；无斜杠和多斜杠均返回 `null`，`legacyIssueKey` 同步保持旧语义
- 诊断持久化复用 `stateDir()`，消除 state root 的重复推导
- 新增超阈值单条诊断回归：内容完整、JSON 可解析，并由下一条记录触发轮转；同时覆盖非法 key 落全局文件
- 返工 diff 为 29 additions / 30 deletions；相对 `origin/main` 的总净增由 239 行降为 238 行

## 验证

- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `pnpm test`（392/392）
- [x] `pnpm run coverage`（lines 92.21%，functions 87.88%）
- [x] `pnpm run lint`
- [x] `pnpm run format:check`
- [x] `pnpm run check:size`
- [x] `pnpm run check:layers`
- [x] `pnpm run check:state-writes`
- [ ] 人工：真实 DSH 触发 controller-error，核对 console 与 JSONL，并在宿主重启后回读

Closes #123