### PR TITLE
refactor(client): 样式颜色/字号 token 化覆盖 ≥80%

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "fmt": "biome format --write src tests scripts",
     "check:size": "node scripts/check-file-size.mjs",
     "check:layers": "node scripts/check-import-layers.mjs",
+    "check:style-tokens": "node scripts/check-style-tokens.mjs",
     "check:state-writes": "node scripts/check-state-writes.mjs",
-    "check": "pnpm run typecheck && pnpm run lint && pnpm run format:check && pnpm run check:size && pnpm run check:layers && pnpm run check:state-writes"
+    "check": "pnpm run typecheck && pnpm run lint && pnpm run format:check && pnpm run check:size && pnpm run check:layers && pnpm run check:style-tokens && pnpm run check:state-writes"
   }
 }

--- a/scripts/check-style-tokens.mjs
+++ b/scripts/check-style-tokens.mjs
@@ -1,0 +1,63 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export const MINIMUM_STYLE_TOKEN_COVERAGE = 0.8
+
+const EXCLUDED_SECTIONS = [
+  ['/* ClickVibe semantic palette: start */', '/* ClickVibe semantic palette: end */'],
+  ['/* Fixed dark terminal palette: start */', '/* Fixed dark terminal palette: end */'],
+]
+
+function removeMarkedSection(css, start, end) {
+  const startIndex = css.indexOf(start)
+  const endIndex = css.indexOf(end, startIndex + start.length)
+  if (startIndex === -1 || endIndex === -1) {
+    throw new Error(`missing style coverage marker: ${startIndex === -1 ? start : end}`)
+  }
+  return css.slice(0, startIndex) + css.slice(endIndex + end.length)
+}
+
+export function extractPanelCss(source) {
+  const declaration = 'export const PANEL_CSS = `'
+  const startIndex = source.indexOf(declaration)
+  const endIndex = source.lastIndexOf('`')
+  if (startIndex === -1 || endIndex <= startIndex) {
+    throw new Error('could not extract PANEL_CSS template')
+  }
+  return source.slice(startIndex + declaration.length, endIndex)
+}
+
+export function measureStyleTokenCoverage(panelCss) {
+  const commonCss = EXCLUDED_SECTIONS.reduce((css, [start, end]) => removeMarkedSection(css, start, end), panelCss)
+  const declarations = [...commonCss.matchAll(/([\w-]+)\s*:\s*([^;{}]+);/g)]
+    .map((match) => ({ property: match[1] ?? '', value: match[2] ?? '' }))
+    .filter(({ property }) => !property.startsWith('--'))
+  const token = /var\(--(?:dsw|cv)-/
+  const colorLiteral = /#[0-9a-f]{3,8}\b|(?:rgb|hsl)a?\(/i
+  const fontSizeLiteral = /\d+(?:\.\d+)?px/i
+  const relevant = declarations.filter(({ property, value }) => {
+    const isFontSize = property === 'font-size' && (token.test(value) || fontSizeLiteral.test(value))
+    const isColorMaterial =
+      /(?:color|background|border|outline|shadow)/.test(property) && (token.test(value) || colorLiteral.test(value))
+    return isFontSize || isColorMaterial
+  })
+  const covered = relevant.filter(({ value }) => token.test(value)).length
+  const total = relevant.length
+  return { covered, total, ratio: total === 0 ? 0 : covered / total }
+}
+
+function run() {
+  const stylesPath = path.resolve(process.argv[2] ?? 'src/client/styles.ts')
+  const css = extractPanelCss(fs.readFileSync(stylesPath, 'utf8'))
+  const coverage = measureStyleTokenCoverage(css)
+  const percent = (coverage.ratio * 100).toFixed(2)
+  console.log(`style token coverage: ${percent}% (${coverage.covered}/${coverage.total})`)
+  if (coverage.ratio < MINIMUM_STYLE_TOKEN_COVERAGE) {
+    console.error(`required style token coverage: ${MINIMUM_STYLE_TOKEN_COVERAGE * 100}%`)
+    process.exitCode = 1
+  }
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (isMain) run()

--- a/src/client/styles.ts
+++ b/src/client/styles.ts
@@ -10,7 +10,7 @@ body[data-ds-dark-theme] .cv-panel-slot { --cv-review-primary: #d2a8ff; --cv-rev
 #root.cv-panel-host-open { margin-right: calc(var(--dsh-sidebar-width, 0px) + var(--cv-sidebar-width, 0px)); width: calc(100% - var(--dsh-sidebar-width, 0px) - var(--cv-sidebar-width, 0px)); transition: margin-right var(--ds-transition-duration-slow) var(--ds-ease-in-out), width var(--ds-transition-duration-slow) var(--ds-ease-in-out); }
 .cv-panel-slot { position: fixed; z-index: 50; top: 0; right: var(--dsh-sidebar-width, 0px); bottom: 0; width: var(--cv-sidebar-width); min-width: 0; overflow: visible; pointer-events: auto; transition: right var(--ds-transition-duration-slow) var(--ds-ease-in-out), width var(--ds-transition-duration-slow) var(--ds-ease-in-out); }
 .cv-panel-slot[data-cv-mobile] { right: 0; width: 100vw; }
-.cv-panel { width: 100%; height: 100%; display: flex; flex-direction: column; background: var(--dsw-alias-bg-base); border-left: 1px solid var(--dsw-alias-border-l2); box-sizing: border-box; font-size: 13px; color: var(--dsw-alias-label-primary); }
+.cv-panel { width: 100%; height: 100%; display: flex; flex-direction: column; background: var(--dsw-alias-bg-base); border-left: 1px solid var(--dsw-alias-border-l2); box-sizing: border-box; font-size: var(--dsw-font-xs-13-font-size); color: var(--dsw-alias-label-primary); }
 .cv-panel-resizer { position: absolute; z-index: 2; top: 0; bottom: 0; left: -5px; width: 10px; cursor: col-resize; touch-action: none; }
 .cv-panel-resizer::after { content: ''; position: absolute; top: 50%; left: 50%; width: 4px; height: 36px; border-radius: 3px; background: var(--dsw-alias-label-caption); opacity: 0; transform: translate(-50%, -50%); transition: opacity 120ms ease; }
 .cv-panel-resizer:hover::after, .cv-panel-resizer:focus-visible::after, .cv-panel-resizer[data-dragging]::after { opacity: .75; }
@@ -18,27 +18,27 @@ body[data-cv-panel-dragging] #root.cv-panel-host-open, body[data-cv-panel-draggi
 @media (prefers-reduced-motion: reduce) { #root.cv-panel-host-open, .cv-panel-slot { transition: none; } }
 .cv-panel-header { display: flex; align-items: center; justify-content: space-between; padding: 10px 14px; font-weight: 600; color: var(--dsw-alias-label-primary); border-bottom: 1px solid var(--dsw-alias-border-l2); flex-shrink: 0; }
 .cv-panel-header-actions { display: flex; align-items: center; gap: 6px; }
-.cv-close { border: none; background: transparent; cursor: pointer; font-size: 14px; color: var(--dsw-alias-label-secondary); }
+.cv-close { border: none; background: transparent; cursor: pointer; font-size: var(--dsw-font-s-14-font-size); color: var(--dsw-alias-label-secondary); }
 .cv-close:hover { color: var(--dsw-alias-label-primary); }
 .cv-input-row { display: flex; gap: 6px; padding: 4px 14px; flex-shrink: 0; }
 .cv-input-row:last-of-type { padding-bottom: 10px; }
 .cv-project-toolbar { padding: 10px 12px; border-bottom: 1px solid var(--dsw-alias-border-l2); display: grid; gap: 8px; }
 .cv-project-selects { display: flex; gap: 6px; }
-.cv-project-import { display: flex; align-items: center; gap: 8px; color: var(--dsw-alias-label-secondary); font-size: 11px; }
+.cv-project-import { display: flex; align-items: center; gap: 8px; color: var(--dsw-alias-label-secondary); font-size: var(--dsw-font-xxxs-11-font-size); }
 .cv-project-import span { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cv-batch-bar { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
-.cv-batch-btn { border: none; border-radius: 6px; padding: 6px 9px; background: var(--dsw-alias-state-business-primary); color: var(--dsw-alias-label-primary-foreground); font-size: 11px; font-weight: 600; cursor: pointer; }
+.cv-batch-btn { border: none; border-radius: 6px; padding: 6px 9px; background: var(--dsw-alias-state-business-primary); color: var(--dsw-alias-label-primary-foreground); font-size: var(--dsw-font-xxxs-11-font-size); font-weight: 600; cursor: pointer; }
 .cv-batch-btn:disabled { opacity: .5; cursor: not-allowed; }
 .cv-batch-btn.cv-batch-secondary { background: var(--dsw-alias-button-contrast-fill); }
 .cv-batch-agent { display: inline-flex; border: 1px solid var(--dsw-alias-border-l2); border-radius: 6px; overflow: hidden; }
-.cv-batch-agent button { border: none; padding: 5px 8px; background: var(--dsw-alias-bg-base); color: var(--dsw-alias-label-secondary); cursor: pointer; font-size: 11px; }
+.cv-batch-agent button { border: none; padding: 5px 8px; background: var(--dsw-alias-bg-base); color: var(--dsw-alias-label-secondary); cursor: pointer; font-size: var(--dsw-font-xxxs-11-font-size); }
 .cv-batch-agent button.on { background: var(--dsw-alias-button-primary-fill); color: var(--dsw-alias-label-primary-foreground); }
-.cv-batch-status { color: var(--dsw-alias-label-secondary); font-size: 11px; }
+.cv-batch-status { color: var(--dsw-alias-label-secondary); font-size: var(--dsw-font-xxxs-11-font-size); }
 .cv-row-select { margin: 0; accent-color: var(--dsw-alias-state-business-primary); }
 .cv-select { min-width: 0; flex: 1; border: 1px solid var(--dsw-alias-border-l2); border-radius: 6px; background: var(--dsw-alias-bg-base); padding: 6px 8px; color: var(--dsw-alias-label-primary); }
-.cv-project-meta { color: var(--dsw-alias-label-secondary); font-size: 11px; }
+.cv-project-meta { color: var(--dsw-alias-label-secondary); font-size: var(--dsw-font-xxxs-11-font-size); }
 .cv-project-list { flex: 1; overflow-y: auto; padding: 8px 10px 16px; }
-.cv-group-title { margin: 10px 2px 5px; color: var(--dsw-alias-label-secondary); font-size: 11px; font-weight: 700; }
+.cv-group-title { margin: 10px 2px 5px; color: var(--dsw-alias-label-secondary); font-size: var(--dsw-font-xxxs-11-font-size); font-weight: 700; }
 .cv-issue-row { display: grid; grid-template-columns: auto auto minmax(0, 1fr) auto; gap: 8px; align-items: center; padding: 9px 8px; border: 1px solid var(--dsw-alias-border-l2); border-radius: 7px; margin-bottom: 6px; background: var(--dsw-alias-bg-base); }
 .cv-issue-row-main { min-width: 0; container-type: inline-size; }
 .cv-issue-row-title { display: block; color: var(--dsw-alias-state-business-primary); font-size: 12.5px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; cursor: pointer; }
@@ -58,13 +58,13 @@ body[data-cv-panel-dragging] #root.cv-panel-host-open, body[data-cv-panel-draggi
 .cv-row-contract { color: var(--dsw-alias-state-error-primary); font-weight: 600; }
 .cv-row-ready { color: var(--dsw-alias-state-success-primary); font-weight: 600; }
 :is(.cv-row-lag, .cv-row-contract, .cv-row-ready) .cv-row-meta-value { color: inherit; }
-.cv-row-action { border: none; border-radius: 6px; padding: 5px 8px; background: var(--dsw-alias-state-success-primary); color: var(--dsw-alias-label-primary-foreground); font-size: 11px; white-space: nowrap; cursor: pointer; }
+.cv-row-action { border: none; border-radius: 6px; padding: 5px 8px; background: var(--dsw-alias-state-success-primary); color: var(--dsw-alias-label-primary-foreground); font-size: var(--dsw-font-xxxs-11-font-size); white-space: nowrap; cursor: pointer; }
 .cv-row-action.cv-row-none { background: var(--dsw-alias-button-primary-dimmed); cursor: default; }
 .cv-row-action.cv-row-running { background: var(--dsw-alias-state-business-primary); cursor: default; }
-.cv-back { border: none; background: transparent; color: var(--dsw-alias-state-business-primary); cursor: pointer; padding: 0; font-size: 12px; }
-.cv-input { flex: 1; min-width: 0; padding: 6px 8px; border: 1px solid var(--dsw-alias-border-l2); border-radius: 6px; background: var(--dsw-alias-bg-base); color: var(--dsw-alias-label-primary); font-size: 12px; }
+.cv-back { border: none; background: transparent; color: var(--dsw-alias-state-business-primary); cursor: pointer; padding: 0; font-size: var(--dsw-font-xxs-12-font-size); }
+.cv-input { flex: 1; min-width: 0; padding: 6px 8px; border: 1px solid var(--dsw-alias-border-l2); border-radius: 6px; background: var(--dsw-alias-bg-base); color: var(--dsw-alias-label-primary); font-size: var(--dsw-font-xxs-12-font-size); }
 .cv-input::placeholder { color: var(--dsw-alias-label-caption); }
-.cv-fetch { padding: 6px 12px; border: none; border-radius: 6px; background: var(--dsw-alias-state-business-primary); color: var(--dsw-alias-label-primary-foreground); cursor: pointer; font-size: 12px; }
+.cv-fetch { padding: 6px 12px; border: none; border-radius: 6px; background: var(--dsw-alias-state-business-primary); color: var(--dsw-alias-label-primary-foreground); cursor: pointer; font-size: var(--dsw-font-xxs-12-font-size); }
 .cv-fetch:disabled { opacity: 0.6; }
 .cv-error { margin: 0 14px 10px; padding: 8px 10px; border-radius: 6px; background: var(--dsw-alias-interactive-bg-hover-danger); color: var(--dsw-alias-state-error-primary); border: 1px solid var(--dsw-alias-state-error-secondary); flex-shrink: 0; }
 .cv-stale { margin: 8px 12px 0; padding: 6px 8px; border-radius: 6px; background: var(--dsw-alias-state-warn-tertiary); color: var(--dsw-alias-state-warn-label); border: 1px solid var(--dsw-alias-state-warn-secondary); font-size: 11.5px; flex-shrink: 0; }
@@ -73,7 +73,7 @@ body[data-cv-panel-dragging] #root.cv-panel-host-open, body[data-cv-panel-draggi
 .cv-loading { padding: 20px 14px; color: var(--dsw-alias-label-secondary); text-align: center; }
 .cv-issue { padding: 12px 14px; display: flex; flex-direction: column; gap: 8px; flex: 1; overflow-y: auto; }
 .cv-issue-head { display: flex; gap: 6px; align-items: center; }
-.cv-badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 11px; font-weight: 600; }
+.cv-badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: var(--dsw-font-xxxs-11-font-size); font-weight: 600; }
 .cv-badge-open { background: var(--dsw-alias-state-success-tertiary); color: var(--dsw-alias-state-success-primary); }
 .cv-badge-closed { background: var(--dsw-alias-interactive-bg-hover-danger); color: var(--dsw-alias-state-error-primary); }
 .cv-badge-merged { background: var(--cv-review-tertiary); color: var(--cv-review-primary); }
@@ -81,43 +81,43 @@ body[data-cv-panel-dragging] #root.cv-panel-host-open, body[data-cv-panel-draggi
 .cv-issue-title { font-size: 15px; font-weight: 700; color: var(--dsw-alias-state-business-primary); text-decoration: none; }
 .cv-issue-title:hover { text-decoration: underline; }
 .cv-dsh-open-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-.cv-dsh-open-btn { border: 1px solid var(--dsw-alias-border-l2); background: var(--dsw-alias-bg-base); border-radius: 6px; padding: 4px 10px; font-size: 12px; color: var(--dsw-alias-label-primary); cursor: pointer; }
+.cv-dsh-open-btn { border: 1px solid var(--dsw-alias-border-l2); background: var(--dsw-alias-bg-base); border-radius: 6px; padding: 4px 10px; font-size: var(--dsw-font-xxs-12-font-size); color: var(--dsw-alias-label-primary); cursor: pointer; }
 .cv-dsh-open-btn:hover:not(:disabled) { background: var(--dsw-alias-interactive-bg-hover-solid); }
 .cv-dsh-open-btn:disabled { opacity: .55; cursor: not-allowed; }
-.cv-dsh-open-status { font-size: 11px; color: var(--dsw-alias-state-warn-label); word-break: break-all; }
-.cv-issue-labels { display: flex; flex-wrap: wrap; gap: 4px; font-size: 11px; }
+.cv-dsh-open-status { font-size: var(--dsw-font-xxxs-11-font-size); color: var(--dsw-alias-state-warn-label); word-break: break-all; }
+.cv-issue-labels { display: flex; flex-wrap: wrap; gap: 4px; font-size: var(--dsw-font-xxxs-11-font-size); }
 .cv-issue-labels span { padding: 1px 6px; border-radius: 10px; background: var(--dsw-alias-state-business-tertiary); color: var(--dsw-alias-state-business-primary); }
-.cv-issue-assignees { font-size: 12px; color: var(--dsw-alias-label-secondary); }
-.cv-meta { width: 100%; border-collapse: collapse; font-size: 12px; }
+.cv-issue-assignees { font-size: var(--dsw-font-xxs-12-font-size); color: var(--dsw-alias-label-secondary); }
+.cv-meta { width: 100%; border-collapse: collapse; font-size: var(--dsw-font-xxs-12-font-size); }
 .cv-meta tr { border-bottom: 1px solid var(--dsw-alias-border-l1); }
 .cv-meta tr:last-child { border-bottom: none; }
 .cv-meta-k { width: 52px; padding: 3px 0; color: var(--dsw-alias-label-caption); vertical-align: top; }
 .cv-meta-v { padding: 3px 0; color: var(--dsw-alias-label-primary); word-break: break-all; }
 .cv-issue-body { border: 1px solid var(--dsw-alias-border-l2); border-radius: 6px; padding: 10px; font-size: 12.5px; }
 .cv-comments { display: flex; flex-direction: column; gap: 6px; }
-.cv-comments-empty { font-size: 12px; color: var(--dsw-alias-label-caption); padding: 4px 0; }
+.cv-comments-empty { font-size: var(--dsw-font-xxs-12-font-size); color: var(--dsw-alias-label-caption); padding: 4px 0; }
 .cv-comments-toggle { border: none; background: transparent; cursor: pointer; font-size: 12.5px; font-weight: 600; color: var(--dsw-alias-state-business-primary); padding: 2px 0; text-align: left; }
 .cv-comment { border: 1px solid var(--dsw-alias-border-l2); border-radius: 6px; padding: 8px 10px; }
 .cv-comment-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px; font-size: 11.5px; }
 .cv-comment-author { font-weight: 600; color: var(--dsw-alias-state-business-primary); }
 .cv-comment-date { color: var(--dsw-alias-label-caption); }
-.cv-toggle { border: 1px solid var(--dsw-alias-border-l2); background: var(--dsw-alias-bg-base); border-radius: 6px; padding: 3px 8px; font-size: 12px; cursor: pointer; color: var(--dsw-alias-label-primary); }
+.cv-toggle { border: 1px solid var(--dsw-alias-border-l2); background: var(--dsw-alias-bg-base); border-radius: 6px; padding: 3px 8px; font-size: var(--dsw-font-xxs-12-font-size); cursor: pointer; color: var(--dsw-alias-label-primary); }
 :where(.cv-panel, .cv-terminal-overlay, .cv-audit-drawer) :is(button, select, input, textarea, a, summary):focus-visible { outline: 2px solid var(--dsw-alias-state-business-primary); outline-offset: 1px; border-radius: 4px; }
 :where(.cv-toggle, .cv-issue-organizer):focus-visible { outline: 2px solid var(--dsw-alias-state-business-primary); outline-offset: 1px; border-radius: 4px; }
 .cv-toggle:hover { background: var(--dsw-alias-interactive-bg-hover-solid); }
 .cv-issue-organizer { border: 0; border-radius: 6px; padding: 4px 8px; background: transparent; color: var(--dsw-alias-label-secondary); font: inherit; white-space: nowrap; cursor: pointer; }
 .cv-issue-organizer:hover { background: var(--dsw-alias-interactive-bg-hover-solid); color: var(--dsw-alias-label-primary); }
-.cv-md { font-size: 13px; line-height: 1.6; color: var(--dsw-alias-label-primary); word-break: break-word; }
+.cv-md { font-size: var(--dsw-font-xs-13-font-size); line-height: 1.6; color: var(--dsw-alias-label-primary); word-break: break-word; }
 .cv-md p { margin: 0 0 8px; }
 .cv-md h1, .cv-md h2, .cv-md h3, .cv-md h4, .cv-md h5, .cv-md h6 { margin: 10px 0 6px; font-weight: 600; }
 .cv-md h1 { font-size: 18px; }
-.cv-md h2 { font-size: 16px; }
+.cv-md h2 { font-size: var(--dsw-font-base-16-font-size); }
 .cv-md h3 { font-size: 14.5px; }
 .cv-md h4, .cv-md h5, .cv-md h6 { font-size: 13.5px; }
 .cv-md pre { background: var(--dsw-alias-markdown-code-block); border: 1px solid var(--dsw-alias-border-l2); border-radius: 6px; padding: 10px; overflow-x: auto; margin: 0 0 8px; }
-.cv-md pre code { background: transparent; padding: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; white-space: pre; }
-.cv-md :not(pre) > code { background: var(--dsw-alias-markdown-inline-code); padding: 1px 4px; border-radius: 4px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }
-.cv-md-code { background: var(--dsw-alias-markdown-inline-code); padding: 1px 4px; border-radius: 4px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }
+.cv-md pre code { background: transparent; padding: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: var(--dsw-font-xxs-12-font-size); white-space: pre; }
+.cv-md :not(pre) > code { background: var(--dsw-alias-markdown-inline-code); padding: 1px 4px; border-radius: 4px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: var(--dsw-font-xxs-12-font-size); }
+.cv-md-code { background: var(--dsw-alias-markdown-inline-code); padding: 1px 4px; border-radius: 4px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: var(--dsw-font-xxs-12-font-size); }
 .cv-md a { color: var(--dsw-alias-state-business-primary); }
 .cv-md ul { padding-left: 20px; list-style: disc; margin: 0 0 8px; }
 .cv-md ol { padding-left: 20px; list-style: decimal; margin: 0 0 8px; }
@@ -132,24 +132,24 @@ body[data-cv-panel-dragging] #root.cv-panel-host-open, body[data-cv-panel-draggi
 .cv-dev-head { font-weight: 600; font-size: 12.5px; color: var(--dsw-alias-label-primary); }
 .cv-dev-actions { display: flex; gap: 6px; }
 .cv-auto-run { position: relative; margin: 6px 0; }
-.cv-auto-run-trigger { border: 1px solid var(--dsw-alias-state-business-primary); border-radius: 6px; padding: 6px 9px; background: transparent; color: var(--dsw-alias-state-business-primary); cursor: pointer; font-size: 11px; font-weight: 600; }
+.cv-auto-run-trigger { border: 1px solid var(--dsw-alias-state-business-primary); border-radius: 6px; padding: 6px 9px; background: transparent; color: var(--dsw-alias-state-business-primary); cursor: pointer; font-size: var(--dsw-font-xxxs-11-font-size); font-weight: 600; }
 .cv-auto-run-trigger:disabled { opacity: .65; cursor: not-allowed; }
 .cv-auto-run-form { display: grid; gap: 7px; margin-top: 6px; padding: 9px; border: 1px solid var(--dsw-alias-border-l2); border-radius: 7px; background: var(--dsw-alias-bg-base); min-width: 220px; }
 .cv-auto-run-compact .cv-auto-run-form { position: absolute; z-index: 20; right: 0; width: 240px; box-shadow: 0 8px 24px color-mix(in srgb, var(--dsw-alias-label-primary) 18%, transparent); }
-.cv-auto-run-form label { display: flex; align-items: center; justify-content: space-between; gap: 8px; color: var(--dsw-alias-label-secondary); font-size: 11px; }
+.cv-auto-run-form label { display: flex; align-items: center; justify-content: space-between; gap: 8px; color: var(--dsw-alias-label-secondary); font-size: var(--dsw-font-xxxs-11-font-size); }
 .cv-auto-run-form select, .cv-auto-run-form input[type="number"] { width: 100px; border: 1px solid var(--dsw-alias-border-l2); border-radius: 4px; background: var(--dsw-alias-bg-base); color: var(--dsw-alias-label-primary); }
 .cv-auto-run-form .cv-auto-run-check { justify-content: flex-start; }
 .cv-auto-run-status, .cv-auto-run-findings { margin-top: 4px; color: var(--dsw-alias-label-secondary); font-size: 10.5px; }
 .cv-auto-run-paused { color: var(--dsw-alias-state-warn-primary); }
 .cv-row-actions { display: flex; align-items: center; gap: 6px; white-space: nowrap; }
 .cv-row-actions .cv-auto-run { margin: 0; }
-.cv-dev-btn { padding: 5px 12px; border: none; border-radius: 6px; cursor: pointer; font-size: 12px; font-weight: 600; color: var(--dsw-alias-label-primary-foreground); }
+.cv-dev-btn { padding: 5px 12px; border: none; border-radius: 6px; cursor: pointer; font-size: var(--dsw-font-xxs-12-font-size); font-weight: 600; color: var(--dsw-alias-label-primary-foreground); }
 .cv-dev-codex { background: var(--dsw-alias-button-primary-fill); }
 .cv-dev-claude { background: var(--dsw-alias-state-warn-primary); }
 .cv-dev-btn:hover { opacity: 0.85; }
-.cv-dev-status { font-size: 12px; color: var(--dsw-alias-label-secondary); }
-.cv-dev-path { font-size: 11px; color: var(--dsw-alias-label-caption); word-break: break-all; margin-top: 2px; }
-.cv-dev-error { font-size: 12px; color: var(--dsw-alias-state-error-primary); background: var(--dsw-alias-interactive-bg-hover-danger); border: 1px solid var(--dsw-alias-state-error-secondary); border-radius: 4px; padding: 6px 8px; }
+.cv-dev-status { font-size: var(--dsw-font-xxs-12-font-size); color: var(--dsw-alias-label-secondary); }
+.cv-dev-path { font-size: var(--dsw-font-xxxs-11-font-size); color: var(--dsw-alias-label-caption); word-break: break-all; margin-top: 2px; }
+.cv-dev-error { font-size: var(--dsw-font-xxs-12-font-size); color: var(--dsw-alias-state-error-primary); background: var(--dsw-alias-interactive-bg-hover-danger); border: 1px solid var(--dsw-alias-state-error-secondary); border-radius: 4px; padding: 6px 8px; }
 /* Fixed dark terminal palette: start */
 .cv-terminal { position: relative; display: flex; flex-direction: column; min-height: 0; overflow: hidden; border: 1px solid #30363d; border-radius: 8px; background: #0d1117; color: #e6edf3; box-shadow: inset 0 1px 0 rgb(255 255 255 / 4%); }
 .cv-terminal-head { min-height: 32px; padding: 0 8px 0 10px; display: flex; align-items: center; gap: 8px; border-bottom: 1px solid #21262d; background: #161b22; font: 600 10.5px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; color: #8b949e; }
@@ -183,32 +183,32 @@ body[data-cv-panel-dragging] #root.cv-panel-host-open, body[data-cv-panel-draggi
 .cv-log-history { border-radius: 6px; background: var(--dsw-alias-interactive-bg-hover-solid); }
 .cv-log-history summary { padding: 5px 8px; cursor: pointer; color: var(--dsw-alias-label-secondary); font-size: 11.5px; font-weight: 600; }
 @media (max-width: 767px) { .cv-terminal-overlay { inset: 0; border-radius: 0; } .cv-terminal-overlay .cv-dev-log { font-size: 12px; } }
-.cv-dev-done { font-size: 12px; color: var(--dsw-alias-state-success-primary); font-weight: 600; }
-.cv-stage { display: inline-block; padding: 1px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; margin-left: 6px; }
+.cv-dev-done { font-size: var(--dsw-font-xxs-12-font-size); color: var(--dsw-alias-state-success-primary); font-weight: 600; }
+.cv-stage { display: inline-block; padding: 1px 8px; border-radius: 10px; font-size: var(--dsw-font-xxxs-11-font-size); font-weight: 600; margin-left: 6px; }
 .cv-stage-idle { background: var(--dsw-alias-interactive-bg-hover-solid); color: var(--dsw-alias-label-secondary); }
 .cv-stage-developing { background: var(--dsw-alias-state-business-tertiary); color: var(--dsw-alias-state-business-primary); }
 .cv-stage-review-ready { background: var(--dsw-alias-state-warn-tertiary); color: var(--dsw-alias-state-warn-label); }
 .cv-stage-reviewing { background: var(--cv-review-tertiary); color: var(--cv-review-primary); }
 .cv-stage-interrupted { background: var(--dsw-alias-state-warn-tertiary); color: var(--dsw-alias-state-warn-label); }
 .cv-stage-passed { background: var(--dsw-alias-state-success-tertiary); color: var(--dsw-alias-state-success-primary); }
-.cv-running-duration { display: inline-flex; align-items: center; gap: 4px; color: var(--dsw-alias-label-secondary); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; white-space: nowrap; }
+.cv-running-duration { display: inline-flex; align-items: center; gap: 4px; color: var(--dsw-alias-label-secondary); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: var(--dsw-font-xxxs-11-font-size); white-space: nowrap; }
 .cv-running-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--dsw-alias-state-success-primary); flex: none; }
 .cv-dev-btn.cv-dev-warn { background: var(--dsw-alias-state-warn-secondary); color: var(--dsw-alias-label-primary-foreground); }
 .cv-dev-btn.cv-dev-review { background: var(--cv-review-primary); color: var(--dsw-alias-label-primary-foreground); }
 .cv-review-fail { display: flex; flex-direction: column; gap: 6px; }
-.cv-review-issues { margin: 0; padding-left: 18px; font-size: 12px; color: var(--dsw-alias-label-primary); }
+.cv-review-issues { margin: 0; padding-left: 18px; font-size: var(--dsw-font-xxs-12-font-size); color: var(--dsw-alias-label-primary); }
 .cv-review-issues li { margin: 2px 0; }
-.cv-refresh { padding: 6px 10px; border: 1px solid var(--dsw-alias-border-l2); border-radius: 6px; background: var(--dsw-alias-bg-base); color: var(--dsw-alias-label-secondary); cursor: pointer; font-size: 14px; line-height: 1; }
+.cv-refresh { padding: 6px 10px; border: 1px solid var(--dsw-alias-border-l2); border-radius: 6px; background: var(--dsw-alias-bg-base); color: var(--dsw-alias-label-secondary); cursor: pointer; font-size: var(--dsw-font-s-14-font-size); line-height: 1; }
 .cv-refresh:hover { background: var(--dsw-alias-interactive-bg-hover-solid); color: var(--dsw-alias-label-primary); }
 .cv-links { display: flex; flex-direction: column; gap: 4px; }
 .cv-section { min-width: 0; border: 1px solid var(--dsw-alias-border-l2); border-radius: 6px; overflow: clip; }
 .cv-section-head { position: sticky; top: 0; z-index: 1; background: var(--dsw-alias-bg-base); }
-.cv-section-toggle { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 8px; border: 0; padding: 7px 9px; background: transparent; color: var(--dsw-alias-label-secondary); font: inherit; font-size: 12px; font-weight: 600; text-align: left; cursor: pointer; }
+.cv-section-toggle { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 8px; border: 0; padding: 7px 9px; background: transparent; color: var(--dsw-alias-label-secondary); font: inherit; font-size: var(--dsw-font-xxs-12-font-size); font-weight: 600; text-align: left; cursor: pointer; }
 .cv-section-toggle:hover { background: var(--dsw-alias-interactive-bg-hover-solid); color: var(--dsw-alias-label-primary); }
 .cv-section-content { max-height: min(360px, 55vh); overflow: auto; overscroll-behavior: contain; padding: 7px 9px 9px; border-top: 1px solid var(--dsw-alias-border-l1); }
 .cv-dep-block { display: flex; flex-direction: column; gap: 4px; }
-.cv-dep-label { font-size: 12px; font-weight: 600; color: var(--dsw-alias-label-secondary); }
-.cv-link-row { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--dsw-alias-label-secondary); flex-wrap: wrap; }
+.cv-dep-label { font-size: var(--dsw-font-xxs-12-font-size); font-weight: 600; color: var(--dsw-alias-label-secondary); }
+.cv-link-row { display: flex; align-items: center; gap: 6px; font-size: var(--dsw-font-xxs-12-font-size); color: var(--dsw-alias-label-secondary); flex-wrap: wrap; }
 .cv-link { color: var(--dsw-alias-state-business-primary); font-weight: 600; text-decoration: none; }
 .cv-link:hover { text-decoration: underline; }
 .cv-link-state { display: inline-block; padding: 0 6px; border-radius: 8px; font-size: 10.5px; font-weight: 600; }
@@ -226,7 +226,7 @@ body[data-cv-panel-dragging] #root.cv-panel-host-open, body[data-cv-panel-draggi
 .cv-link-state-issue-closed { background: var(--cv-review-tertiary); color: var(--cv-review-primary); }
 .cv-stage-new { background: var(--dsw-alias-state-warn-tertiary); color: var(--dsw-alias-state-warn-label); }
 .cv-timeline { border-top: 1px solid var(--dsw-alias-border-l2); padding-top: 6px; display: flex; flex-direction: column; gap: 4px; }
-.cv-timeline-head { font-size: 12px; font-weight: 600; color: var(--dsw-alias-label-secondary); }
+.cv-timeline-head { font-size: var(--dsw-font-xxs-12-font-size); font-weight: 600; color: var(--dsw-alias-label-secondary); }
 .cv-tl-row { display: flex; align-items: center; gap: 6px; font-size: 11.5px; }
 .cv-tl-open { flex: 1; min-width: 0; display: flex; align-items: center; gap: 6px; flex-wrap: wrap; padding: 3px 4px; border: 0; border-radius: 4px; background: transparent; color: inherit; font: inherit; text-align: left; cursor: pointer; }
 .cv-tl-open:hover { background: var(--dsw-alias-interactive-bg-hover-solid); }
@@ -255,30 +255,30 @@ body[data-cv-panel-dragging] #root.cv-panel-host-open, body[data-cv-panel-draggi
 .cv-audit-drawer { position: absolute; top: 0; right: 0; bottom: 0; width: min(480px, 92vw); overflow: auto; padding: 18px; background: var(--dsw-alias-bg-base); box-shadow: var(--dsw-shadow-lv3); color: var(--dsw-alias-label-primary); }
 .cv-audit-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; padding-bottom: 12px; border-bottom: 1px solid var(--dsw-alias-border-l2); }
 .cv-audit-close { border: 0; background: transparent; color: var(--dsw-alias-label-secondary); font-size: 26px; line-height: 1; cursor: pointer; }
-.cv-audit-summary { margin-top: 12px; padding: 8px 10px; border-radius: 6px; background: var(--dsw-alias-interactive-bg-hover-solid); font-size: 12px; font-weight: 600; }
-.cv-audit-section { margin-top: 16px; font-size: 12px; overflow-wrap: anywhere; }
-.cv-audit-section h4 { margin: 0 0 7px; font-size: 12px; color: var(--dsw-alias-label-secondary); }
-.cv-audit-muted { color: var(--dsw-alias-label-caption); font-size: 11px; }
+.cv-audit-summary { margin-top: 12px; padding: 8px 10px; border-radius: 6px; background: var(--dsw-alias-interactive-bg-hover-solid); font-size: var(--dsw-font-xxs-12-font-size); font-weight: 600; }
+.cv-audit-section { margin-top: 16px; font-size: var(--dsw-font-xxs-12-font-size); overflow-wrap: anywhere; }
+.cv-audit-section h4 { margin: 0 0 7px; font-size: var(--dsw-font-xxs-12-font-size); color: var(--dsw-alias-label-secondary); }
+.cv-audit-muted { color: var(--dsw-alias-label-caption); font-size: var(--dsw-font-xxxs-11-font-size); }
 .cv-audit-list { margin: 0; padding-left: 22px; display: flex; flex-direction: column; gap: 7px; }
 .cv-audit-commits code { margin-right: 5px; }
 .cv-audit-diffstat { list-style: none; padding-left: 0; }
 .cv-audit-diffstat li { display: flex; justify-content: space-between; gap: 12px; }
 .cv-audit-diffstat span { overflow-wrap: anywhere; }
-.cv-audit-log { margin-top: 16px; border: 1px solid var(--dsw-alias-state-business-primary); border-radius: 6px; padding: 7px 10px; background: var(--dsw-alias-bg-base); color: var(--dsw-alias-state-business-primary); font-size: 11px; cursor: pointer; }
-.cv-delivery-summary { font-size: 12px; color: var(--dsw-alias-label-secondary); background: var(--dsw-alias-interactive-bg-hover-solid); border-radius: 4px; padding: 6px 8px; }
-.cv-review-next { font-size: 12px; font-weight: 600; }
+.cv-audit-log { margin-top: 16px; border: 1px solid var(--dsw-alias-state-business-primary); border-radius: 6px; padding: 7px 10px; background: var(--dsw-alias-bg-base); color: var(--dsw-alias-state-business-primary); font-size: var(--dsw-font-xxxs-11-font-size); cursor: pointer; }
+.cv-delivery-summary { font-size: var(--dsw-font-xxs-12-font-size); color: var(--dsw-alias-label-secondary); background: var(--dsw-alias-interactive-bg-hover-solid); border-radius: 4px; padding: 6px 8px; }
+.cv-review-next { font-size: var(--dsw-font-xxs-12-font-size); font-weight: 600; }
 .cv-state { border: 1px solid var(--dsw-alias-border-l2); border-radius: 6px; padding: 8px 10px; display: flex; flex-direction: column; gap: 4px; }
-.cv-state-head { font-size: 12px; font-weight: 600; color: var(--dsw-alias-label-secondary); }
+.cv-state-head { font-size: var(--dsw-font-xxs-12-font-size); font-weight: 600; color: var(--dsw-alias-label-secondary); }
 .cv-state-table { width: 100%; border-collapse: collapse; font-size: 11.5px; }
 .cv-state-table td { padding: 3px 0; vertical-align: top; }
 .cv-state-k { width: 78px; color: var(--dsw-alias-label-caption); font-weight: 600; }
 .cv-state-v { color: var(--dsw-alias-label-primary); word-break: break-all; }
-.cv-state-delta { display: block; color: var(--dsw-alias-label-secondary); font-size: 11px; }
+.cv-state-delta { display: block; color: var(--dsw-alias-label-secondary); font-size: var(--dsw-font-xxxs-11-font-size); }
 .cv-state-warn { display: inline-block; margin-left: 6px; padding: 0 6px; border-radius: 8px; background: var(--dsw-alias-state-warn-tertiary); color: var(--dsw-alias-state-warn-label); font-weight: 600; font-size: 10.5px; }
-.cv-review-stale { font-size: 12px; color: var(--dsw-alias-state-warn-label); background: var(--dsw-alias-state-warn-tertiary); border: 1px solid var(--dsw-alias-state-warn-secondary); border-radius: 4px; padding: 6px 8px; }
-.cv-dev-noop { font-size: 12px; color: var(--dsw-alias-label-caption); padding: 4px 0; }
+.cv-review-stale { font-size: var(--dsw-font-xxs-12-font-size); color: var(--dsw-alias-state-warn-label); background: var(--dsw-alias-state-warn-tertiary); border: 1px solid var(--dsw-alias-state-warn-secondary); border-radius: 4px; padding: 6px 8px; }
+.cv-dev-noop { font-size: var(--dsw-font-xxs-12-font-size); color: var(--dsw-alias-label-caption); padding: 4px 0; }
 .cv-agent-toggle { display: inline-flex; gap: 2px; border: 1px solid var(--dsw-alias-border-l2); border-radius: 6px; overflow: hidden; align-self: center; }
-.cv-agent-toggle button { border: none; background: var(--dsw-alias-bg-base); color: var(--dsw-alias-label-secondary); padding: 4px 10px; font-size: 12px; cursor: pointer; }
+.cv-agent-toggle button { border: none; background: var(--dsw-alias-bg-base); color: var(--dsw-alias-label-secondary); padding: 4px 10px; font-size: var(--dsw-font-xxs-12-font-size); cursor: pointer; }
 .cv-agent-toggle button.on { background: var(--dsw-alias-state-business-primary); color: var(--dsw-alias-label-primary-foreground); }
 .cv-agent-toggle button:disabled { opacity: 0.45; cursor: not-allowed; }
 .cv-dev-btn.cv-dev-sync { background: var(--dsw-alias-state-business-primary); }
@@ -289,7 +289,7 @@ body[data-cv-panel-dragging] #root.cv-panel-host-open, body[data-cv-panel-draggi
 .cv-context-toggle { border: none; background: transparent; color: var(--dsw-alias-state-business-primary); font-size: 11.5px; cursor: pointer; padding: 2px 0; text-decoration: underline; }
 .cv-context-toggle:hover { opacity: 0.8; }
 .cv-context-toggle:disabled { opacity: 0.45; cursor: not-allowed; }
-.cv-context-input { width: 100%; box-sizing: border-box; border: 1px solid var(--dsw-alias-border-l2); border-radius: 6px; background: var(--dsw-alias-bg-base); color: var(--dsw-alias-label-primary); padding: 6px 8px; font-size: 12px; font-family: inherit; line-height: 1.5; resize: vertical; }
+.cv-context-input { width: 100%; box-sizing: border-box; border: 1px solid var(--dsw-alias-border-l2); border-radius: 6px; background: var(--dsw-alias-bg-base); color: var(--dsw-alias-label-primary); padding: 6px 8px; font-size: var(--dsw-font-xxs-12-font-size); font-family: inherit; line-height: 1.5; resize: vertical; }
 .cv-context-input::placeholder { color: var(--dsw-alias-label-caption); }
 .cv-tl-user-context { color: var(--dsw-alias-label-secondary); word-break: break-all; }
 `

--- a/tests/client-styles.test.ts
+++ b/tests/client-styles.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { measureStyleTokenCoverage, MINIMUM_STYLE_TOKEN_COVERAGE } from '../scripts/check-style-tokens.mjs'
 import { PANEL_CSS } from '../src/client/styles.ts'
 
 const DSH_THEME_TOKENS = new Set([
@@ -37,6 +38,11 @@ const DSH_THEME_TOKENS = new Set([
   '--dsw-alias-state-warn-secondary',
   '--dsw-alias-state-warn-tertiary',
   '--dsw-shadow-lv3',
+  '--dsw-font-base-16-font-size',
+  '--dsw-font-s-14-font-size',
+  '--dsw-font-xs-13-font-size',
+  '--dsw-font-xxs-12-font-size',
+  '--dsw-font-xxxs-11-font-size',
 ])
 
 function between(start: string, end: string): string {
@@ -53,6 +59,14 @@ function declarations(selector: string): string {
   assert.notEqual(match, null, `missing ${selector}`)
   return match?.[1] ?? ''
 }
+
+test('at least 80% of common color and font-size materials use theme tokens', () => {
+  const coverage = measureStyleTokenCoverage(PANEL_CSS)
+  assert.ok(
+    coverage.ratio >= MINIMUM_STYLE_TOKEN_COVERAGE,
+    `style token coverage ${(coverage.ratio * 100).toFixed(2)}% (${coverage.covered}/${coverage.total}) is below ${MINIMUM_STYLE_TOKEN_COVERAGE * 100}%`,
+  )
+})
 
 test('panel common materials use only real DSH theme tokens', () => {
   const namedTokens = [...PANEL_CSS.matchAll(/var\((--dsw-[a-z0-9-]+)/g)].map((match) => match[1] ?? '')


### PR DESCRIPTION
## 变更摘要

- 将 `styles.ts` 中所有与 DSH 字号档位完全等值的 11/12/13/14/16px 声明改为真实 `--dsw-font-*-font-size` token，不改变实际字号
- 保留 #77 明确约束的固定深色终端色板与最小 ClickVibe review 语义色板
- 新增 `pnpm run check:style-tokens` 可重复统计脚本，并把 ≥80% 纳入 `pnpm run check` 与样式测试

## 验收结果

- token 覆盖率：91.41%（298/326），高于 80% 门槛
- token 命名：直接消费 DSH `--dsw-font-*`，与 #77 的 `--dsw-*` 主题体系一致
- 明/暗视觉：在运行中的 DSH 页面注入本分支 `PANEL_CSS`，明暗主题下主要列表、按钮、状态色、文字层级可接受；11/13/14px 计算值保持不变
- 固定深色终端仍不消费 DSH 主题 token

## 验证

- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `pnpm test`：397/397
- [x] `pnpm run coverage`：lines 92.02%，functions 87.73%
- [x] `pnpm run check`
- [x] `pnpm run check:style-tokens`：91.41%（298/326）
- [x] [人工] 明/暗主题主要界面视觉采样

本机全量测试使用“复制现有 config、隔离 `~/.clickvibe/state`”的临时 HOME；否则 `/state` 路由测试会读到真实运行中的 #91 auto-run 并产生额外 GitHub 请求。未修改该独立测试隔离缺口。

Closes #91
