### PR TITLE
test: 隔离限流熔断路由测试的宿主状态

### DIFF
--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -2836,32 +2836,42 @@ test('/fetch maps PR REST fields and latest reviews without any GraphQL read com
 })
 
 test('rate-limit response opens a circuit and returns the friendly recovery time on later routes', async () => {
-  const reset = Math.floor((Date.now() + 10 * 60_000) / 1000)
-  let requests = 0
-  const handler = createHandler(async () => {
-    requests++
-    return {
-      exitCode: 1,
-      stdout: {
-        text: [
-          'HTTP/2.0 403 Forbidden',
-          'x-ratelimit-remaining: 0',
-          `x-ratelimit-reset: ${reset}`,
-          '',
-          JSON.stringify({ message: 'API rate limit exceeded' }),
-        ].join('\n'),
-      },
-      stderr: { text: '' },
-    }
-  })
+  const previousHome = process.env.HOME
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-rate-limit-circuit-'))
+  process.env.HOME = tempHome
+  try {
+    const reset = Math.floor((Date.now() + 10 * 60_000) / 1000)
+    let githubRequests = 0
+    const handler = createHandler(async (spec) => {
+      assert.match(spec.command, /^gh api /, `unexpected non-GitHub shell command: ${spec.command}`)
+      githubRequests++
+      return {
+        exitCode: 1,
+        stdout: {
+          text: [
+            'HTTP/2.0 403 Forbidden',
+            'x-ratelimit-remaining: 0',
+            `x-ratelimit-reset: ${reset}`,
+            '',
+            JSON.stringify({ message: 'API rate limit exceeded' }),
+          ].join('\n'),
+        },
+        stderr: { text: '' },
+      }
+    })
 
-  const first = await post(handler, '/clickvibe/api/fetch', { url: 'https://github.com/o/r/issues/41' })
-  const second = await post(handler, '/clickvibe/api/state', { repoKey: 'o/r' })
-  assert.equal(first.status, 429)
-  assert.equal(second.status, 429)
-  assert.match(first.body.error ?? '', /^GitHub 额度已用完,约 \d{2}:\d{2} 恢复$/)
-  assert.equal(second.body.error, first.body.error)
-  assert.equal(requests, 1, 'open circuit must reject without another GitHub request')
+    const first = await post(handler, '/clickvibe/api/fetch', { url: 'https://github.com/o/r/issues/41' })
+    const second = await post(handler, '/clickvibe/api/state', { repoKey: 'o/r' })
+    assert.equal(first.status, 429)
+    assert.equal(second.status, 429)
+    assert.match(first.body.error ?? '', /^GitHub 额度已用完,约 \d{2}:\d{2} 恢复$/)
+    assert.equal(second.body.error, first.body.error)
+    assert.equal(githubRequests, 1, 'open circuit must reject without another GitHub request')
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
 })
 
 test('repository GitHub aggregation uses its short TTL cache and force refresh bypasses it', async () => {


### PR DESCRIPTION
## 根因

该测试直接继承真实 HOME。调用 /state 时，pauseOrphanedAutoRuns 会扫描宿主持久化的 running workflow，并异步触发 reconcile。原 fake shell 又把所有 shell 命令都统计成 GitHub request。宿主 I/O 调度决定这些后台 git 探测是在断言前还是断言后完成，因此产生 3 !== 1 的时段相关 flaky。

复制现场状态后稳定复现为 9 !== 1：首个 gh api 之外，4 个 running workflow 各触发两条 git 探测。Issue 现场只有 1 个 workflow 时即对应额外 2 次。

## 修复

- 为该测试分配独立临时 HOME，并在 finally 中恢复环境与清理目录。
- 计数明确收窄为 gh api；若出现非 GitHub shell 命令则直接给出可读失败。
- 不改生产熔断器和 workflow 状态机。

## 验证

- typecheck、build、test、coverage、lint、format、check:size、check:layers、check:style-tokens、check:state-writes 全绿。
- 覆盖率：lines 92.10%，functions 87.86%。
- 最终 HEAD 3404ace 在 16 核 DSH 宿主连续 20 次全量测试，20/20 均为 398/398。
- soak 开始 load average 13.74 / 23.95 / 21.43，结束 59.15 / 34.08 / 25.61。

Closes #127