### PR TITLE
fix: 自动跑到底对基础设施故障永不放弃(重试+熔断+看门狗)

### DIFF
--- a/docs/plans/2026-08-25-auto-run-infrastructure-recovery-design.md
+++ b/docs/plans/2026-08-25-auto-run-infrastructure-recovery-design.md
@@ -1,0 +1,83 @@
+# Auto-run infrastructure recovery design (#120)
+
+## Contract
+
+Git/GitHub facts remain the only source for the next workflow action. Controller
+recovery state only answers when reconciliation may run again; it never derives a
+business stage or authorizes a task launch.
+
+Semantic conclusions may stop or pause auto-run: the original budget deadline,
+the configured review-round boundary, an explicit user/supervisor task terminal
+outcome, an issue closure, an authorization-contract change, or a deterministic
+merge gate rejection. Network, git/gh, filesystem, registry, controller and
+cleanup execution failures never permanently stop it.
+
+## Mechanism
+
+`auto-run.ts` remains the per-workflow single command domain. Reconcile signals,
+deadline wakes and state-refresh recovery are coalesced by workflow key. Every
+state transition uses the revision-checked metadata command; task starts continue
+through the existing ownership and lease/fencing primitives.
+
+`auto-run-recovery-policy.ts` is pure. It computes:
+
+- capped exponential backoff with jitter (5 seconds to 5 minutes), without a
+  retry-count limit;
+- an exact-stack fingerprint and consecutive streak;
+- the third-identical-stack fuse decision;
+- watchdog eligibility, cooldown and the rolling hourly reattach limit.
+
+`auto-run-recovery.ts` applies those decisions. Each retry persists a small
+`controllerRecovery` checkpoint when workflow storage is available and writes a
+full diagnostic record with the original stack. A temporarily unreadable state
+file keeps a timer armed and performs no action until the workflow can be loaded
+and its original deadline rechecked.
+
+Rate limits bypass exponential backoff. `GithubRateLimitError.resetAt`, derived
+from `Retry-After` before `x-ratelimit-reset`, schedules reset plus a two-second
+buffer. The REST circuit rejects queued requests before they reach `gh` and keeps
+the primary/secondary classification.
+
+## Fuse and watchdog
+
+Three consecutive occurrences of one exact stack pause as `controller-error` and
+persist the fingerprint, streak, stack and fuse basis. Failures with another
+stack break that streak. Confirmed running or unknown task ownership suppresses
+the fuse: the controller retries without changing status or touching the task.
+
+Only `paused/controller-error` enters the watchdog. After the persisted cooldown
+it re-observes ownership inside the same command domain:
+
+- `running`: reattach the controller without touching the task;
+- `unknown`: wait and retry, with no new task;
+- `interrupted`: convert to the semantic `session-interrupted` pause;
+- `none`: reattach and let fresh facts derive the next action.
+
+The event stream is the durable rolling-window ledger. Ten watchdog reattachments
+within an hour delay the next wake until the oldest event leaves the window; they
+do not permanently abandon the run.
+
+## Budget and GitHub burst control
+
+Every wake is bounded by the original deadline. At expiry, controller-error is
+replaced by `budget-exhausted`; a host-confirmed task is stopped through its local
+handle or host job ID before the pause is persisted. Unknown ownership is never
+treated as permission to start or kill a task.
+
+Host REST calls share one process-global serialized lane with a minimum launch
+interval. Agent development, resume/rework and review prompts separately require
+`gh api` REST, prohibit GraphQL-heavy `gh pr view`/`gh issue view` context reads,
+and limit unchanged-resource reads to once per task.
+
+## Verification map
+
+| Invariant | Regression |
+|---|---|
+| Alternating transient failures never fuse or exhaust a count | 30-minute pure-policy simulation |
+| Same exact stack trips at three | policy + durable integration diagnostics |
+| Running task is unaffected | host-registry ownership integration |
+| Watchdog is controller-error-only and hourly bounded | pure gate + persisted event integration |
+| Retry/watchdog cannot cross deadline | expired paused state + host task stop tests |
+| Filesystem observation gap does not abandon recovery | unavailable-state wake test |
+| Primary/secondary rate scheduling stays distinct | REST circuit tests |
+| Cross-resource host burst is serialized | blocked first request + minimum-start interval test |

--- a/docs/plans/2026-08-25-auto-run-infrastructure-recovery-design.md
+++ b/docs/plans/2026-08-25-auto-run-infrastructure-recovery-design.md
@@ -14,18 +14,11 @@ cleanup execution failures never permanently stop it.
 
 ## Mechanism
 
-`auto-run.ts` remains the per-workflow single command domain. Reconcile signals,
-deadline wakes and state-refresh recovery are coalesced by workflow key. Every
-state transition uses the revision-checked metadata command; task starts continue
-through the existing ownership and lease/fencing primitives.
+`auto-run.ts` coalesces signals per workflow; revision-checked metadata commands
+and the existing ownership/lease primitives remain the only mutation paths.
 
-`auto-run-recovery-policy.ts` is pure. It computes:
-
-- capped exponential backoff with jitter (5 seconds to 5 minutes), without a
-  retry-count limit;
-- an exact-stack fingerprint and consecutive streak;
-- the third-identical-stack fuse decision;
-- watchdog eligibility, cooldown and the rolling hourly reattach limit.
+`auto-run-recovery-policy.ts` purely computes capped unlimited backoff, exact-stack
+streak/fuse decisions, and watchdog cooldown/hourly limits.
 
 `auto-run-recovery.ts` applies those decisions. Each retry persists a small
 `controllerRecovery` checkpoint when workflow storage is available and writes a
@@ -33,10 +26,8 @@ full diagnostic record with the original stack. A temporarily unreadable state
 file keeps a timer armed and performs no action until the workflow can be loaded
 and its original deadline rechecked.
 
-Rate limits bypass exponential backoff. `GithubRateLimitError.resetAt`, derived
-from `Retry-After` before `x-ratelimit-reset`, schedules reset plus a two-second
-buffer. The REST circuit rejects queued requests before they reach `gh` and keeps
-the primary/secondary classification.
+Rate limits use `Retry-After` before `x-ratelimit-reset`, schedule reset plus two
+seconds, and let the REST circuit reject queued requests while retaining kind.
 
 ## Fuse and watchdog
 
@@ -45,13 +36,9 @@ persist the fingerprint, streak, stack and fuse basis. Failures with another
 stack break that streak. Confirmed running or unknown task ownership suppresses
 the fuse: the controller retries without changing status or touching the task.
 
-Only `paused/controller-error` enters the watchdog. After the persisted cooldown
-it re-observes ownership inside the same command domain:
-
-- `running`: reattach the controller without touching the task;
-- `unknown`: wait and retry, with no new task;
-- `interrupted`: convert to the semantic `session-interrupted` pause;
-- `none`: reattach and let fresh facts derive the next action.
+Only `paused/controller-error` enters the watchdog. After cooldown it re-observes
+ownership: running reattaches without touching the task, unknown waits,
+interrupted becomes semantic `session-interrupted`, and none resumes fact derivation.
 
 The event stream is the durable rolling-window ledger. Ten watchdog reattachments
 within an hour delay the next wake until the oldest event leaves the window; they
@@ -64,10 +51,8 @@ replaced by `budget-exhausted`; a host-confirmed task is stopped through its loc
 handle or host job ID before the pause is persisted. Unknown ownership is never
 treated as permission to start or kill a task.
 
-Host REST calls share one process-global serialized lane with a minimum launch
-interval. Agent development, resume/rework and review prompts separately require
-`gh api` REST, prohibit GraphQL-heavy `gh pr view`/`gh issue view` context reads,
-and limit unchanged-resource reads to once per task.
+Host REST calls share one serialized lane. Agent prompts require `gh api`, avoid
+GraphQL-heavy context reads, and limit unchanged-resource reads to once per task.
 
 ## Verification map
 
@@ -81,3 +66,14 @@ and limit unchanged-resource reads to once per task.
 | Filesystem observation gap does not abandon recovery | unavailable-state wake test |
 | Primary/secondary rate scheduling stays distinct | REST circuit tests |
 | Cross-resource host burst is serialized | blocked first request + minimum-start interval test |
+| Queue dispatch preserves fuse/watchdog/semantic pause | public reconcile-entry integration |
+
+## Action failure enumeration
+
+| Producer | Failure source | Classification protection |
+|---|---|---|
+| `startDevelop` | confirmed live snapshot differs from authorized snapshot | explicit `authorization-denied` marker at comparison |
+| `startDevelop` | missing/persisted snapshot, refresh, filesystem, git, task launch | unmarked, therefore controller retry |
+| `createPullRequest` / `startReview` / `resumeDevelop` / `syncWorktree` | controller execution | unmarked, except existing structured sync conflict |
+| `mergeAndCleanup` | gate verdict or post-merge cleanup | existing `gateFailures` / `cleanupPending` discriminators |
+| `applyDecision` | any future unmarked action failure | defaults to controller retry; no text heuristic |

--- a/docs/state-model.md
+++ b/docs/state-model.md
@@ -29,7 +29,7 @@ workflow 每次提交都携带持久化 revision;所有普通写要求 expected 
 
 - 开发/返工中断:使用「恢复开发」,只在原 agent 归属匹配时续接已记录的 session;session 缺失、归属不匹配或被 agent 拒绝时按既有规则降级为同一 worktree 的全新会话。
 - Review 中断:确认旧宿主任务已经停止后使用「重新 Review」,重新审查当前 HEAD;不得沿用未物化结论的旧 Review。
-- 自动跑到底:只有任务失败/停止/超时或上述宿主终止证据才使用 `session-interrupted`;GitHub、git、宿主 registry/controller/占位等非 Agent 故障使用 `controller-error`,由人处理后重新挂起。系统不得根据本地 step 或日志时间戳自动双开任务。
+- 自动跑到底:只有任务失败/停止/超时或上述宿主终止证据才使用 `session-interrupted`;GitHub、git、文件系统、宿主 registry/controller/占位等基础设施故障在预算内指数退避重试。相同错误栈连续三次只临时熔断为 `controller-error`,看门狗冷却后自动重挂;`unknown` ownership 继续 fail closed,不得启动第二个任务。`session-interrupted`、`task-timeout`、`budget-exhausted`、`rounds-exhausted` 等语义暂停不由看门狗恢复。
 
 方案评估与选型:
 
@@ -39,7 +39,7 @@ workflow 每次提交都携带持久化 revision;所有普通写要求 expected 
 | 宿主重启时插件接管旧任务 | `ctx.jobs` 是进程内 host registry,注册不随插件 producer/controller fiber 消失;可覆盖热重载和多模块实例,但不能跨宿主进程 | **选用作同宿主重载的任务所有权事实源**;启动前同步占位,持久化 host job ID 并校验 workflow/task label |
 | 运行探活(PID/进程扫描/agent 日志游标) | shell 契约不暴露稳定 PID;扫描命令行或看日志新鲜度既不能证明所有权,也不能安全停止/接管 | 拒绝单信号探活;仅使用 supervisor 的 job 生命周期事实 |
 
-实现同时输出 `runtimeInstanceId`、PID、模块加载时间和任务 `set/close/delete`、host job 注册、auto-run 判断/异常的结构化诊断。`requestAutoRunReconcile()` 的未知异常记录为 `controller-error`,不再冒充 agent 会话中断。
+实现同时输出 `runtimeInstanceId`、PID、模块加载时间和任务 `set/close/delete`、host job 注册、auto-run 判断/异常的结构化诊断。`requestAutoRunReconcile()` 的未知异常记录错误类型、原始消息、完整栈、fingerprint、连续次数、总重试次数和下次时间,不再冒充 agent 会话中断。GitHub 限流另按响应头 reset 调度。
 
 这些控制器诊断除同步写入 `console.warn` 外,还会 best-effort 追加到持久 JSONL。带有效 `workflowKey` 的事件写入 `~/.clickvibe/state/<owner>/<repo>/issue-<number>/diagnostics.jsonl`;无 workflow 归属或 key 无法解析的事件写入全局 `~/.clickvibe/state/diagnostics.jsonl`。活动文件默认上限为 5 MiB,可在 `~/.clickvibe/config.yaml` 设置 `diagnosticsMaxBytes` 覆盖;追加将超限时,上一段保留为同目录的 `diagnostics.1.jsonl`,再创建新的活动文件。轮转不截断单条事件,所以单条记录大于上限时允许独占一个文件段。诊断落盘失败不影响请求路径或 console 输出。
 

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -115,8 +115,12 @@ export function sameSnapshot(left: PromptSnapshot, right: PromptSnapshot): boole
   return JSON.stringify(left) === JSON.stringify(right)
 }
 
+export const GITHUB_USAGE_REQUIREMENT =
+  '查询 PR/Issue 上下文优先使用 `gh api` REST，不使用 `gh pr view` / `gh issue view` 的 GraphQL 聚合；同一资源在单任务内只查询一次，除非写动作后必须回读验证或已有事实明确失效。'
+
 export const DEVELOPMENT_REQUIREMENTS = [
   '先执行 git fetch origin 同步远端,并检查 base(默认 origin/main)是否有更新;若已有更新,先合并或变基到最新再继续。',
+  GITHUB_USAGE_REQUIREMENT,
   '先理解当前需求快照;如有歧义可自行判断或提问。',
   '实现代码改动,并保留现有 worktree 中尚未提交的有效工作。',
   '运行相关测试。',
@@ -182,6 +186,7 @@ export async function buildReviewPrompt(
     requirements: [
       '本轮 review 采用根因 review 协议:先读取 PR/issue 上全部历史 review 轮次做母题分类(同类复发必须点名轮次),对每个 finding 给出代码根因(什么构造让这类问题不可能)与过程根因(为什么活到本轮);先做静态枚举审计(枚举全部可违反路径,非构造保护即为 finding,不需要复现),再做动态对抗验证(CRITICAL 必须复现,含失败率);判定修复高度时对比改造前后的公开 API/导出面,排除改名式修复;结论按 verdict 输出(pass/fix-these/stop-and-redesign),同类连续复发或 diff 持续发散时输出 stop-and-redesign 而非问题清单。若仓库存在 skills/root-cause-review/SKILL.md 或 docs/fix-discipline.md,以其全文为准。',
       '先执行 git fetch origin 同步远端最新状态(并行开发时 base 可能已变化)。',
+      GITHUB_USAGE_REQUIREMENT,
       `执行 git diff ${base}...HEAD 查看完整改动。`,
       ...(sessionId ? ['先复核之前发现的问题是否已解决,再审查全部新改动。'] : []),
       '严格按当前需求快照中的验收标准逐条审查,同时检查 bug、安全隐患和测试覆盖。',

--- a/src/github/rest.ts
+++ b/src/github/rest.ts
@@ -63,8 +63,9 @@ async function serializeGithubRequest<T>(minimumIntervalMs: number, request: () 
     while (Date.now() < lane.nextStartAt) {
       await new Promise((resolve) => setTimeout(resolve, lane.nextStartAt - Date.now()))
     }
+    const pending = request()
     lane.nextStartAt = Date.now() + minimumIntervalMs
-    return await request()
+    return await pending
   } finally {
     release()
   }

--- a/src/github/rest.ts
+++ b/src/github/rest.ts
@@ -31,6 +31,45 @@ interface IncludedResponse {
   body: string
 }
 
+interface HostGithubRequestLane {
+  tail: Promise<void>
+  nextStartAt: number
+}
+
+const HOST_GITHUB_MINIMUM_INTERVAL_MS = 250
+const hostGithubLaneSymbol = Symbol.for('clickvibe.github-request-lane')
+
+function hostGithubLane(): HostGithubRequestLane {
+  const root = globalThis as unknown as Record<PropertyKey, unknown>
+  const existing = root[hostGithubLaneSymbol] as HostGithubRequestLane | undefined
+  if (existing) return existing
+  const created = { tail: Promise.resolve(), nextStartAt: 0 }
+  root[hostGithubLaneSymbol] = created
+  return created
+}
+
+async function serializeGithubRequest<T>(minimumIntervalMs: number, request: () => Promise<T>): Promise<T> {
+  const lane = hostGithubLane()
+  const previous = lane.tail
+  let release = () => {}
+  lane.tail = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  await previous
+  try {
+    // Timers may wake just before their requested deadline. Re-check the
+    // monotonic wall-clock condition so the configured start interval is a
+    // guarantee rather than a best-effort delay.
+    while (Date.now() < lane.nextStartAt) {
+      await new Promise((resolve) => setTimeout(resolve, lane.nextStartAt - Date.now()))
+    }
+    lane.nextStartAt = Date.now() + minimumIntervalMs
+    return await request()
+  } finally {
+    release()
+  }
+}
+
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
@@ -122,18 +161,21 @@ export function deriveReviewDecision(reviews: GithubReviewRest[]): 'APPROVED' | 
 /** One ctx-scoped REST reader: rate-limit circuit, request parsing and read caches. */
 export class GithubRestReader {
   private readonly ctx: ShellContext
+  private readonly minimumIntervalMs: number
   private readonly resources = new Map<string, CachedValue<unknown>>()
   private readonly aggregates = new Map<string, CachedValue<unknown>>()
   private readonly inFlight = new Map<string, Promise<unknown>>()
   private readonly versions = new Map<string, string>()
   private circuitUntil = 0
+  private circuitKind: GithubRateLimitKind = 'unknown'
 
-  constructor(ctx: ShellContext) {
+  constructor(ctx: ShellContext, options: { minimumIntervalMs?: number } = {}) {
     this.ctx = ctx
+    this.minimumIntervalMs = Math.max(0, options.minimumIntervalMs ?? HOST_GITHUB_MINIMUM_INTERVAL_MS)
   }
 
   rateLimitError(now = Date.now()): GithubRateLimitError | null {
-    return this.circuitUntil > now ? new GithubRateLimitError(this.circuitUntil) : null
+    return this.circuitUntil > now ? new GithubRateLimitError(this.circuitUntil, this.circuitKind) : null
   }
 
   rememberVersion(key: string, version: string | null | undefined): void {
@@ -174,65 +216,71 @@ export class GithubRestReader {
     timeoutMs = 30_000,
     mutation?: { method: 'POST' | 'PATCH'; body: unknown },
   ): Promise<IncludedResponse> {
-    this.assertCircuitOpen()
-    const command = [
-      'gh api --include',
-      shellQuote(path),
-      mutation ? `--method ${mutation.method} --input -` : '',
-      accept ? `-H ${shellQuote(`Accept: ${accept}`)}` : '',
-    ]
-      .filter(Boolean)
-      .join(' ')
-    const spec = this.ctx.shell.resolve({
-      command,
-      timeoutMs,
-      ...(mutation ? { stdin: JSON.stringify(mutation.body) } : {}),
-    })
-    const result = await this.ctx.shell.run(spec)
-    const stdout = await this.output(result)
-    let response: IncludedResponse
-    try {
-      response = parseIncludedResponse(stdout)
-    } catch (parseError) {
-      const detail = [result.stderr?.text, stdout].filter(Boolean).join('\n').trim()
-      if (result.exitCode !== 0 && /(?:rate limit|secondary rate)/i.test(detail)) {
-        this.circuitUntil = Date.now() + 60 * 60_000
-        logTaskDiagnostic('github-rate-circuit-trip', {
-          kind: 'unknown' as const,
-          path,
-          until: this.circuitUntil,
-          note: 'gh CLI 失败且无响应头,按 60 分钟保守熔断',
-        })
-        throw new GithubRateLimitError(this.circuitUntil, 'unknown')
-      }
-      if (result.exitCode !== 0) throw new Error(detail || `gh api 执行失败(exit ${result.exitCode})`)
-      throw parseError
-    }
-    const detail = [result.stderr?.text, response.body].filter(Boolean).join('\n')
-    if (isRateLimited(response, detail)) {
-      this.circuitUntil = resetFrom(response.headers, Date.now())
-      const kind: GithubRateLimitKind = response.headers.get('x-ratelimit-remaining') === '0' ? 'primary' : 'secondary'
-      logTaskDiagnostic('github-rate-circuit-trip', {
-        kind,
-        path,
-        remaining: response.headers.get('x-ratelimit-remaining'),
-        reset: response.headers.get('x-ratelimit-reset'),
-        retryAfter: response.headers.get('retry-after'),
-        until: this.circuitUntil,
+    return serializeGithubRequest(this.minimumIntervalMs, async () => {
+      // A request queued before another resource trips the circuit must not hit GitHub afterwards.
+      this.assertCircuitOpen()
+      const command = [
+        'gh api --include',
+        shellQuote(path),
+        mutation ? `--method ${mutation.method} --input -` : '',
+        accept ? `-H ${shellQuote(`Accept: ${accept}`)}` : '',
+      ]
+        .filter(Boolean)
+        .join(' ')
+      const spec = this.ctx.shell.resolve({
+        command,
+        timeoutMs,
+        ...(mutation ? { stdin: JSON.stringify(mutation.body) } : {}),
       })
-      throw new GithubRateLimitError(this.circuitUntil, kind)
-    }
-    if (result.exitCode !== 0 || response.status < 200 || response.status >= 300) {
-      let message = response.body.trim()
+      const result = await this.ctx.shell.run(spec)
+      const stdout = await this.output(result)
+      let response: IncludedResponse
       try {
-        const parsed = JSON.parse(response.body) as { message?: unknown }
-        message = String(parsed.message ?? message)
-      } catch {
-        /* retain raw response body */
+        response = parseIncludedResponse(stdout)
+      } catch (parseError) {
+        const detail = [result.stderr?.text, stdout].filter(Boolean).join('\n').trim()
+        if (result.exitCode !== 0 && /(?:rate limit|secondary rate)/i.test(detail)) {
+          this.circuitUntil = Date.now() + 60 * 60_000
+          this.circuitKind = 'unknown'
+          logTaskDiagnostic('github-rate-circuit-trip', {
+            kind: 'unknown' as const,
+            path,
+            until: this.circuitUntil,
+            note: 'gh CLI 失败且无响应头,按 60 分钟保守熔断',
+          })
+          throw new GithubRateLimitError(this.circuitUntil, 'unknown')
+        }
+        if (result.exitCode !== 0) throw new Error(detail || `gh api 执行失败(exit ${result.exitCode})`)
+        throw parseError
       }
-      throw new Error(`GitHub REST ${response.status}: ${message || result.stderr?.text || '请求失败'}`)
-    }
-    return response
+      const detail = [result.stderr?.text, response.body].filter(Boolean).join('\n')
+      if (isRateLimited(response, detail)) {
+        this.circuitUntil = resetFrom(response.headers, Date.now())
+        const kind: GithubRateLimitKind =
+          response.headers.get('x-ratelimit-remaining') === '0' ? 'primary' : 'secondary'
+        this.circuitKind = kind
+        logTaskDiagnostic('github-rate-circuit-trip', {
+          kind,
+          path,
+          remaining: response.headers.get('x-ratelimit-remaining'),
+          reset: response.headers.get('x-ratelimit-reset'),
+          retryAfter: response.headers.get('retry-after'),
+          until: this.circuitUntil,
+        })
+        throw new GithubRateLimitError(this.circuitUntil, kind)
+      }
+      if (result.exitCode !== 0 || response.status < 200 || response.status >= 300) {
+        let message = response.body.trim()
+        try {
+          const parsed = JSON.parse(response.body) as { message?: unknown }
+          message = String(parsed.message ?? message)
+        } catch {
+          /* retain raw response body */
+        }
+        throw new Error(`GitHub REST ${response.status}: ${message || result.stderr?.text || '请求失败'}`)
+      }
+      return response
+    })
   }
 
   async json<T = unknown>(path: string, accept?: string, timeoutMs?: number): Promise<T> {

--- a/src/infra/auto-run-scheduler.ts
+++ b/src/infra/auto-run-scheduler.ts
@@ -1,0 +1,78 @@
+import type { Context } from '@deepseek-ai/cordis'
+
+export type AutoRunWake = (ctx: Context, key: string) => void
+
+interface AutoRunScheduleState {
+  wakeTimers: Map<string, ReturnType<typeof setTimeout>>
+  deadlineTimers: Map<string, ReturnType<typeof setTimeout>>
+}
+
+const scheduleStateSymbol = Symbol.for('clickvibe.auto-run-schedule-state')
+const root = globalThis as unknown as Record<PropertyKey, unknown>
+const scheduleState = (root[scheduleStateSymbol] as AutoRunScheduleState | undefined) ?? {
+  wakeTimers: new Map(),
+  deadlineTimers: new Map(),
+}
+root[scheduleStateSymbol] = scheduleState
+const { wakeTimers, deadlineTimers } = scheduleState
+
+function clearWake(key: string): void {
+  const timer = wakeTimers.get(key)
+  if (timer) clearTimeout(timer)
+  wakeTimers.delete(key)
+}
+
+function clearDeadline(key: string): void {
+  const timer = deadlineTimers.get(key)
+  if (timer) clearTimeout(timer)
+  deadlineTimers.delete(key)
+}
+
+export function autoRunWakePending(key: string): boolean {
+  return wakeTimers.has(key)
+}
+
+export function clearAutoRunSchedule(key: string): void {
+  clearWake(key)
+  clearDeadline(key)
+}
+
+export function scheduleAutoRunWakeAt(ctx: Context, key: string, retryAt: number, wake: AutoRunWake): void {
+  clearWake(key)
+  const delay = Math.max(0, retryAt - Date.now())
+  const timer = setTimeout(
+    () => {
+      wakeTimers.delete(key)
+      wake(ctx, key)
+    },
+    Math.min(delay, 2_147_483_647),
+  )
+  timer.unref?.()
+  wakeTimers.set(key, timer)
+}
+
+export function scheduleAutoRunWake(
+  ctx: Context,
+  key: string,
+  retryAt: number,
+  deadline: string,
+  wake: AutoRunWake,
+): void {
+  const deadlineAt = Date.parse(deadline)
+  const target = Number.isFinite(deadlineAt) ? Math.min(retryAt, deadlineAt) : retryAt
+  scheduleAutoRunWakeAt(ctx, key, target, wake)
+}
+
+export function armAutoRunDeadline(ctx: Context, key: string, deadline: string, wake: AutoRunWake): void {
+  clearDeadline(key)
+  const delay = Math.max(0, Date.parse(deadline) - Date.now())
+  const timer = setTimeout(
+    () => {
+      deadlineTimers.delete(key)
+      wake(ctx, key)
+    },
+    Math.min(delay, 2_147_483_647),
+  )
+  timer.unref?.()
+  deadlineTimers.set(key, timer)
+}

--- a/src/infra/contracts.ts
+++ b/src/infra/contracts.ts
@@ -60,6 +60,15 @@ export interface AutoRunUnresolvedRound {
   issues: string[]
 }
 
+export interface AutoRunControllerRecovery {
+  kind: 'transient' | 'rate-limit' | 'fused'
+  attempt: number
+  consecutive: number
+  fingerprint: string
+  retryAt: string
+  lastFailureAt: string
+}
+
 /** Durable enhancement only; absence always means manual workflow mode. */
 export interface AutoRunState {
   status: 'running' | 'paused' | 'completed'
@@ -77,12 +86,27 @@ export interface AutoRunState {
   unresolved: AutoRunUnresolvedRound[]
   lastObservedAt: string | null
   pausedReason: AutoRunPausedReason | null
+  /** Durable scheduler checkpoint; git/GitHub facts remain the workflow truth. */
+  controllerRecovery?: AutoRunControllerRecovery
 }
 
 export function isAutoRunState(value: unknown): value is AutoRunState {
   if (value === undefined) return true
   if (!value || typeof value !== 'object') return false
   const state = value as Partial<AutoRunState>
+  const recovery = state.controllerRecovery
+  const validRecovery =
+    recovery === undefined ||
+    (typeof recovery === 'object' &&
+      recovery !== null &&
+      (recovery.kind === 'transient' || recovery.kind === 'rate-limit' || recovery.kind === 'fused') &&
+      Number.isInteger(recovery.attempt) &&
+      recovery.attempt > 0 &&
+      Number.isInteger(recovery.consecutive) &&
+      recovery.consecutive > 0 &&
+      typeof recovery.fingerprint === 'string' &&
+      typeof recovery.retryAt === 'string' &&
+      typeof recovery.lastFailureAt === 'string')
   return (
     (state.status === 'running' || state.status === 'paused' || state.status === 'completed') &&
     (state.devAgent === 'codex' || state.devAgent === 'claude') &&
@@ -93,6 +117,7 @@ export function isAutoRunState(value: unknown): value is AutoRunState {
     Number(state.budgetHours) > 0 &&
     typeof state.startedAt === 'string' &&
     typeof state.deadline === 'string' &&
-    Array.isArray(state.unresolved)
+    Array.isArray(state.unresolved) &&
+    validRecovery
   )
 }

--- a/src/workflow/auto-run-policy.ts
+++ b/src/workflow/auto-run-policy.ts
@@ -15,7 +15,7 @@ export const AUTO_RUN_RETRY_MS = 5_000
 export type AutoRunDecision =
   | { kind: 'manual' }
   | { kind: 'wait'; rounds: number; unresolved: AutoRunUnresolvedRound[] }
-  | { kind: 'complete'; rounds: number; unresolved: AutoRunUnresolvedRound[] }
+  | { kind: 'complete'; reason?: 'issue-closed'; rounds: number; unresolved: AutoRunUnresolvedRound[] }
   | {
       kind: 'trigger'
       action: Extract<NextActionKind, 'develop' | 'create-pr' | 'review' | 'rework' | 'sync' | 'merge' | 'cleanup'>
@@ -125,15 +125,17 @@ export function decideAutoRun(input: {
   now: number
   reviewEvents: readonly IssueWorkflow['events'][number][]
   taskOutcome?: AutoRunTaskOutcome
+  issueOpen?: boolean
 }): AutoRunDecision {
   if (!input.autoRun || input.autoRun.status !== 'running') return { kind: 'manual' }
   const autoRun = input.autoRun
   const reviews = aggregateAutoRunReviews(autoRun, input.reviewEvents)
+  if (input.now >= Date.parse(input.autoRun.deadline)) return paused('budget-exhausted', reviews)
   if (input.taskOutcome === 'timed_out') return paused('task-timeout', reviews)
   if (input.taskOutcome === 'failed' || input.taskOutcome === 'stopped') {
     return paused('session-interrupted', reviews)
   }
-  if (input.now >= Date.parse(input.autoRun.deadline)) return paused('budget-exhausted', reviews)
+  if (input.issueOpen === false) return { kind: 'complete', reason: 'issue-closed', ...reviews }
   if (reviews.rounds >= input.autoRun.maxRounds && input.nextAction.kind === 'rework') {
     return paused('rounds-exhausted', reviews)
   }

--- a/src/workflow/auto-run-policy.ts
+++ b/src/workflow/auto-run-policy.ts
@@ -10,7 +10,23 @@ export interface AutoRunConfig {
 }
 
 export type AutoRunTaskOutcome = 'done' | 'failed' | 'stopped' | 'timed_out'
+export type AutoRunSemanticFailure = 'authorization-denied'
 export const AUTO_RUN_RETRY_MS = 5_000
+
+export interface AutoRunFailureClassification {
+  semanticFailure?: AutoRunSemanticFailure
+}
+
+/** Keep controller-only classification out of the JSON response contract. */
+export function classifiedAutoRunFailure(
+  error: string,
+  semanticFailure: AutoRunSemanticFailure,
+): { ok: false; error: string } & AutoRunFailureClassification {
+  return Object.defineProperty({ ok: false as const, error }, 'semanticFailure', {
+    value: semanticFailure,
+    enumerable: false,
+  }) as { ok: false; error: string } & AutoRunFailureClassification
+}
 
 export type AutoRunDecision =
   | { kind: 'manual' }
@@ -109,13 +125,14 @@ export function autoRunFailureReason(
     cleanupPending?: boolean
     gateFailures?: unknown[]
     controllerError?: boolean
+    semanticFailure?: AutoRunSemanticFailure
   },
 ): AutoRunPausedReason {
   if (result.controllerError) return 'controller-error'
   if (result.cleanupPending || (action === 'cleanup' && result.merged)) return 'cleanup-failed'
   if (result.conflict) return 'sync-conflict'
   if (action === 'merge' || action === 'cleanup' || result.gateFailures) return 'merge-gate-rejected'
-  if (/授权|快照/.test(result.error ?? '')) return 'authorization-denied'
+  if (result.semanticFailure) return result.semanticFailure
   return 'controller-error'
 }
 

--- a/src/workflow/auto-run-recovery-policy.ts
+++ b/src/workflow/auto-run-recovery-policy.ts
@@ -1,0 +1,107 @@
+import type { AutoRunState, WorkflowEvent } from '../infra/state.ts'
+
+export const AUTO_RUN_BASE_RETRY_MS = 5_000
+export const AUTO_RUN_MAX_RETRY_MS = 5 * 60_000
+export const AUTO_RUN_FUSE_THRESHOLD = 3
+export const AUTO_RUN_WATCHDOG_COOLDOWN_MS = 5 * 60_000
+export const AUTO_RUN_WATCHDOG_LIMIT = 10
+export const AUTO_RUN_WATCHDOG_WINDOW_MS = 60 * 60_000
+export const AUTO_RUN_WATCHDOG_NOTE = '看门狗自动重挂 controller-error'
+
+export interface ControllerFailureEvidence {
+  name: string
+  message: string
+  stack: string | null
+}
+
+export interface ControllerFailureAttempt extends ControllerFailureEvidence {
+  attempt: number
+  consecutive: number
+  fingerprint: string
+  delayMs: number
+  retryAt: number
+  fused: boolean
+}
+
+function stableFingerprint(value: string): string {
+  let hash = 2_166_136_261
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 16_777_619)
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
+export function controllerFailureEvidence(error: unknown): ControllerFailureEvidence {
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message, stack: error.stack ?? null }
+  }
+  return { name: typeof error, message: String(error), stack: null }
+}
+
+/** Pure capped exponential backoff. A successful reconcile clears the previous attempt. */
+export function nextControllerFailure(
+  previous: ControllerFailureAttempt | null,
+  evidence: ControllerFailureEvidence,
+  now: number,
+  random: number,
+): ControllerFailureAttempt {
+  const identity = evidence.stack?.trim() || `${evidence.name}:${evidence.message}`
+  const fingerprint = stableFingerprint(identity)
+  const attempt = (previous?.attempt ?? 0) + 1
+  const consecutive = previous?.fingerprint === fingerprint ? previous.consecutive + 1 : 1
+  const exponent = Math.min(attempt - 1, 16)
+  const uncapped = AUTO_RUN_BASE_RETRY_MS * 2 ** exponent
+  const jitter = 0.75 + Math.max(0, Math.min(1, random)) * 0.5
+  const delayMs = Math.min(AUTO_RUN_MAX_RETRY_MS, Math.round(uncapped * jitter))
+  return {
+    ...evidence,
+    attempt,
+    consecutive,
+    fingerprint,
+    delayMs,
+    retryAt: now + delayMs,
+    fused: consecutive >= AUTO_RUN_FUSE_THRESHOLD,
+  }
+}
+
+export type AutoRunWatchdogDecision =
+  | { kind: 'none' }
+  | { kind: 'reattach' }
+  | { kind: 'budget-exhausted' }
+  | { kind: 'session-interrupted' }
+  | { kind: 'wait'; retryAt: number; reason: 'cooldown' | 'ownership-unknown' | 'hourly-limit' }
+
+function watchdogEvents(events: readonly WorkflowEvent[], now: number): WorkflowEvent[] {
+  const cutoff = now - AUTO_RUN_WATCHDOG_WINDOW_MS
+  return events.filter(
+    (event) => event.kind === 'auto-run' && event.note === AUTO_RUN_WATCHDOG_NOTE && Date.parse(event.at) > cutoff,
+  )
+}
+
+/** Pure watchdog gate. Runtime code must re-observe ownership immediately before applying it. */
+export function decideAutoRunWatchdog(
+  autoRun: AutoRunState,
+  events: readonly WorkflowEvent[],
+  ownership: 'none' | 'running' | 'unknown' | 'interrupted',
+  now: number,
+): AutoRunWatchdogDecision {
+  if (autoRun.status !== 'paused' || autoRun.pausedReason !== 'controller-error') return { kind: 'none' }
+  if (now >= Date.parse(autoRun.deadline)) return { kind: 'budget-exhausted' }
+  if (ownership === 'interrupted') return { kind: 'session-interrupted' }
+  if (ownership === 'unknown') {
+    return { kind: 'wait', retryAt: now + AUTO_RUN_BASE_RETRY_MS, reason: 'ownership-unknown' }
+  }
+  const cooldownAt = autoRun.controllerRecovery?.retryAt
+    ? Date.parse(autoRun.controllerRecovery.retryAt)
+    : Date.parse(autoRun.lastObservedAt ?? autoRun.startedAt) + AUTO_RUN_WATCHDOG_COOLDOWN_MS
+  if (Number.isFinite(cooldownAt) && now < cooldownAt) {
+    return { kind: 'wait', retryAt: cooldownAt, reason: 'cooldown' }
+  }
+  const recent = watchdogEvents(events, now)
+  if (recent.length >= AUTO_RUN_WATCHDOG_LIMIT) {
+    const oldest = Math.min(...recent.map((event) => Date.parse(event.at)))
+    return { kind: 'wait', retryAt: oldest + AUTO_RUN_WATCHDOG_WINDOW_MS, reason: 'hourly-limit' }
+  }
+  return { kind: 'reattach' }
+}

--- a/src/workflow/auto-run-recovery.ts
+++ b/src/workflow/auto-run-recovery.ts
@@ -1,0 +1,451 @@
+import type { Context } from '@deepseek-ai/cordis'
+import { isGithubRateLimitError, recoveryLabel } from '../github/rest.ts'
+import type { AutoRunControllerRecovery } from '../infra/contracts.ts'
+import {
+  armAutoRunDeadline,
+  autoRunWakePending,
+  clearAutoRunSchedule,
+  scheduleAutoRunWake,
+  scheduleAutoRunWakeAt,
+  type AutoRunWake,
+} from '../infra/auto-run-scheduler.ts'
+import { liveTasks } from '../infra/runtime.ts'
+import {
+  appendEvent,
+  type AutoRunPausedReason,
+  commitWorkflowMetadata,
+  type IssueWorkflow,
+  loadWorkflow,
+  workflowRevision,
+} from '../infra/state.ts'
+import { logTaskDiagnostic } from '../infra/task-diagnostics.ts'
+import { observeWorkflowTask, type TaskOwnershipContext } from '../infra/task-ownership.ts'
+import {
+  AUTO_RUN_WATCHDOG_COOLDOWN_MS,
+  AUTO_RUN_WATCHDOG_NOTE,
+  AUTO_RUN_BASE_RETRY_MS,
+  controllerFailureEvidence,
+  decideAutoRunWatchdog,
+  nextControllerFailure,
+  type ControllerFailureAttempt,
+} from './auto-run-recovery-policy.ts'
+import { autoRunRetryDelay } from './auto-run-policy.ts'
+
+const failureAttemptsSymbol = Symbol.for('clickvibe.auto-run-failure-attempts')
+const failureAttemptsRoot = globalThis as unknown as Record<PropertyKey, unknown>
+const failureAttempts =
+  (failureAttemptsRoot[failureAttemptsSymbol] as Map<string, ControllerFailureAttempt> | undefined) ?? new Map()
+failureAttemptsRoot[failureAttemptsSymbol] = failureAttempts
+const RATE_RETRY_BUFFER_MS = 2_000
+
+export { armAutoRunDeadline, autoRunWakePending }
+export type { AutoRunWake }
+
+export class AutoRunControllerError extends Error {
+  readonly source: string
+
+  constructor(source: string, message: string) {
+    super(message)
+    this.name = 'AutoRunControllerError'
+    this.source = source
+  }
+}
+
+export function clearAutoRunTimers(key: string): void {
+  clearAutoRunSchedule(key)
+  failureAttempts.delete(key)
+}
+
+export function scheduleAutoRunObservation(ctx: Context, key: string, deadline: string, wake: AutoRunWake): void {
+  const delay = autoRunRetryDelay(Date.now(), Date.parse(deadline))
+  if (delay !== null) scheduleAutoRunWake(ctx, key, Date.now() + delay, deadline, wake)
+}
+
+interface PauseEvidence {
+  action?: string
+  error?: string
+  note?: string
+}
+
+async function pauseLoaded(
+  workflow: IssueWorkflow,
+  reason: AutoRunPausedReason,
+  evidence?: PauseEvidence,
+  ctx?: Context,
+): Promise<void> {
+  if (!workflow.autoRun) return
+  const canTransition =
+    workflow.autoRun.status === 'running' ||
+    (workflow.autoRun.status === 'paused' &&
+      workflow.autoRun.pausedReason === 'controller-error' &&
+      (reason === 'budget-exhausted' || reason === 'session-interrupted' || reason === 'task-timeout'))
+  if (!canTransition) return
+  const evidenceNote = evidence
+    ? `(${[
+        evidence.action ? `动作 ${evidence.action}` : null,
+        evidence.error ? `错误: ${evidence.error.slice(0, 200)}` : null,
+        evidence.note ?? null,
+      ]
+        .filter(Boolean)
+        .join(' · ')})`
+    : ''
+  logTaskDiagnostic('auto-run-pause', {
+    reason,
+    ...(evidence ? { action: evidence.action ?? null, error: evidence.error?.slice(0, 500) ?? null } : {}),
+    workflowKey: workflow.key,
+    step: workflow.autoRun.step ?? 0,
+    updatedAt: workflow.updatedAt,
+    devTaskId: workflow.devTaskId,
+    reviewTaskId: workflow.reviewTaskId,
+    liveTaskKeys: [...liveTasks.entries()].filter(([, task]) => !task.closed).map(([taskId]) => taskId),
+  })
+  workflow.autoRun.status = 'paused'
+  workflow.autoRun.pausedReason = reason
+  workflow.autoRun.lastObservedAt = new Date().toISOString()
+  if (reason === 'budget-exhausted' && ctx) stopBudgetTask(ctx, workflow)
+  await appendEvent(
+    workflow,
+    {
+      kind: 'auto-run',
+      at: new Date().toISOString(),
+      round: workflow.autoRun.rounds,
+      step: workflow.autoRun.step,
+      note: `自动跑到底已暂停:${reason}${evidenceNote}`,
+    },
+    workflowRevision(workflow) ?? 0,
+  )
+  if (reason !== 'controller-error') clearAutoRunSchedule(workflow.key)
+}
+
+export async function pauseAutoRun(
+  key: string,
+  reason: AutoRunPausedReason,
+  evidence?: PauseEvidence,
+  ctx?: Context,
+): Promise<void> {
+  const workflow = await loadWorkflow(key)
+  if (workflow) await pauseLoaded(workflow, reason, evidence, ctx)
+}
+
+export async function completeAutoRun(key: string, note = '自动跑到底已收敛,等待人工合并'): Promise<void> {
+  const workflow = await loadWorkflow(key)
+  if (!workflow?.autoRun || workflow.autoRun.status !== 'running') return
+  workflow.autoRun.status = 'completed'
+  workflow.autoRun.pausedReason = null
+  delete workflow.autoRun.controllerRecovery
+  await appendEvent(
+    workflow,
+    {
+      kind: 'auto-run',
+      at: new Date().toISOString(),
+      round: workflow.autoRun.rounds,
+      step: workflow.autoRun.step,
+      note,
+    },
+    workflowRevision(workflow) ?? 0,
+  )
+  clearAutoRunTimers(key)
+}
+
+function persistedAttempt(workflow: IssueWorkflow, evidence: ReturnType<typeof controllerFailureEvidence>) {
+  const saved = workflow.autoRun?.controllerRecovery
+  if (!saved) return null
+  return {
+    ...evidence,
+    attempt: saved.attempt,
+    consecutive: saved.consecutive,
+    fingerprint: saved.fingerprint,
+    delayMs: Math.max(0, Date.parse(saved.retryAt) - Date.parse(saved.lastFailureAt)),
+    retryAt: Date.parse(saved.retryAt),
+    fused: saved.kind === 'fused',
+  }
+}
+
+function recoveryState(
+  attempt: ControllerFailureAttempt,
+  kind: AutoRunControllerRecovery['kind'],
+  retryAt = attempt.retryAt,
+  failedAt = Date.now(),
+): AutoRunControllerRecovery {
+  return {
+    kind,
+    attempt: attempt.attempt,
+    consecutive: attempt.consecutive,
+    fingerprint: attempt.fingerprint,
+    retryAt: new Date(retryAt).toISOString(),
+    lastFailureAt: new Date(failedAt).toISOString(),
+  }
+}
+
+async function persistRecovery(workflow: IssueWorkflow, recovery: AutoRunControllerRecovery): Promise<void> {
+  if (!workflow.autoRun) return
+  workflow.autoRun.controllerRecovery = recovery
+  try {
+    Object.assign(
+      workflow,
+      await commitWorkflowMetadata(workflow, workflowRevision(workflow), { autoRun: workflow.autoRun }),
+    )
+  } catch (error) {
+    logTaskDiagnostic('auto-run-recovery-persist-error', {
+      workflowKey: workflow.key,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+function safeOwnership(ctx: Context, workflow: IssueWorkflow): ReturnType<typeof observeWorkflowTask> {
+  try {
+    return observeWorkflowTask(ctx as unknown as TaskOwnershipContext, workflow)
+  } catch {
+    const taskId = workflow.stage === 'reviewing' ? workflow.reviewTaskId : workflow.devTaskId
+    const kind = workflow.stage === 'reviewing' ? 'review' : 'dev'
+    return taskId
+      ? { state: 'unknown', startedAt: null, source: 'registry-error', kind, taskId }
+      : { state: 'none', startedAt: null, source: 'not-in-flight' }
+  }
+}
+
+function stopBudgetTask(ctx: Context, workflow: IssueWorkflow): void {
+  const ownership = safeOwnership(ctx, workflow)
+  if (ownership.state !== 'running') {
+    logTaskDiagnostic('auto-run-budget-task-stop', {
+      workflowKey: workflow.key,
+      ownershipState: ownership.state,
+      stopped: false,
+    })
+    return
+  }
+  const local = liveTasks.get(ownership.taskId)
+  if (local && !local.closed) {
+    local.process?.kill()
+    logTaskDiagnostic('auto-run-budget-task-stop', {
+      workflowKey: workflow.key,
+      ownershipState: ownership.state,
+      taskId: ownership.taskId,
+      stopped: true,
+      source: 'local-map',
+    })
+    return
+  }
+  const hostJobId = ownership.kind === 'dev' ? workflow.devHostJobId : workflow.reviewHostJobId
+  const jobs = (ctx as unknown as { jobs?: { kill?: (id: string, caller?: unknown, reason?: string) => unknown } }).jobs
+  const stopped = Boolean(hostJobId && jobs?.kill && jobs.kill(hostJobId, undefined, 'auto-run budget exhausted'))
+  logTaskDiagnostic('auto-run-budget-task-stop', {
+    workflowKey: workflow.key,
+    ownershipState: ownership.state,
+    taskId: ownership.taskId,
+    hostJobId: hostJobId ?? null,
+    stopped,
+    source: 'host-registry',
+  })
+}
+
+async function pauseOrRetry(
+  ctx: Context,
+  workflow: IssueWorkflow,
+  reason: AutoRunPausedReason,
+  wake: AutoRunWake,
+  evidence?: PauseEvidence,
+): Promise<boolean> {
+  try {
+    await pauseLoaded(workflow, reason, evidence, ctx)
+    return true
+  } catch (error) {
+    logTaskDiagnostic('auto-run-pause-persist-error', {
+      workflowKey: workflow.key,
+      reason,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    scheduleAutoRunWakeAt(ctx, workflow.key, Date.now() + AUTO_RUN_BASE_RETRY_MS, wake)
+    return false
+  }
+}
+
+export async function handleAutoRunControllerFailure(
+  ctx: Context,
+  key: string,
+  error: unknown,
+  source: string,
+  wake: AutoRunWake,
+): Promise<void> {
+  const workflow = await loadWorkflow(key)
+  if (!workflow?.autoRun || workflow.autoRun.status !== 'running') {
+    if (!workflow) {
+      logTaskDiagnostic('auto-run-state-unavailable', {
+        workflowKey: key,
+        source,
+        retryInMs: AUTO_RUN_BASE_RETRY_MS,
+      })
+      scheduleAutoRunWakeAt(ctx, key, Date.now() + AUTO_RUN_BASE_RETRY_MS, wake)
+    }
+    return
+  }
+  const now = Date.now()
+  if (now >= Date.parse(workflow.autoRun.deadline)) {
+    await pauseOrRetry(ctx, workflow, 'budget-exhausted', wake)
+    return
+  }
+  if (isGithubRateLimitError(error)) {
+    const retryAt = error.resetAt + RATE_RETRY_BUFFER_MS
+    const evidence = controllerFailureEvidence(error)
+    const previous = failureAttempts.get(key) ?? persistedAttempt(workflow, evidence)
+    const attempt = nextControllerFailure(previous, evidence, now, Math.random())
+    failureAttempts.set(key, attempt)
+    workflow.autoRun.controllerRecovery = recoveryState(attempt, 'rate-limit', retryAt, now)
+    logTaskDiagnostic('auto-run-rate-deferred', {
+      workflowKey: key,
+      retryAt: new Date(retryAt).toISOString(),
+      resetAt: new Date(error.resetAt).toISOString(),
+      source,
+      delayMs: Math.max(0, retryAt - now),
+      kind: error.kind,
+      attempt: attempt.attempt,
+    })
+    try {
+      await appendEvent(
+        workflow,
+        {
+          kind: 'auto-run',
+          at: new Date(now).toISOString(),
+          round: workflow.autoRun.rounds,
+          step: workflow.autoRun.step,
+          note: `自动跑到底遇 GitHub 限流(${source}),自动等待至 ${recoveryLabel(retryAt)} 重试(不暂停)`,
+        },
+        workflowRevision(workflow) ?? 0,
+      )
+    } catch (persistError) {
+      logTaskDiagnostic('auto-run-recovery-persist-error', {
+        workflowKey: key,
+        source,
+        error: persistError instanceof Error ? persistError.message : String(persistError),
+      })
+    }
+    scheduleAutoRunWake(ctx, key, retryAt, workflow.autoRun.deadline, wake)
+    return
+  }
+
+  const evidence = controllerFailureEvidence(error)
+  const previous = failureAttempts.get(key) ?? persistedAttempt(workflow, evidence)
+  const attempt = nextControllerFailure(previous, evidence, now, Math.random())
+  const ownership = safeOwnership(ctx, workflow)
+  failureAttempts.set(
+    key,
+    ownership.state === 'running' || ownership.state === 'unknown'
+      ? { ...attempt, fingerprint: `ownership-barrier:${attempt.fingerprint}`, consecutive: 0, fused: false }
+      : attempt,
+  )
+  const retryAt = attempt.fused && ownership.state === 'none' ? now + AUTO_RUN_WATCHDOG_COOLDOWN_MS : attempt.retryAt
+  const diagnostic = {
+    workflowKey: key,
+    source,
+    ownershipState: ownership.state,
+    errorName: attempt.name,
+    errorMessage: attempt.message,
+    errorStack: attempt.stack,
+    attempt: attempt.attempt,
+    consecutive: attempt.consecutive,
+    fingerprint: attempt.fingerprint,
+    retryAt: new Date(retryAt).toISOString(),
+  }
+  if (ownership.state === 'interrupted') {
+    await pauseOrRetry(ctx, workflow, 'session-interrupted', wake, { error: attempt.message })
+    return
+  }
+  if (attempt.fused && ownership.state === 'none') {
+    workflow.autoRun.controllerRecovery = recoveryState(attempt, 'fused', retryAt, now)
+    logTaskDiagnostic('auto-run-controller-fuse', {
+      ...diagnostic,
+      basis: `same-stack fingerprint ${attempt.fingerprint} consecutive ${attempt.consecutive} >= 3`,
+    })
+    const paused = await pauseOrRetry(ctx, workflow, 'controller-error', wake, {
+      error: attempt.message,
+      note: `相同错误栈连续 ${attempt.consecutive} 次触发熔断;fingerprint=${attempt.fingerprint}`,
+    })
+    armAutoRunDeadline(ctx, key, workflow.autoRun.deadline, wake)
+    scheduleAutoRunWake(ctx, key, paused ? retryAt : now + AUTO_RUN_BASE_RETRY_MS, workflow.autoRun.deadline, wake)
+    return
+  }
+
+  logTaskDiagnostic('auto-run-controller-retry', diagnostic)
+  if (ownership.state === 'none')
+    await persistRecovery(workflow, recoveryState(attempt, 'transient', attempt.retryAt, now))
+  scheduleAutoRunWake(ctx, key, attempt.retryAt, workflow.autoRun.deadline, wake)
+}
+
+export async function clearAutoRunControllerFailure(key: string): Promise<void> {
+  failureAttempts.delete(key)
+  const workflow = await loadWorkflow(key)
+  if (!workflow?.autoRun?.controllerRecovery || workflow.autoRun.status !== 'running') return
+  delete workflow.autoRun.controllerRecovery
+  try {
+    await commitWorkflowMetadata(workflow, workflowRevision(workflow), { autoRun: workflow.autoRun })
+  } catch (error) {
+    logTaskDiagnostic('auto-run-recovery-clear-error', {
+      workflowKey: key,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+export async function maintainPausedAutoRun(
+  ctx: Context,
+  key: string,
+  wake: AutoRunWake,
+): Promise<'handled' | 'reattached'> {
+  const workflow = await loadWorkflow(key)
+  if (!workflow?.autoRun) return 'handled'
+  const ownership = safeOwnership(ctx, workflow)
+  const decision = decideAutoRunWatchdog(workflow.autoRun, workflow.events, ownership.state, Date.now())
+  if (decision.kind === 'none') return 'handled'
+  if (decision.kind === 'budget-exhausted') {
+    await pauseOrRetry(ctx, workflow, 'budget-exhausted', wake)
+    return 'handled'
+  }
+  if (decision.kind === 'session-interrupted') {
+    await pauseOrRetry(ctx, workflow, 'session-interrupted', wake)
+    return 'handled'
+  }
+  if (decision.kind === 'wait') {
+    logTaskDiagnostic('auto-run-watchdog-wait', {
+      workflowKey: key,
+      reason: decision.reason,
+      ownershipState: ownership.state,
+      retryAt: new Date(decision.retryAt).toISOString(),
+    })
+    armAutoRunDeadline(ctx, key, workflow.autoRun.deadline, wake)
+    scheduleAutoRunWake(ctx, key, decision.retryAt, workflow.autoRun.deadline, wake)
+    return 'handled'
+  }
+  workflow.autoRun.status = 'running'
+  workflow.autoRun.pausedReason = null
+  workflow.autoRun.lastObservedAt = new Date().toISOString()
+  delete workflow.autoRun.controllerRecovery
+  failureAttempts.delete(key)
+  try {
+    await appendEvent(
+      workflow,
+      {
+        kind: 'auto-run',
+        at: new Date().toISOString(),
+        round: workflow.autoRun.rounds,
+        step: workflow.autoRun.step,
+        note: AUTO_RUN_WATCHDOG_NOTE,
+      },
+      workflowRevision(workflow) ?? 0,
+    )
+  } catch (error) {
+    logTaskDiagnostic('auto-run-watchdog-persist-error', {
+      workflowKey: key,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    scheduleAutoRunWakeAt(ctx, key, Date.now() + AUTO_RUN_BASE_RETRY_MS, wake)
+    return 'handled'
+  }
+  logTaskDiagnostic('auto-run-watchdog-reattach', {
+    workflowKey: key,
+    ownershipState: ownership.state,
+    deadline: workflow.autoRun.deadline,
+  })
+  armAutoRunDeadline(ctx, key, workflow.autoRun.deadline, wake)
+  return 'reattached'
+}

--- a/src/workflow/auto-run.ts
+++ b/src/workflow/auto-run.ts
@@ -1,24 +1,12 @@
 import type { Context } from '@deepseek-ai/cordis'
 import { ensureWorktree } from '../agent/worktree.ts'
 import { fetchIssue, issueSnapshot, sameIssueContract } from '../github/issue.ts'
-import { githubRest, isGithubRateLimitError, recoveryLabel } from '../github/rest.ts'
+import { githubRest } from '../github/rest.ts'
 import { type IssuePromptSnapshot } from '../infra/develop-core.ts'
 import { liveTasks, parseUrl } from '../infra/runtime.ts'
-import {
-  appendEvent,
-  type AutoRunPausedReason,
-  issueKey,
-  loadWorkflow,
-  commitWorkflowMetadata,
-  workflowRevision,
-} from '../infra/state.ts'
+import { appendEvent, issueKey, loadWorkflow, commitWorkflowMetadata, workflowRevision } from '../infra/state.ts'
 import { logTaskDiagnostic } from '../infra/task-diagnostics.ts'
-import {
-  observeWorkflowTask,
-  taskLaunchDecision,
-  type TaskOwnershipContext,
-  type WorkflowTaskRef,
-} from '../infra/task-ownership.ts'
+import { observeWorkflowTask, type TaskOwnershipContext } from '../infra/task-ownership.ts'
 import { createPullRequest } from './create-pr.ts'
 import { startDevelop } from './develop-start.ts'
 import { mergeAndCleanup } from './merge.ts'
@@ -27,74 +15,40 @@ import {
   type AutoRunConfig,
   type AutoRunTaskOutcome,
   autoRunFailureReason,
-  autoRunRetryDelay,
   decideAutoRun,
   validateAutoRunConfig,
 } from './auto-run-policy.ts'
 import type { AutoRunState, IssueWorkflow } from '../infra/state.ts'
-import type { LiveTask } from '../infra/runtime.ts'
+import {
+  armAutoRunDeadline,
+  autoRunWakePending,
+  AutoRunControllerError,
+  clearAutoRunControllerFailure,
+  completeAutoRun,
+  handleAutoRunControllerFailure,
+  maintainPausedAutoRun,
+  pauseAutoRun,
+  scheduleAutoRunObservation,
+} from './auto-run-recovery.ts'
 import { registerAutoRunReconciler } from './auto-run-signal.ts'
 import { enrichWorkflowStates } from './repository-state.ts'
 import { resumeDevelop } from './resume.ts'
 import { startReview } from './review-flow.ts'
 import { syncWorktree } from './sync.ts'
 
-const running = new Set<string>()
-const queued = new Map<string, AutoRunTaskOutcome | undefined>()
-const deadlineTimers = new Map<string, ReturnType<typeof setTimeout>>()
-const observationTimers = new Map<string, ReturnType<typeof setTimeout>>()
-const rateRetryTimers = new Map<string, ReturnType<typeof setTimeout>>()
-
-/** #120 切片②:限流按 reset 自动重试的缓冲,避免压着恢复时刻立即再撞。 */
-const RATE_RETRY_BUFFER_MS = 2_000
-
-function clearRateRetry(key: string): void {
-  const timer = rateRetryTimers.get(key)
-  if (timer) clearTimeout(timer)
-  rateRetryTimers.delete(key)
+interface AutoRunCommandState {
+  running: Set<string>
+  queued: Map<string, AutoRunTaskOutcome | undefined>
 }
 
-/** Defer instead of pausing when the only failure is a GitHub rate limit. */
-async function scheduleRateRetry(ctx: Context, key: string, resetAt: number, source: string): Promise<void> {
-  clearRateRetry(key)
-  const delay = Math.max(0, resetAt + RATE_RETRY_BUFFER_MS - Date.now())
-  logTaskDiagnostic('auto-run-rate-deferred', {
-    workflowKey: key,
-    retryAt: new Date(resetAt + RATE_RETRY_BUFFER_MS).toISOString(),
-    resetAt: new Date(resetAt).toISOString(),
-    source,
-    delayMs: delay,
-  })
-  const workflow = await loadWorkflow(key)
-  if (workflow?.autoRun?.status === 'running') {
-    await appendEvent(
-      workflow,
-      {
-        kind: 'auto-run',
-        at: new Date().toISOString(),
-        round: workflow.autoRun.rounds,
-        step: workflow.autoRun.step,
-        note: `自动跑到底遇 GitHub 限流(${source}),自动等待至 ${recoveryLabel(resetAt + RATE_RETRY_BUFFER_MS)} 重试(不暂停)`,
-      },
-      workflowRevision(workflow) ?? 0,
-    )
-  }
-  const timer = setTimeout(
-    () => {
-      rateRetryTimers.delete(key)
-      requestAutoRunReconcile(ctx, key)
-    },
-    Math.min(delay, 2_147_483_647),
-  )
-  timer.unref?.()
-  rateRetryTimers.set(key, timer)
+const commandStateSymbol = Symbol.for('clickvibe.auto-run-command-state')
+const commandStateRoot = globalThis as unknown as Record<PropertyKey, unknown>
+const commandState = (commandStateRoot[commandStateSymbol] as AutoRunCommandState | undefined) ?? {
+  running: new Set(),
+  queued: new Map(),
 }
-
-function liveTaskFor(taskRef: WorkflowTaskRef | null): LiveTask | null {
-  if (!taskRef) return null
-  const task = liveTasks.get(taskRef.taskId)
-  return task && !task.closed ? task : null
-}
+commandStateRoot[commandStateSymbol] = commandState
+const { running, queued } = commandState
 
 async function persistDecision(key: string, decision: Exclude<AutoRunDecision, { kind: 'manual' }>): Promise<void> {
   const workflow = await loadWorkflow(key)
@@ -109,133 +63,21 @@ async function persistDecision(key: string, decision: Exclude<AutoRunDecision, {
   )
 }
 
-interface PauseEvidence {
-  action?: string
-  error?: string
-}
-
-async function pauseAutoRun(key: string, reason: AutoRunPausedReason, evidence?: PauseEvidence): Promise<void> {
-  const workflow = await loadWorkflow(key)
-  if (!workflow?.autoRun || workflow.autoRun.status !== 'running') return
-  const evidenceNote = evidence
-    ? `(${[
-        evidence.action ? `动作 ${evidence.action}` : null,
-        evidence.error ? `错误: ${evidence.error.slice(0, 200)}` : null,
-      ]
-        .filter(Boolean)
-        .join(' · ')})`
-    : ''
-  logTaskDiagnostic('auto-run-pause', {
-    reason,
-    ...(evidence ? { action: evidence.action ?? null, error: evidence.error?.slice(0, 500) ?? null } : {}),
-    workflowKey: key,
-    step: workflow.autoRun.step ?? 0,
-    updatedAt: workflow.updatedAt,
-    devTaskId: workflow.devTaskId,
-    reviewTaskId: workflow.reviewTaskId,
-    liveTaskKeys: [...liveTasks.entries()].filter(([, task]) => !task.closed).map(([taskId]) => taskId),
-  })
-  workflow.autoRun.status = 'paused'
-  workflow.autoRun.pausedReason = reason
-  workflow.autoRun.lastObservedAt = new Date().toISOString()
-  await appendEvent(
-    workflow,
-    {
-      kind: 'auto-run',
-      at: new Date().toISOString(),
-      round: workflow.autoRun.rounds,
-      step: workflow.autoRun.step,
-      note: `自动跑到底已暂停:${reason}${evidenceNote}`,
-    },
-    workflowRevision(workflow) ?? 0,
-  )
-  clearDeadline(key)
-  clearObservation(key)
-  clearRateRetry(key)
-}
-
-async function completeAutoRun(key: string): Promise<void> {
-  const workflow = await loadWorkflow(key)
-  if (!workflow?.autoRun || workflow.autoRun.status !== 'running') return
-  workflow.autoRun.status = 'completed'
-  workflow.autoRun.pausedReason = null
-  await appendEvent(
-    workflow,
-    {
-      kind: 'auto-run',
-      at: new Date().toISOString(),
-      round: workflow.autoRun.rounds,
-      step: workflow.autoRun.step,
-      note: '自动跑到底已收敛,等待人工合并',
-    },
-    workflowRevision(workflow) ?? 0,
-  )
-  clearDeadline(key)
-  clearObservation(key)
-  clearRateRetry(key)
-}
-
-function clearObservation(key: string): void {
-  const timer = observationTimers.get(key)
-  if (timer) clearTimeout(timer)
-  observationTimers.delete(key)
-}
-
-function scheduleObservation(ctx: Context, key: string, deadline: string): void {
-  clearObservation(key)
-  const delay = autoRunRetryDelay(Date.now(), Date.parse(deadline))
-  if (delay === null) return
-  const timer = setTimeout(() => {
-    observationTimers.delete(key)
-    requestAutoRunReconcile(ctx, key)
-  }, delay)
-  timer.unref?.()
-  observationTimers.set(key, timer)
-}
-
-function clearDeadline(key: string): void {
-  const timer = deadlineTimers.get(key)
-  if (timer) clearTimeout(timer)
-  deadlineTimers.delete(key)
-}
-
-function armDeadline(ctx: Context, key: string, deadline: string): void {
-  clearDeadline(key)
-  const delay = Math.max(0, Date.parse(deadline) - Date.now())
-  const timer = setTimeout(
-    () => {
-      void (async () => {
-        if (Date.now() < Date.parse(deadline)) {
-          armDeadline(ctx, key, deadline)
-          return
-        }
-        await pauseAutoRun(key, 'budget-exhausted')
-        const workflow = await loadWorkflow(key)
-        if (workflow) {
-          const gate = taskLaunchDecision(observeWorkflowTask(ctx as unknown as TaskOwnershipContext, workflow))
-          if (!gate.allowed && gate.running) liveTaskFor(gate.task)?.process?.kill()
-        }
-      })()
-    },
-    Math.min(delay, 2_147_483_647),
-  )
-  timer.unref?.()
-  deadlineTimers.set(key, timer)
-}
-
 async function applyDecision(ctx: Context, key: string, decision: AutoRunDecision): Promise<void> {
   if (decision.kind === 'manual') return
   if (decision.kind === 'wait') {
     const workflow = await loadWorkflow(key)
-    if (workflow?.autoRun?.status === 'running') scheduleObservation(ctx, key, workflow.autoRun.deadline)
+    if (workflow?.autoRun?.status === 'running') {
+      scheduleAutoRunObservation(ctx, key, workflow.autoRun.deadline, requestAutoRunReconcile)
+    }
     return
   }
   if (decision.kind === 'pause') {
-    await pauseAutoRun(key, decision.reason)
+    await pauseAutoRun(key, decision.reason, undefined, ctx)
     return
   }
   if (decision.kind === 'complete') {
-    await completeAutoRun(key)
+    await completeAutoRun(key, decision.reason === 'issue-closed' ? 'Issue 已关闭,自动跑到底结束' : undefined)
     return
   }
   const workflow = await loadWorkflow(key)
@@ -276,10 +118,7 @@ async function applyDecision(ctx: Context, key: string, decision: AutoRunDecisio
   }
   if (!result.ok) {
     const circuit = githubRest(ctx as never).rateLimitError()
-    if (circuit) {
-      await scheduleRateRetry(ctx, key, circuit.resetAt, `动作 ${decision.action}`)
-      return
-    }
+    if (circuit) throw circuit
     if (result.conflict) {
       // 原则 10(可恢复性优于预防):sync 冲突现场已由 syncWorktree 保留并记录,
       // 属可恢复工作——不暂停,直接排队下一轮 reconcile,由 derive 推导出 resume
@@ -288,19 +127,31 @@ async function applyDecision(ctx: Context, key: string, decision: AutoRunDecisio
       requestAutoRunReconcile(ctx, key)
       return
     }
-    await pauseAutoRun(key, autoRunFailureReason(decision.action, result), {
-      action: decision.action,
-      error: result.error,
-    })
+    const reason = autoRunFailureReason(decision.action, result)
+    if (reason === 'controller-error' || reason === 'cleanup-failed') {
+      throw new AutoRunControllerError(`action:${decision.action}`, result.error ?? reason)
+    }
+    await pauseAutoRun(
+      key,
+      reason,
+      {
+        action: decision.action,
+        error: result.error,
+      },
+      ctx,
+    )
     return
   }
   if (decision.action === 'create-pr' || decision.action === 'sync') requestAutoRunReconcile(ctx, key)
 }
 
 async function reconcileOnce(ctx: Context, key: string, outcome?: AutoRunTaskOutcome): Promise<void> {
-  clearObservation(key)
   const workflow = await loadWorkflow(key)
   if (!workflow?.autoRun || workflow.autoRun.status !== 'running') return
+  if (Date.now() >= Date.parse(workflow.autoRun.deadline)) {
+    await pauseAutoRun(key, 'budget-exhausted', undefined, ctx)
+    return
+  }
   const [observed] = await enrichWorkflowStates(ctx, [workflow])
   if (!observed) return
   const decision = decideAutoRun({
@@ -308,10 +159,12 @@ async function reconcileOnce(ctx: Context, key: string, outcome?: AutoRunTaskOut
     nextAction: observed.derived.nextAction,
     now: Date.now(),
     reviewEvents: workflow.events,
+    issueOpen: observed.issueState !== 'CLOSED',
     ...(outcome ? { taskOutcome: outcome } : {}),
   })
   if (decision.kind !== 'manual') await persistDecision(key, decision)
   await applyDecision(ctx, key, decision)
+  await clearAutoRunControllerFailure(key)
 }
 
 export function requestAutoRunReconcile(ctx: Context, key: string, outcome?: AutoRunTaskOutcome): void {
@@ -325,7 +178,13 @@ export function requestAutoRunReconcile(ctx: Context, key: string, outcome?: Aut
     try {
       do {
         queued.delete(key)
-        await reconcileOnce(ctx, key, nextOutcome)
+        const current = await loadWorkflow(key)
+        if (current?.autoRun?.status === 'paused' && current.autoRun.pausedReason === 'controller-error') {
+          const maintained = await maintainPausedAutoRun(ctx, key, requestAutoRunReconcile)
+          if (maintained === 'reattached') await reconcileOnce(ctx, key, nextOutcome)
+        } else {
+          await reconcileOnce(ctx, key, nextOutcome)
+        }
         nextOutcome = queued.get(key)
       } while (queued.has(key))
     } catch (error) {
@@ -336,13 +195,8 @@ export function requestAutoRunReconcile(ctx: Context, key: string, outcome?: Aut
         errorMessage: error instanceof Error ? error.message : String(error),
         errorStack: error instanceof Error ? error.stack : null,
       })
-      if (isGithubRateLimitError(error)) {
-        await scheduleRateRetry(ctx, key, error.resetAt, 'reconcile')
-      } else {
-        await pauseAutoRun(key, 'controller-error', {
-          error: `${error instanceof Error ? error.message : String(error)}`,
-        })
-      }
+      const source = error instanceof AutoRunControllerError ? error.source : 'reconcile'
+      await handleAutoRunControllerFailure(ctx, key, error, source, requestAutoRunReconcile)
     } finally {
       running.delete(key)
     }
@@ -403,7 +257,7 @@ export async function startAutoRun(
     { kind: 'auto-run', at: startedAt, round: 0, note: '自动跑到底已启动' },
     workflowRevision(ensured.workflow) ?? 0,
   )
-  armDeadline(ctx, key, ensured.workflow.autoRun.deadline)
+  armAutoRunDeadline(ctx, key, ensured.workflow.autoRun.deadline, requestAutoRunReconcile)
   requestAutoRunReconcile(ctx, key)
   return { ok: true, workflowKey: key }
 }
@@ -413,24 +267,34 @@ export async function pauseOrphanedAutoRuns(
   workflows: readonly (IssueWorkflow & { autoRun?: AutoRunState })[],
 ): Promise<void> {
   for (const candidate of workflows) {
-    if (candidate.autoRun?.status !== 'running' || running.has(candidate.key) || observationTimers.has(candidate.key)) {
+    const autoRun = candidate.autoRun
+    if (!autoRun) continue
+    const eligible =
+      autoRun.status === 'running' || (autoRun.status === 'paused' && autoRun.pausedReason === 'controller-error')
+    if (!eligible || running.has(candidate.key) || autoRunWakePending(candidate.key)) {
       continue
     }
-    const ownership = observeWorkflowTask(ctx as unknown as TaskOwnershipContext, candidate)
+    armAutoRunDeadline(ctx, candidate.key, autoRun.deadline, requestAutoRunReconcile)
+    let ownership: ReturnType<typeof observeWorkflowTask> | null = null
+    try {
+      ownership = observeWorkflowTask(ctx as unknown as TaskOwnershipContext, candidate)
+    } catch (error) {
+      logTaskDiagnostic('auto-run-ownership-error', {
+        workflowKey: candidate.key,
+        error: error instanceof Error ? error.message : String(error),
+        trigger: 'state-refresh',
+      })
+    }
     logTaskDiagnostic('auto-run-ownership-observed', {
       workflowKey: candidate.key,
-      step: candidate.autoRun.step ?? 0,
+      step: autoRun.step ?? 0,
       updatedAt: candidate.updatedAt,
-      ownership,
+      ownership: ownership ?? { state: 'unknown', source: 'registry-error' },
       devTaskId: candidate.devTaskId,
       reviewTaskId: candidate.reviewTaskId,
       liveTaskKeys: [...liveTasks.entries()].filter(([, task]) => !task.closed).map(([taskId]) => taskId),
       trigger: 'state-refresh',
     })
-    if (ownership.state === 'interrupted') {
-      await pauseAutoRun(candidate.key, 'session-interrupted')
-      continue
-    }
-    requestAutoRunReconcile(ctx, candidate.key)
+    requestAutoRunReconcile(ctx, candidate.key, ownership?.state === 'interrupted' ? 'stopped' : undefined)
   }
 }

--- a/src/workflow/auto-run.ts
+++ b/src/workflow/auto-run.ts
@@ -110,6 +110,7 @@ async function applyDecision(ctx: Context, key: string, decision: AutoRunDecisio
     cleanupPending?: boolean
     gateFailures?: unknown[]
     controllerError?: boolean
+    semanticFailure?: 'authorization-denied'
   }
   switch (decision.action) {
     case 'develop':
@@ -219,6 +220,11 @@ export function requestAutoRunReconcile(ctx: Context, key: string, outcome?: Aut
       await handleAutoRunControllerFailure(ctx, key, error, source, requestAutoRunReconcile)
     } finally {
       running.delete(key)
+      if (queued.has(key)) {
+        const pending = queued.get(key)
+        queued.delete(key)
+        requestAutoRunReconcile(ctx, key, pending)
+      }
     }
   })()
 }

--- a/src/workflow/develop-start.ts
+++ b/src/workflow/develop-start.ts
@@ -56,6 +56,7 @@ import {
 } from '../infra/task-ownership.ts'
 import { withWorkflowLock } from '../infra/workflow-lock.ts'
 import { deriveAutoDevelopment } from './auto-development.ts'
+import { type AutoRunFailureClassification, classifiedAutoRunFailure } from './auto-run-policy.ts'
 import { deriveDevelopmentEventKind } from './delivery-audit.ts'
 import { finalizeDevRun } from './dev-completion.ts'
 import { deriveWorkflowState } from './derive.ts'
@@ -126,7 +127,8 @@ export async function startDevelop(
   payload: unknown,
   authorizedSnapshot: IssuePromptSnapshot | null,
 ): Promise<
-  { ok: true; taskId: string; worktree: string; branch: string } | { ok: false; error: string; controllerError?: true }
+  | { ok: true; taskId: string; worktree: string; branch: string }
+  | ({ ok: false; error: string; controllerError?: true } & AutoRunFailureClassification)
 > {
   const body = (payload ?? {}) as {
     url?: unknown
@@ -179,7 +181,10 @@ export async function startDevelop(
       automaticSnapshot = fetched
       const current = issueSnapshot(fetched.data.item as Record<string, unknown>)
       if (!sameSnapshot(current, authorizedSnapshot)) {
-        return { ok: false, error: 'Issue 内容在确认后已变化,旧授权已失效;请刷新面板并按当前快照重新确认' }
+        return classifiedAutoRunFailure(
+          'Issue 内容在确认后已变化,旧授权已失效;请刷新面板并按当前快照重新确认',
+          'authorization-denied',
+        )
       }
       launchSnapshot = { snapshot: current, freshness: 'current' }
     } else {

--- a/tests/auto-run-policy.test.ts
+++ b/tests/auto-run-policy.test.ts
@@ -245,6 +245,27 @@ test('deadline and task outcomes converge to explicit pause reasons', () => {
     decideAutoRun({ autoRun: running(), nextAction, now: 0, reviewEvents: [], taskOutcome: 'failed' }).reason,
     'session-interrupted',
   )
+  assert.equal(
+    decideAutoRun({
+      autoRun: running(),
+      nextAction,
+      now: Date.parse('2026-08-24T00:00:00Z'),
+      reviewEvents: [],
+      taskOutcome: 'failed',
+    }).reason,
+    'budget-exhausted',
+  )
+})
+
+test('a closed issue terminates auto-run after the budget gate without inventing more work', () => {
+  const decision = decideAutoRun({
+    autoRun: running(),
+    nextAction: { kind: 'none', label: '已关闭', hint: '' },
+    now: Date.parse('2026-08-23T01:00:00Z'),
+    reviewEvents: [],
+    issueOpen: false,
+  })
+  assert.deepEqual(decision, { kind: 'complete', reason: 'issue-closed', rounds: 0, unresolved: [] })
 })
 
 test('temporary observation gaps retry within the wall-clock budget', () => {

--- a/tests/auto-run-policy.test.ts
+++ b/tests/auto-run-policy.test.ts
@@ -4,6 +4,7 @@ import {
   aggregateAutoRunReviews,
   autoRunFailureReason,
   autoRunRetryDelay,
+  classifiedAutoRunFailure,
   decideAutoRun,
   isOrphanedAutoRun,
   validateAutoRunConfig,
@@ -290,4 +291,19 @@ test('cleanup failures remain distinct from merge gate rejection', () => {
   assert.equal(autoRunFailureReason('review', { ok: false, controllerError: true }), 'controller-error')
   assert.equal(autoRunFailureReason('create-pr', { ok: false, error: 'GitHub network failed' }), 'controller-error')
   assert.equal(autoRunFailureReason('sync', { ok: false, error: 'git authentication failed' }), 'controller-error')
+  assert.equal(
+    autoRunFailureReason('develop', { ok: false, error: '无法读取授权快照文件: EACCES' }),
+    'controller-error',
+  )
+  assert.equal(
+    autoRunFailureReason('develop', {
+      error: 'Issue contract changed',
+      semanticFailure: 'authorization-denied',
+    }),
+    'authorization-denied',
+  )
+  assert.equal(
+    JSON.stringify(classifiedAutoRunFailure('Issue contract changed', 'authorization-denied')),
+    '{"ok":false,"error":"Issue contract changed"}',
+  )
 })

--- a/tests/auto-run-recovery-policy.test.ts
+++ b/tests/auto-run-recovery-policy.test.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import type { AutoRunState, WorkflowEvent } from '../src/infra/state.ts'
+import {
+  AUTO_RUN_MAX_RETRY_MS,
+  AUTO_RUN_WATCHDOG_LIMIT,
+  AUTO_RUN_WATCHDOG_NOTE,
+  decideAutoRunWatchdog,
+  nextControllerFailure,
+} from '../src/workflow/auto-run-recovery-policy.ts'
+
+function autoRun(overrides: Partial<AutoRunState> = {}): AutoRunState {
+  return {
+    status: 'paused',
+    autoMerge: false,
+    devAgent: 'codex',
+    reviewAgent: 'codex',
+    maxRounds: 20,
+    budgetHours: 24,
+    startedAt: '2026-08-25T00:00:00.000Z',
+    deadline: '2026-08-26T00:00:00.000Z',
+    step: 1,
+    rounds: 0,
+    unresolved: [],
+    lastObservedAt: '2026-08-25T00:00:00.000Z',
+    pausedReason: 'controller-error',
+    ...overrides,
+  }
+}
+
+test('alternating transient stacks retry without a count limit for thirty simulated minutes', () => {
+  const startedAt = Date.parse('2026-08-25T00:00:00.000Z')
+  const deadline = startedAt + 60 * 60_000
+  let now = startedAt
+  let failure: ReturnType<typeof nextControllerFailure> | null = null
+  let attempts = 0
+  while (now < startedAt + 30 * 60_000) {
+    const stack =
+      attempts % 2 === 0 ? 'Error: network A\n at reconcile (a.ts:1:1)' : 'Error: git B\n at sync (b.ts:2:2)'
+    failure = nextControllerFailure(failure, { name: 'Error', message: stack.split('\n')[0], stack }, now, 0.5)
+    assert.equal(failure.fused, false, `alternating stack unexpectedly fused at attempt ${attempts + 1}`)
+    assert.ok(failure.delayMs <= AUTO_RUN_MAX_RETRY_MS)
+    assert.ok(failure.retryAt <= deadline)
+    now = failure.retryAt
+    attempts += 1
+  }
+  assert.ok(attempts > 10, 'the simulation must exceed any small fixed retry count')
+  assert.equal(failure?.attempt, attempts)
+})
+
+test('the third consecutive identical stack trips the deterministic fuse with separate fingerprints', () => {
+  const stackA = 'Error: invariant broke\n at reconcile (auto-run.ts:10:2)'
+  const stackB = 'Error: another fault\n at reconcile (auto-run.ts:11:2)'
+  const first = nextControllerFailure(null, { name: 'Error', message: 'invariant broke', stack: stackA }, 0, 0)
+  const second = nextControllerFailure(first, { name: 'Error', message: 'invariant broke', stack: stackA }, 5_000, 0)
+  const different = nextControllerFailure(second, { name: 'Error', message: 'another fault', stack: stackB }, 10_000, 0)
+  const restarted = nextControllerFailure(
+    different,
+    { name: 'Error', message: 'invariant broke', stack: stackA },
+    15_000,
+    0,
+  )
+  const twice = nextControllerFailure(
+    restarted,
+    { name: 'Error', message: 'invariant broke', stack: stackA },
+    20_000,
+    0,
+  )
+  const fused = nextControllerFailure(twice, { name: 'Error', message: 'invariant broke', stack: stackA }, 25_000, 0)
+
+  assert.equal(first.consecutive, 1)
+  assert.equal(second.consecutive, 2)
+  assert.notEqual(different.fingerprint, first.fingerprint)
+  assert.equal(different.consecutive, 1)
+  assert.equal(restarted.consecutive, 1, 'a different stack must break the consecutive streak')
+  assert.equal(fused.consecutive, 3)
+  assert.equal(fused.fused, true)
+  assert.equal(fused.stack, stackA)
+})
+
+test('watchdog only reattaches controller-error and never crosses budget or ownership gates', () => {
+  const now = Date.parse('2026-08-25T01:00:00.000Z')
+  const ready = autoRun({
+    controllerRecovery: {
+      kind: 'fused',
+      attempt: 3,
+      consecutive: 3,
+      fingerprint: 'same-stack',
+      retryAt: new Date(now - 1).toISOString(),
+      lastFailureAt: new Date(now - 300_000).toISOString(),
+    },
+  })
+  assert.deepEqual(decideAutoRunWatchdog(ready, [], 'none', now), { kind: 'reattach' })
+  assert.deepEqual(decideAutoRunWatchdog(ready, [], 'running', now), { kind: 'reattach' })
+  assert.equal(decideAutoRunWatchdog(ready, [], 'unknown', now).kind, 'wait')
+  assert.deepEqual(decideAutoRunWatchdog(ready, [], 'interrupted', now), { kind: 'session-interrupted' })
+  assert.deepEqual(decideAutoRunWatchdog(autoRun({ pausedReason: 'session-interrupted' }), [], 'none', now), {
+    kind: 'none',
+  })
+  assert.deepEqual(decideAutoRunWatchdog(ready, [], 'none', Date.parse(ready.deadline)), { kind: 'budget-exhausted' })
+})
+
+test('watchdog hourly limit delays instead of permanently abandoning the run', () => {
+  const now = Date.parse('2026-08-25T01:00:00.000Z')
+  const events: WorkflowEvent[] = Array.from({ length: AUTO_RUN_WATCHDOG_LIMIT }, (_, index) => ({
+    kind: 'auto-run',
+    at: new Date(now - 30 * 60_000 + index).toISOString(),
+    note: AUTO_RUN_WATCHDOG_NOTE,
+  }))
+  const decision = decideAutoRunWatchdog(autoRun(), events, 'none', now)
+  assert.equal(decision.kind, 'wait')
+  if (decision.kind !== 'wait') return
+  assert.equal(decision.reason, 'hourly-limit')
+  assert.equal(decision.retryAt, Date.parse(events[0].at) + 60 * 60_000)
+})

--- a/tests/auto-run-recovery.test.ts
+++ b/tests/auto-run-recovery.test.ts
@@ -3,92 +3,113 @@ import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
-import { type IssueWorkflow, issueKey, loadWorkflow } from '../src/infra/state.ts'
-import { requestAutoRunReconcile } from '../src/workflow/auto-run.ts'
+import { GithubRateLimitError } from '../src/github/rest.ts'
+import { type IssueWorkflow, issueKey, loadWorkflow, workflowRevision } from '../src/infra/state.ts'
+import { AUTO_RUN_WATCHDOG_NOTE } from '../src/workflow/auto-run-recovery-policy.ts'
+import {
+  autoRunWakePending,
+  clearAutoRunTimers,
+  handleAutoRunControllerFailure,
+  maintainPausedAutoRun,
+} from '../src/workflow/auto-run-recovery.ts'
 import { commitWorkflowFixture } from './workflow-fixture.ts'
 
-test('a reconcile exception is preserved as controller-error, never session-interrupted', async () => {
-  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-reconcile-'))
+function workflow(tempHome: string, number: string, overrides: Partial<IssueWorkflow> = {}): IssueWorkflow {
+  const key = issueKey('owner/repo', number)
+  return {
+    key,
+    url: `https://github.com/owner/repo/issues/${number}`,
+    repoKey: 'owner/repo',
+    worktree: tempHome,
+    branch: `clickvibe-issue-${number}`,
+    stage: 'idle',
+    devAgent: null,
+    devTaskId: null,
+    devHostJobId: null,
+    devSessionId: null,
+    devSessionAgent: null,
+    devInterrupted: false,
+    reviewAgent: null,
+    reviewTaskId: null,
+    reviewHostJobId: null,
+    reviewSessionId: null,
+    reviewSessionAgent: null,
+    reviewResult: null,
+    prNumber: null,
+    issueState: 'OPEN',
+    baseRef: 'origin/main @ b9c6dea',
+    autoRun: {
+      status: 'running',
+      autoMerge: false,
+      devAgent: 'codex',
+      reviewAgent: 'codex',
+      maxRounds: 20,
+      budgetHours: 24,
+      startedAt: new Date().toISOString(),
+      deadline: new Date(Date.now() + 60_000).toISOString(),
+      step: 1,
+      rounds: 0,
+      unresolved: [],
+      lastObservedAt: null,
+      pausedReason: null,
+    },
+    updatedAt: Date.now(),
+    events: [],
+    ...overrides,
+  }
+}
+
+async function pollWorkflow(key: string, ready: (value: IssueWorkflow) => boolean): Promise<IssueWorkflow> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const value = await loadWorkflow(key)
+    if (value && ready(value)) return value
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  const value = await loadWorkflow(key)
+  assert.fail(`workflow did not reach expected state: ${JSON.stringify(value?.autoRun)}`)
+}
+
+async function diagnosticRecords(tempHome: string, number: string): Promise<Record<string, unknown>[]> {
+  const path = join(tempHome, '.clickvibe', 'state', 'owner', 'repo', `issue-${number}`, 'diagnostics.jsonl')
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const content = await readFile(path, 'utf8').catch(() => '')
+    if (content.trim()) return content.trim().split('\n').map(JSON.parse)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  return []
+}
+
+const idleContext = { jobs: { list: () => [], get: () => assert.fail('no task expected') } }
+const noWake = () => {}
+
+test('one infrastructure failure stays running and records an unlimited retry checkpoint', async () => {
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-reconcile-retry-'))
   const previousHome = process.env.HOME
   process.env.HOME = tempHome
   try {
-    const key = issueKey('owner/repo', '111')
-    const workflow: IssueWorkflow = {
-      key,
-      url: 'https://github.com/owner/repo/issues/111',
-      repoKey: 'owner/repo',
-      worktree: tempHome,
-      branch: 'clickvibe-issue-111',
-      stage: 'developing',
-      devAgent: null,
-      devTaskId: 'dev-task-111',
-      devHostJobId: 'clickvibe-111',
-      devSessionId: null,
-      devSessionAgent: null,
-      devInterrupted: false,
-      reviewAgent: null,
-      reviewTaskId: null,
-      reviewSessionId: null,
-      reviewSessionAgent: null,
-      reviewResult: null,
-      prNumber: null,
-      issueState: 'OPEN',
-      baseRef: 'origin/main @ 82e55b2',
-      autoRun: {
-        status: 'running',
-        autoMerge: false,
-        devAgent: 'codex',
-        reviewAgent: 'codex',
-        maxRounds: 20,
-        budgetHours: 24,
-        startedAt: '2026-08-24T00:00:00Z',
-        deadline: '2026-08-25T00:00:00Z',
-        step: 1,
-        rounds: 0,
-        unresolved: [],
-        lastObservedAt: null,
-        pausedReason: null,
-      },
-      updatedAt: Date.now(),
-      events: [],
-    }
-    await commitWorkflowFixture(workflow, workflow.revision ?? null)
-    const ctx = Object.defineProperty({}, 'jobs', {
-      get() {
-        throw new Error('forced reconcile failure')
-      },
-    })
-    requestAutoRunReconcile(ctx as never, key)
+    const current = workflow(tempHome, '1201')
+    await commitWorkflowFixture(current, current.revision ?? null)
+    await handleAutoRunControllerFailure(
+      idleContext as never,
+      current.key,
+      new Error('forced reconcile failure'),
+      'reconcile',
+      noWake,
+    )
 
-    let observed: IssueWorkflow | null = null
-    for (let attempt = 0; attempt < 50; attempt += 1) {
-      observed = await loadWorkflow(key)
-      if (observed?.autoRun?.status === 'paused') break
-      await new Promise((resolve) => setTimeout(resolve, 10))
-    }
-    assert.equal(observed?.autoRun?.status, 'paused')
-    assert.equal(observed?.autoRun?.pausedReason, 'controller-error')
-    assert.match(observed?.events.at(-1)?.note ?? '', /controller-error/)
-    // 证据必须落盘:暂停原因之外,原始错误文本要写进本地事件(#90 事故:两次
-    // controller-error 暂停均无法追溯,console 诊断几分钟内被滚动缓冲冲掉)。
-    assert.match(observed?.events.at(-1)?.note ?? '', /forced reconcile failure/)
-    const diagnosticPath = join(tempHome, '.clickvibe', 'state', 'owner', 'repo', 'issue-111', 'diagnostics.jsonl')
-    let diagnostics = ''
-    for (let attempt = 0; attempt < 50; attempt += 1) {
-      diagnostics = await readFile(diagnosticPath, 'utf8').catch(() => '')
-      if (diagnostics.includes('auto-run-reconcile-error')) break
-      await new Promise((resolve) => setTimeout(resolve, 10))
-    }
-    assert.notEqual(diagnostics, '')
-    const reconcileError = diagnostics
-      .trim()
-      .split('\n')
-      .map((line) => JSON.parse(line))
-      .find((record) => record.event === 'auto-run-reconcile-error')
-    assert.equal(reconcileError.errorName, 'Error')
-    assert.equal(reconcileError.errorMessage, 'forced reconcile failure')
-    assert.match(reconcileError.errorStack, /forced reconcile failure/)
-    assert.equal(reconcileError.workflowKey, key)
+    const observed = await pollWorkflow(current.key, (value) => (value.autoRun?.controllerRecovery?.attempt ?? 0) >= 1)
+    assert.equal(observed.autoRun?.status, 'running')
+    assert.equal(observed.autoRun?.pausedReason, null)
+    assert.equal(observed.autoRun?.controllerRecovery?.kind, 'transient')
+    const records = await diagnosticRecords(tempHome, '1201')
+    const retry = records.find((record) => record.event === 'auto-run-controller-retry')
+    assert.equal(retry?.errorName, 'Error')
+    assert.equal(retry?.errorMessage, 'forced reconcile failure')
+    assert.match(String(retry?.errorStack), /forced reconcile failure/)
+    assert.equal(retry?.attempt, 1)
+    assert.equal(retry?.consecutive, 1)
+    assert.equal(typeof retry?.fingerprint, 'string')
+    assert.equal(typeof retry?.retryAt, 'string')
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
@@ -96,88 +117,245 @@ test('a reconcile exception is preserved as controller-error, never session-inte
   }
 })
 
-// ---- #120 切片②:限流按 reset 自动重试,不再暂停(GitHub 二级限流 +10min 签名) ----
+test('the third identical controller stack fuses with complete durable evidence', async () => {
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-reconcile-fuse-'))
+  const previousHome = process.env.HOME
+  process.env.HOME = tempHome
+  try {
+    const current = workflow(tempHome, '1202')
+    await commitWorkflowFixture(current, current.revision ?? null)
+    const error = new Error('deterministic reconcile failure')
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      await handleAutoRunControllerFailure(idleContext as never, current.key, error, 'reconcile', noWake)
+      await pollWorkflow(current.key, (value) =>
+        attempt < 3 ? (value.autoRun?.controllerRecovery?.attempt ?? 0) >= attempt : value.autoRun?.status === 'paused',
+      )
+    }
+    const observed = await loadWorkflow(current.key)
+    assert.equal(observed?.autoRun?.status, 'paused')
+    assert.equal(observed?.autoRun?.pausedReason, 'controller-error')
+    assert.equal(observed?.autoRun?.controllerRecovery?.kind, 'fused')
+    assert.match(observed?.events.at(-1)?.note ?? '', /连续 3 次.*fingerprint/)
+    const records = await diagnosticRecords(tempHome, '1202')
+    const fuse = records.find((record) => record.event === 'auto-run-controller-fuse')
+    assert.equal(fuse?.consecutive, 3)
+    assert.match(String(fuse?.errorStack), /deterministic reconcile failure/)
+    assert.equal(typeof fuse?.fingerprint, 'string')
+    assert.match(String(fuse?.basis), /same-stack.*3/)
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
+})
 
-test('a rate-limit reconcile failure defers to the reset time instead of pausing', async () => {
-  const { GithubRateLimitError } = await import('../src/github/rest.ts')
+test('watchdog reattaches only paused controller-error after cooldown and records the event', async () => {
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-watchdog-'))
+  const previousHome = process.env.HOME
+  process.env.HOME = tempHome
+  try {
+    const current = workflow(tempHome, '1203')
+    current.autoRun = {
+      ...current.autoRun!,
+      status: 'paused',
+      pausedReason: 'controller-error',
+      lastObservedAt: new Date(Date.now() - 600_000).toISOString(),
+      controllerRecovery: {
+        kind: 'fused',
+        attempt: 3,
+        consecutive: 3,
+        fingerprint: 'fused-stack',
+        retryAt: new Date(Date.now() - 1).toISOString(),
+        lastFailureAt: new Date(Date.now() - 600_000).toISOString(),
+      },
+    }
+    await commitWorkflowFixture(current, current.revision ?? null)
+    await maintainPausedAutoRun(idleContext as never, current.key, noWake)
+    const observed = await pollWorkflow(current.key, (value) =>
+      value.events.some((event) => event.note === AUTO_RUN_WATCHDOG_NOTE),
+    )
+    assert.equal(observed.autoRun?.status, 'running')
+    assert.equal(observed.autoRun?.pausedReason, null)
+    assert.equal(observed.events.filter((event) => event.note === AUTO_RUN_WATCHDOG_NOTE).length, 1)
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
+})
+
+test('a controller failure cannot pause or interfere with a host-confirmed running task', async () => {
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-running-task-'))
+  const previousHome = process.env.HOME
+  process.env.HOME = tempHome
+  try {
+    const current = workflow(tempHome, '1204', {
+      stage: 'developing',
+      devTaskId: 'dev-running-1204',
+      devHostJobId: 'host-running-1204',
+    })
+    await commitWorkflowFixture(current, current.revision ?? null)
+    const ctx = {
+      jobs: {
+        list: () => [
+          {
+            id: 'host-running-1204',
+            kind: 'clickvibe',
+            label: `clickvibe:${current.key}:dev:dev-running-1204`,
+            status: 'running',
+            startedAt: Date.now(),
+          },
+        ],
+        get: () => assert.fail('list owns the task evidence'),
+      },
+    }
+    const failure = new Error('controller failed while task runs')
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await handleAutoRunControllerFailure(ctx as never, current.key, failure, 'reconcile', noWake)
+    }
+    const records = await diagnosticRecords(tempHome, '1204')
+    assert.ok(records.some((record) => record.event === 'auto-run-controller-retry'))
+    const observed = await loadWorkflow(current.key)
+    assert.equal(observed?.autoRun?.status, 'running')
+    assert.equal(observed?.autoRun?.pausedReason, null)
+    assert.ok(!observed?.events.some((event) => event.note?.includes('已暂停')))
+
+    // Running/unknown observations are streak barriers: after the task settles,
+    // the same stack starts at one instead of carrying a delayed fuse into idle.
+    observed!.stage = 'idle'
+    observed!.devTaskId = null
+    observed!.devHostJobId = null
+    await commitWorkflowFixture(observed!, workflowRevision(observed!))
+    await handleAutoRunControllerFailure(idleContext as never, current.key, failure, 'reconcile', noWake)
+    const afterSettlement = await loadWorkflow(current.key)
+    assert.equal(afterSettlement?.autoRun?.status, 'running')
+    assert.equal(afterSettlement?.autoRun?.controllerRecovery?.consecutive, 1)
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
+})
+
+test('a rate-limit failure defers to reset instead of entering the ordinary fuse', async () => {
   const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-ratelimit-'))
   const previousHome = process.env.HOME
   process.env.HOME = tempHome
-  let failure: Error = new GithubRateLimitError(Date.now() + 300)
   try {
-    const key = issueKey('owner/repo', '120')
-    const workflow: IssueWorkflow = {
-      key,
-      url: 'https://github.com/owner/repo/issues/120',
-      repoKey: 'owner/repo',
-      worktree: tempHome,
-      branch: 'clickvibe-issue-120',
-      stage: 'developing',
-      devAgent: null,
-      devTaskId: 'dev-task-120',
-      devHostJobId: 'clickvibe-120',
-      devSessionId: null,
-      devSessionAgent: null,
-      devInterrupted: false,
-      reviewAgent: null,
-      reviewTaskId: null,
-      reviewSessionId: null,
-      reviewSessionAgent: null,
-      reviewResult: null,
-      prNumber: null,
-      issueState: 'OPEN',
-      baseRef: 'origin/main @ 82e55b2',
-      autoRun: {
-        status: 'running',
-        autoMerge: false,
-        devAgent: 'codex',
-        reviewAgent: 'codex',
-        maxRounds: 20,
-        budgetHours: 24,
-        startedAt: '2026-08-25T00:00:00Z',
-        deadline: '2026-08-26T00:00:00Z',
-        step: 1,
-        rounds: 0,
-        unresolved: [],
-        lastObservedAt: null,
-        pausedReason: null,
-      },
-      updatedAt: Date.now(),
-      events: [],
-    }
-    await commitWorkflowFixture(workflow, workflow.revision ?? null)
-    const ctx = Object.defineProperty({}, 'jobs', {
-      get() {
-        throw failure
-      },
-    })
-    requestAutoRunReconcile(ctx as never, key)
-
-    let observed: IssueWorkflow | null = null
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      observed = await loadWorkflow(key)
-      if (observed?.events.some((event) => (event.note ?? '').includes('限流'))) break
-      await new Promise((resolve) => setTimeout(resolve, 20))
-    }
-    // 限流不暂停:autoRun 保持 running,事件流写明等待与自动重试
-    assert.equal(observed?.autoRun?.status, 'running', 'rate-limit must not pause the auto-run')
-    assert.match(
-      observed?.events.at(-1)?.note ?? '',
-      /限流.*自动(等待|重试)/,
-      'the durable event must explain the deferral',
+    const current = workflow(tempHome, '1205')
+    await commitWorkflowFixture(current, current.revision ?? null)
+    const failure = new GithubRateLimitError(Date.now() + 60_000, 'secondary')
+    await handleAutoRunControllerFailure(idleContext as never, current.key, failure, 'reconcile', noWake)
+    const observed = await pollWorkflow(
+      current.key,
+      (value) => value.autoRun?.controllerRecovery?.kind === 'rate-limit',
     )
-
-    // reset 过后的重试若遇到普通故障,仍按 controller-error 暂停(证据保留)
-    failure = new Error('post-reset real failure')
-    await new Promise((resolve) => setTimeout(resolve, 3_000))
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      observed = await loadWorkflow(key)
-      if (observed?.autoRun?.status === 'paused') break
-      await new Promise((resolve) => setTimeout(resolve, 20))
-    }
-    assert.equal(observed?.autoRun?.pausedReason, 'controller-error')
-    assert.match(observed?.events.at(-1)?.note ?? '', /post-reset real failure/)
+    assert.equal(observed.autoRun?.status, 'running')
+    assert.match(observed.events.at(-1)?.note ?? '', /限流.*自动等待/)
   } finally {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
+})
+
+test('watchdog and retry never revive a controller-error pause after the original deadline', async () => {
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-watchdog-budget-'))
+  const previousHome = process.env.HOME
+  process.env.HOME = tempHome
+  try {
+    const current = workflow(tempHome, '1206')
+    current.autoRun = {
+      ...current.autoRun!,
+      status: 'paused',
+      pausedReason: 'controller-error',
+      deadline: new Date(Date.now() - 1).toISOString(),
+      controllerRecovery: {
+        kind: 'fused',
+        attempt: 3,
+        consecutive: 3,
+        fingerprint: 'expired',
+        retryAt: new Date(Date.now() - 1).toISOString(),
+        lastFailureAt: new Date(Date.now() - 10_000).toISOString(),
+      },
+    }
+    await commitWorkflowFixture(current, current.revision ?? null)
+    await maintainPausedAutoRun(idleContext as never, current.key, noWake)
+    const observed = await pollWorkflow(current.key, (value) => value.autoRun?.pausedReason === 'budget-exhausted')
+    assert.equal(observed.autoRun?.status, 'paused')
+    assert.ok(!observed.events.some((event) => event.note === AUTO_RUN_WATCHDOG_NOTE))
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
+})
+
+test('budget exhaustion stops a host-confirmed task before persisting the semantic pause', async () => {
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-budget-stop-'))
+  const previousHome = process.env.HOME
+  process.env.HOME = tempHome
+  const killed: string[] = []
+  try {
+    const current = workflow(tempHome, '1207', {
+      stage: 'developing',
+      devTaskId: 'dev-budget-1207',
+      devHostJobId: 'host-budget-1207',
+    })
+    current.autoRun!.deadline = new Date(Date.now() - 1).toISOString()
+    await commitWorkflowFixture(current, current.revision ?? null)
+    const job = {
+      id: 'host-budget-1207',
+      kind: 'clickvibe',
+      label: `clickvibe:${current.key}:dev:dev-budget-1207`,
+      status: 'running' as const,
+      startedAt: Date.now(),
+    }
+    const ctx = {
+      jobs: {
+        list: () => [job],
+        get: () => job,
+        kill(id: string) {
+          killed.push(id)
+          return 'requested'
+        },
+      },
+    }
+    await handleAutoRunControllerFailure(
+      ctx as never,
+      current.key,
+      new Error('late controller tick'),
+      'reconcile',
+      noWake,
+    )
+    const observed = await loadWorkflow(current.key)
+    assert.equal(observed?.autoRun?.pausedReason, 'budget-exhausted')
+    assert.deepEqual(killed, ['host-budget-1207'])
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  }
+})
+
+test('temporarily unavailable workflow storage keeps a wake armed instead of abandoning recovery', async () => {
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-state-unavailable-'))
+  const previousHome = process.env.HOME
+  process.env.HOME = tempHome
+  const key = issueKey('owner/repo', '1208')
+  try {
+    await handleAutoRunControllerFailure(
+      idleContext as never,
+      key,
+      new Error('filesystem unavailable'),
+      'reconcile',
+      noWake,
+    )
+    assert.equal(autoRunWakePending(key), true)
+    const records = await diagnosticRecords(tempHome, '1208')
+    assert.ok(records.some((record) => record.event === 'auto-run-state-unavailable'))
+  } finally {
+    clearAutoRunTimers(key)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })

--- a/tests/auto-run-recovery.test.ts
+++ b/tests/auto-run-recovery.test.ts
@@ -11,54 +11,10 @@ import {
   clearAutoRunTimers,
   handleAutoRunControllerFailure,
   maintainPausedAutoRun,
+  pauseAutoRun,
 } from '../src/workflow/auto-run-recovery.ts'
 import { requestAutoRunReconcile } from '../src/workflow/auto-run.ts'
-import { commitWorkflowFixture } from './workflow-fixture.ts'
-
-function workflow(tempHome: string, number: string, overrides: Partial<IssueWorkflow> = {}): IssueWorkflow {
-  const key = issueKey('owner/repo', number)
-  return {
-    key,
-    url: `https://github.com/owner/repo/issues/${number}`,
-    repoKey: 'owner/repo',
-    worktree: tempHome,
-    branch: `clickvibe-issue-${number}`,
-    stage: 'idle',
-    devAgent: null,
-    devTaskId: null,
-    devHostJobId: null,
-    devSessionId: null,
-    devSessionAgent: null,
-    devInterrupted: false,
-    reviewAgent: null,
-    reviewTaskId: null,
-    reviewHostJobId: null,
-    reviewSessionId: null,
-    reviewSessionAgent: null,
-    reviewResult: null,
-    prNumber: null,
-    issueState: 'OPEN',
-    baseRef: 'origin/main @ b9c6dea',
-    autoRun: {
-      status: 'running',
-      autoMerge: false,
-      devAgent: 'codex',
-      reviewAgent: 'codex',
-      maxRounds: 20,
-      budgetHours: 24,
-      startedAt: new Date().toISOString(),
-      deadline: new Date(Date.now() + 60_000).toISOString(),
-      step: 1,
-      rounds: 0,
-      unresolved: [],
-      lastObservedAt: null,
-      pausedReason: null,
-    },
-    updatedAt: Date.now(),
-    events: [],
-    ...overrides,
-  }
-}
+import { autoRunWorkflowFixture as workflow, commitWorkflowFixture } from './workflow-fixture.ts'
 
 async function pollWorkflow(key: string, ready: (value: IssueWorkflow) => boolean): Promise<IssueWorkflow> {
   for (let attempt = 0; attempt < 200; attempt += 1) {
@@ -82,318 +38,268 @@ async function diagnosticRecords(tempHome: string, number: string): Promise<Reco
 
 const idleContext = { jobs: { list: () => [], get: () => assert.fail('no task expected') } }
 const noWake = () => {}
+let tempHome: string
+let previousHome: string | undefined
+
+test.before(async () => {
+  tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-auto-run-recovery-'))
+  previousHome = process.env.HOME
+  process.env.HOME = tempHome
+})
+
+test.after(async () => {
+  for (const number of ['1201', '1202', '1203', '1204', '1205', '1206', '1207', '1208', '1209', '122']) {
+    clearAutoRunTimers(issueKey('owner/repo', number))
+  }
+  if (previousHome === undefined) delete process.env.HOME
+  else process.env.HOME = previousHome
+  await rm(tempHome, { recursive: true, force: true })
+})
+
+function failingReconcileContext(error: Error) {
+  return {
+    jobs: { list: () => [], get: () => assert.fail('no task expected') },
+    shell: {
+      resolve: (spec: unknown) => spec,
+      async run(): Promise<never> {
+        throw error
+      },
+    },
+  }
+}
 
 test('one infrastructure failure stays running and records an unlimited retry checkpoint', async () => {
-  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-reconcile-retry-'))
-  const previousHome = process.env.HOME
-  process.env.HOME = tempHome
-  try {
-    const current = workflow(tempHome, '1201')
-    await commitWorkflowFixture(current, current.revision ?? null)
-    await handleAutoRunControllerFailure(
-      idleContext as never,
-      current.key,
-      new Error('forced reconcile failure'),
-      'reconcile',
-      noWake,
-    )
+  const current = workflow(tempHome, '1201')
+  await commitWorkflowFixture(current, current.revision ?? null)
+  await handleAutoRunControllerFailure(
+    idleContext as never,
+    current.key,
+    new Error('forced reconcile failure'),
+    'reconcile',
+    noWake,
+  )
 
-    const observed = await pollWorkflow(current.key, (value) => (value.autoRun?.controllerRecovery?.attempt ?? 0) >= 1)
-    assert.equal(observed.autoRun?.status, 'running')
-    assert.equal(observed.autoRun?.pausedReason, null)
-    assert.equal(observed.autoRun?.controllerRecovery?.kind, 'transient')
-    const records = await diagnosticRecords(tempHome, '1201')
-    const retry = records.find((record) => record.event === 'auto-run-controller-retry')
-    assert.equal(retry?.errorName, 'Error')
-    assert.equal(retry?.errorMessage, 'forced reconcile failure')
-    assert.match(String(retry?.errorStack), /forced reconcile failure/)
-    assert.equal(retry?.attempt, 1)
-    assert.equal(retry?.consecutive, 1)
-    assert.equal(typeof retry?.fingerprint, 'string')
-    assert.equal(typeof retry?.retryAt, 'string')
-  } finally {
-    if (previousHome === undefined) delete process.env.HOME
-    else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
-  }
+  const observed = await pollWorkflow(current.key, (value) => (value.autoRun?.controllerRecovery?.attempt ?? 0) >= 1)
+  assert.equal(observed.autoRun?.status, 'running')
+  assert.equal(observed.autoRun?.pausedReason, null)
+  assert.equal(observed.autoRun?.controllerRecovery?.kind, 'transient')
+  const records = await diagnosticRecords(tempHome, '1201')
+  const retry = records.find((record) => record.event === 'auto-run-controller-retry')
+  assert.equal(retry?.errorName, 'Error')
+  assert.equal(retry?.errorMessage, 'forced reconcile failure')
+  assert.match(String(retry?.errorStack), /forced reconcile failure/)
+  assert.equal(retry?.attempt, 1)
+  assert.equal(retry?.consecutive, 1)
+  assert.equal(typeof retry?.fingerprint, 'string')
+  assert.equal(typeof retry?.retryAt, 'string')
 })
 
-test('the third identical controller stack fuses with complete durable evidence', async () => {
-  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-reconcile-fuse-'))
-  const previousHome = process.env.HOME
-  process.env.HOME = tempHome
-  try {
-    const current = workflow(tempHome, '1202')
-    await commitWorkflowFixture(current, current.revision ?? null)
-    const error = new Error('deterministic reconcile failure')
-    for (let attempt = 1; attempt <= 3; attempt += 1) {
-      await handleAutoRunControllerFailure(idleContext as never, current.key, error, 'reconcile', noWake)
-      await pollWorkflow(current.key, (value) =>
-        attempt < 3 ? (value.autoRun?.controllerRecovery?.attempt ?? 0) >= attempt : value.autoRun?.status === 'paused',
-      )
-    }
-    const observed = await loadWorkflow(current.key)
-    assert.equal(observed?.autoRun?.status, 'paused')
-    assert.equal(observed?.autoRun?.pausedReason, 'controller-error')
-    assert.equal(observed?.autoRun?.controllerRecovery?.kind, 'fused')
-    assert.match(observed?.events.at(-1)?.note ?? '', /连续 3 次.*fingerprint/)
-    const records = await diagnosticRecords(tempHome, '1202')
-    const fuse = records.find((record) => record.event === 'auto-run-controller-fuse')
-    assert.equal(fuse?.consecutive, 3)
-    assert.match(String(fuse?.errorStack), /deterministic reconcile failure/)
-    assert.equal(typeof fuse?.fingerprint, 'string')
-    assert.match(String(fuse?.basis), /same-stack.*3/)
-  } finally {
-    if (previousHome === undefined) delete process.env.HOME
-    else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+test('the reconcile queue fuses three identical stacks and coalesces watchdog signals', async () => {
+  const current = workflow(tempHome, '1202')
+  await commitWorkflowFixture(current, current.revision ?? null)
+  const ctx = failingReconcileContext(new Error('deterministic reconcile failure'))
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    requestAutoRunReconcile(ctx as never, current.key)
+    await pollWorkflow(current.key, (value) =>
+      attempt < 3 ? (value.autoRun?.controllerRecovery?.attempt ?? 0) >= attempt : value.autoRun?.status === 'paused',
+    )
   }
+  const observed = await loadWorkflow(current.key)
+  assert.equal(observed?.autoRun?.pausedReason, 'controller-error')
+  assert.equal(observed?.autoRun?.controllerRecovery?.kind, 'fused')
+  assert.match(observed?.events.at(-1)?.note ?? '', /连续 3 次.*fingerprint/)
+  const fuse = (await diagnosticRecords(tempHome, '1202')).find((record) => record.event === 'auto-run-controller-fuse')
+  assert.equal(fuse?.consecutive, 3)
+  assert.match(String(fuse?.errorStack), /缺少与该 OPEN Issue 绑定的服务端确认快照/)
+  assert.equal(typeof fuse?.fingerprint, 'string')
+  assert.match(String(fuse?.basis), /same-stack.*3/)
+
+  observed!.autoRun!.lastObservedAt = new Date(Date.now() - 600_000).toISOString()
+  observed!.autoRun!.controllerRecovery!.retryAt = new Date(Date.now() - 1).toISOString()
+  await commitWorkflowFixture(observed!, workflowRevision(observed!))
+  for (let signal = 0; signal < 5; signal += 1) requestAutoRunReconcile(ctx as never, current.key)
+  const reattached = await pollWorkflow(
+    current.key,
+    (value) => value.autoRun?.status === 'running' && value.autoRun.controllerRecovery?.kind === 'transient',
+  )
+  assert.equal(reattached.events.filter((event) => event.note === AUTO_RUN_WATCHDOG_NOTE).length, 1)
 })
 
-test('watchdog reattaches only paused controller-error after cooldown and records the event', async () => {
-  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-watchdog-'))
-  const previousHome = process.env.HOME
-  process.env.HOME = tempHome
-  try {
-    const current = workflow(tempHome, '1203')
-    current.autoRun = {
-      ...current.autoRun!,
-      status: 'paused',
-      pausedReason: 'controller-error',
-      lastObservedAt: new Date(Date.now() - 600_000).toISOString(),
-      controllerRecovery: {
-        kind: 'fused',
-        attempt: 3,
-        consecutive: 3,
-        fingerprint: 'fused-stack',
-        retryAt: new Date(Date.now() - 1).toISOString(),
-        lastFailureAt: new Date(Date.now() - 600_000).toISOString(),
-      },
-    }
-    await commitWorkflowFixture(current, current.revision ?? null)
-    await maintainPausedAutoRun(idleContext as never, current.key, noWake)
-    const observed = await pollWorkflow(current.key, (value) =>
-      value.events.some((event) => event.note === AUTO_RUN_WATCHDOG_NOTE),
-    )
-    assert.equal(observed.autoRun?.status, 'running')
-    assert.equal(observed.autoRun?.pausedReason, null)
-    assert.equal(observed.events.filter((event) => event.note === AUTO_RUN_WATCHDOG_NOTE).length, 1)
-  } finally {
-    if (previousHome === undefined) delete process.env.HOME
-    else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+test('the queue reattaches controller-error and same-round failure remains transient', async () => {
+  const current = workflow(tempHome, '1203')
+  current.autoRun = {
+    ...current.autoRun!,
+    status: 'paused',
+    pausedReason: 'controller-error',
+    lastObservedAt: new Date(Date.now() - 600_000).toISOString(),
+    controllerRecovery: {
+      kind: 'fused',
+      attempt: 3,
+      consecutive: 3,
+      fingerprint: 'fused-stack',
+      retryAt: new Date(Date.now() - 1).toISOString(),
+      lastFailureAt: new Date(Date.now() - 600_000).toISOString(),
+    },
   }
+  await commitWorkflowFixture(current, current.revision ?? null)
+  requestAutoRunReconcile(failingReconcileContext(new Error('failure after watchdog')) as never, current.key)
+  const observed = await pollWorkflow(
+    current.key,
+    (value) => value.autoRun?.status === 'running' && value.autoRun.controllerRecovery?.kind === 'transient',
+  )
+  assert.equal(observed.autoRun?.pausedReason, null)
+  assert.equal(observed.events.filter((event) => event.note === AUTO_RUN_WATCHDOG_NOTE).length, 1)
+})
+
+test('the queue and controller pause cannot downgrade a semantic interruption', async () => {
+  const current = workflow(tempHome, '1209')
+  current.autoRun = { ...current.autoRun!, status: 'paused', pausedReason: 'session-interrupted' }
+  await commitWorkflowFixture(current, current.revision ?? null)
+  requestAutoRunReconcile(failingReconcileContext(new Error('ignored controller failure')) as never, current.key)
+  await pauseAutoRun(current.key, 'controller-error', { error: 'must not replace semantics' })
+  await new Promise((resolve) => setTimeout(resolve, 50))
+  const observed = await loadWorkflow(current.key)
+  assert.equal(observed?.autoRun?.pausedReason, 'session-interrupted')
+  assert.ok(!observed?.events.some((event) => event.note === AUTO_RUN_WATCHDOG_NOTE))
 })
 
 test('a controller failure cannot pause or interfere with a host-confirmed running task', async () => {
-  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-running-task-'))
-  const previousHome = process.env.HOME
-  process.env.HOME = tempHome
-  try {
-    const current = workflow(tempHome, '1204', {
-      stage: 'developing',
-      devTaskId: 'dev-running-1204',
-      devHostJobId: 'host-running-1204',
-    })
-    await commitWorkflowFixture(current, current.revision ?? null)
-    const ctx = {
-      jobs: {
-        list: () => [
-          {
-            id: 'host-running-1204',
-            kind: 'clickvibe',
-            label: `clickvibe:${current.key}:dev:dev-running-1204`,
-            status: 'running',
-            startedAt: Date.now(),
-          },
-        ],
-        get: () => assert.fail('list owns the task evidence'),
-      },
-    }
-    const failure = new Error('controller failed while task runs')
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      await handleAutoRunControllerFailure(ctx as never, current.key, failure, 'reconcile', noWake)
-    }
-    const records = await diagnosticRecords(tempHome, '1204')
-    assert.ok(records.some((record) => record.event === 'auto-run-controller-retry'))
-    const observed = await loadWorkflow(current.key)
-    assert.equal(observed?.autoRun?.status, 'running')
-    assert.equal(observed?.autoRun?.pausedReason, null)
-    assert.ok(!observed?.events.some((event) => event.note?.includes('已暂停')))
-
-    // Running/unknown observations are streak barriers: after the task settles,
-    // the same stack starts at one instead of carrying a delayed fuse into idle.
-    observed!.stage = 'idle'
-    observed!.devTaskId = null
-    observed!.devHostJobId = null
-    await commitWorkflowFixture(observed!, workflowRevision(observed!))
-    await handleAutoRunControllerFailure(idleContext as never, current.key, failure, 'reconcile', noWake)
-    const afterSettlement = await loadWorkflow(current.key)
-    assert.equal(afterSettlement?.autoRun?.status, 'running')
-    assert.equal(afterSettlement?.autoRun?.controllerRecovery?.consecutive, 1)
-  } finally {
-    if (previousHome === undefined) delete process.env.HOME
-    else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+  const current = workflow(tempHome, '1204', {
+    stage: 'developing',
+    devTaskId: 'dev-running-1204',
+    devHostJobId: 'host-running-1204',
+  })
+  await commitWorkflowFixture(current, current.revision ?? null)
+  const ctx = {
+    jobs: {
+      list: () => [
+        {
+          id: 'host-running-1204',
+          kind: 'clickvibe',
+          label: `clickvibe:${current.key}:dev:dev-running-1204`,
+          status: 'running',
+          startedAt: Date.now(),
+        },
+      ],
+      get: () => assert.fail('list owns the task evidence'),
+    },
   }
+  const failure = new Error('controller failed while task runs')
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await handleAutoRunControllerFailure(ctx as never, current.key, failure, 'reconcile', noWake)
+  }
+  assert.ok((await diagnosticRecords(tempHome, '1204')).some((record) => record.event === 'auto-run-controller-retry'))
+  const observed = await loadWorkflow(current.key)
+  assert.equal(observed?.autoRun?.status, 'running')
+  assert.equal(observed?.autoRun?.pausedReason, null)
+  assert.ok(!observed?.events.some((event) => event.note?.includes('已暂停')))
+
+  observed!.stage = 'idle'
+  observed!.devTaskId = null
+  observed!.devHostJobId = null
+  await commitWorkflowFixture(observed!, workflowRevision(observed!))
+  await handleAutoRunControllerFailure(idleContext as never, current.key, failure, 'reconcile', noWake)
+  const afterSettlement = await loadWorkflow(current.key)
+  assert.equal(afterSettlement?.autoRun?.controllerRecovery?.consecutive, 1)
 })
 
 test('a rate-limit failure defers to reset instead of entering the ordinary fuse', async () => {
-  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-ratelimit-'))
-  const previousHome = process.env.HOME
-  process.env.HOME = tempHome
-  try {
-    const current = workflow(tempHome, '1205')
-    await commitWorkflowFixture(current, current.revision ?? null)
-    const failure = new GithubRateLimitError(Date.now() + 60_000, 'secondary')
-    await handleAutoRunControllerFailure(idleContext as never, current.key, failure, 'reconcile', noWake)
-    const observed = await pollWorkflow(
-      current.key,
-      (value) => value.autoRun?.controllerRecovery?.kind === 'rate-limit',
-    )
-    assert.equal(observed.autoRun?.status, 'running')
-    assert.match(observed.events.at(-1)?.note ?? '', /限流.*自动等待/)
-  } finally {
-    if (previousHome === undefined) delete process.env.HOME
-    else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
-  }
+  const current = workflow(tempHome, '1205')
+  await commitWorkflowFixture(current, current.revision ?? null)
+  const failure = new GithubRateLimitError(Date.now() + 60_000, 'secondary')
+  await handleAutoRunControllerFailure(idleContext as never, current.key, failure, 'reconcile', noWake)
+  const observed = await pollWorkflow(current.key, (value) => value.autoRun?.controllerRecovery?.kind === 'rate-limit')
+  assert.equal(observed.autoRun?.status, 'running')
+  assert.match(observed.events.at(-1)?.note ?? '', /限流.*自动等待/)
 })
 
 test('watchdog and retry never revive a controller-error pause after the original deadline', async () => {
-  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-watchdog-budget-'))
-  const previousHome = process.env.HOME
-  process.env.HOME = tempHome
-  try {
-    const current = workflow(tempHome, '1206')
-    current.autoRun = {
-      ...current.autoRun!,
-      status: 'paused',
-      pausedReason: 'controller-error',
-      deadline: new Date(Date.now() - 1).toISOString(),
-      controllerRecovery: {
-        kind: 'fused',
-        attempt: 3,
-        consecutive: 3,
-        fingerprint: 'expired',
-        retryAt: new Date(Date.now() - 1).toISOString(),
-        lastFailureAt: new Date(Date.now() - 10_000).toISOString(),
-      },
-    }
-    await commitWorkflowFixture(current, current.revision ?? null)
-    await maintainPausedAutoRun(idleContext as never, current.key, noWake)
-    const observed = await pollWorkflow(current.key, (value) => value.autoRun?.pausedReason === 'budget-exhausted')
-    assert.equal(observed.autoRun?.status, 'paused')
-    assert.ok(!observed.events.some((event) => event.note === AUTO_RUN_WATCHDOG_NOTE))
-  } finally {
-    if (previousHome === undefined) delete process.env.HOME
-    else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+  const current = workflow(tempHome, '1206')
+  current.autoRun = {
+    ...current.autoRun!,
+    status: 'paused',
+    pausedReason: 'controller-error',
+    deadline: new Date(Date.now() - 1).toISOString(),
+    controllerRecovery: {
+      kind: 'fused',
+      attempt: 3,
+      consecutive: 3,
+      fingerprint: 'expired',
+      retryAt: new Date(Date.now() - 1).toISOString(),
+      lastFailureAt: new Date(Date.now() - 10_000).toISOString(),
+    },
   }
+  await commitWorkflowFixture(current, current.revision ?? null)
+  await maintainPausedAutoRun(idleContext as never, current.key, noWake)
+  const observed = await pollWorkflow(current.key, (value) => value.autoRun?.pausedReason === 'budget-exhausted')
+  assert.ok(!observed.events.some((event) => event.note === AUTO_RUN_WATCHDOG_NOTE))
 })
 
 test('budget exhaustion stops a host-confirmed task before persisting the semantic pause', async () => {
-  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-budget-stop-'))
-  const previousHome = process.env.HOME
-  process.env.HOME = tempHome
   const killed: string[] = []
-  try {
-    const current = workflow(tempHome, '1207', {
-      stage: 'developing',
-      devTaskId: 'dev-budget-1207',
-      devHostJobId: 'host-budget-1207',
-    })
-    current.autoRun!.deadline = new Date(Date.now() - 1).toISOString()
-    await commitWorkflowFixture(current, current.revision ?? null)
-    const job = {
-      id: 'host-budget-1207',
-      kind: 'clickvibe',
-      label: `clickvibe:${current.key}:dev:dev-budget-1207`,
-      status: 'running' as const,
-      startedAt: Date.now(),
-    }
-    const ctx = {
-      jobs: {
-        list: () => [job],
-        get: () => job,
-        kill(id: string) {
-          killed.push(id)
-          return 'requested'
-        },
-      },
-    }
-    await handleAutoRunControllerFailure(
-      ctx as never,
-      current.key,
-      new Error('late controller tick'),
-      'reconcile',
-      noWake,
-    )
-    const observed = await loadWorkflow(current.key)
-    assert.equal(observed?.autoRun?.pausedReason, 'budget-exhausted')
-    assert.deepEqual(killed, ['host-budget-1207'])
-  } finally {
-    if (previousHome === undefined) delete process.env.HOME
-    else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+  const current = workflow(tempHome, '1207', {
+    stage: 'developing',
+    devTaskId: 'dev-budget-1207',
+    devHostJobId: 'host-budget-1207',
+  })
+  current.autoRun!.deadline = new Date(Date.now() - 1).toISOString()
+  await commitWorkflowFixture(current, current.revision ?? null)
+  const job = {
+    id: 'host-budget-1207',
+    kind: 'clickvibe',
+    label: `clickvibe:${current.key}:dev:dev-budget-1207`,
+    status: 'running' as const,
+    startedAt: Date.now(),
   }
+  const ctx = {
+    jobs: {
+      list: () => [job],
+      get: () => job,
+      kill(id: string) {
+        killed.push(id)
+        return 'requested'
+      },
+    },
+  }
+  await handleAutoRunControllerFailure(ctx as never, current.key, new Error('late tick'), 'reconcile', noWake)
+  assert.equal((await loadWorkflow(current.key))?.autoRun?.pausedReason, 'budget-exhausted')
+  assert.deepEqual(killed, ['host-budget-1207'])
 })
 
 test('temporarily unavailable workflow storage keeps a wake armed instead of abandoning recovery', async () => {
-  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-state-unavailable-'))
-  const previousHome = process.env.HOME
-  process.env.HOME = tempHome
   const key = issueKey('owner/repo', '1208')
-  try {
-    await handleAutoRunControllerFailure(
-      idleContext as never,
-      key,
-      new Error('filesystem unavailable'),
-      'reconcile',
-      noWake,
-    )
-    assert.equal(autoRunWakePending(key), true)
-    const records = await diagnosticRecords(tempHome, '1208')
-    assert.ok(records.some((record) => record.event === 'auto-run-state-unavailable'))
-  } finally {
-    clearAutoRunTimers(key)
-    if (previousHome === undefined) delete process.env.HOME
-    else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
-  }
+  await handleAutoRunControllerFailure(
+    idleContext as never,
+    key,
+    new Error('filesystem unavailable'),
+    'reconcile',
+    noWake,
+  )
+  assert.equal(autoRunWakePending(key), true)
+  assert.ok((await diagnosticRecords(tempHome, '1208')).some((record) => record.event === 'auto-run-state-unavailable'))
 })
 
 test('rapid rate-limit reconciles during one circuit window defer only once', async () => {
-  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-defer-dedupe-'))
-  const previousHome = process.env.HOME
-  process.env.HOME = tempHome
-  try {
-    const current = workflow(tempHome, '122', {
-      stage: 'developing',
-      devTaskId: 'dev-task-122',
-      devHostJobId: 'clickvibe-122',
-    })
-    await commitWorkflowFixture(current, current.revision ?? null)
-    const resetAt = Date.now() + 120_000 // 远离触发,只验证去抖
-    const ctx = Object.defineProperty({}, 'jobs', {
-      get() {
-        throw new GithubRateLimitError(resetAt)
-      },
-    })
-    // 模拟面板轮询:熔断窗口内连续 3 次 reconcile
-    requestAutoRunReconcile(ctx as never, current.key)
-    await new Promise((resolve) => setTimeout(resolve, 50))
-    requestAutoRunReconcile(ctx as never, current.key)
-    await new Promise((resolve) => setTimeout(resolve, 50))
-    requestAutoRunReconcile(ctx as never, current.key)
-    await new Promise((resolve) => setTimeout(resolve, 300))
-    const observed = await loadWorkflow(current.key)
-    const defers = (observed?.events ?? []).filter((event) => (event.note ?? '').includes('限流'))
-    assert.equal(defers.length, 1, `同一熔断窗口只应记录一次等待,实际 ${defers.length} 次`)
-    assert.equal(observed?.autoRun?.status, 'running')
-  } finally {
-    if (previousHome === undefined) delete process.env.HOME
-    else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
-  }
+  const current = workflow(tempHome, '122', {
+    stage: 'developing',
+    devTaskId: 'dev-task-122',
+    devHostJobId: 'clickvibe-122',
+  })
+  await commitWorkflowFixture(current, current.revision ?? null)
+  const resetAt = Date.now() + 120_000 // 远离触发,只验证去抖
+  const ctx = Object.defineProperty({}, 'jobs', {
+    get() {
+      throw new GithubRateLimitError(resetAt)
+    },
+  })
+  requestAutoRunReconcile(ctx as never, current.key)
+  await new Promise((resolve) => setTimeout(resolve, 50))
+  requestAutoRunReconcile(ctx as never, current.key)
+  await new Promise((resolve) => setTimeout(resolve, 50))
+  requestAutoRunReconcile(ctx as never, current.key)
+  await new Promise((resolve) => setTimeout(resolve, 300))
+  const observed = await loadWorkflow(current.key)
+  const defers = (observed?.events ?? []).filter((event) => (event.note ?? '').includes('限流'))
+  assert.equal(defers.length, 1, `同一熔断窗口只应记录一次等待,实际 ${defers.length} 次`)
+  assert.equal(observed?.autoRun?.status, 'running')
 })

--- a/tests/github-rest.test.ts
+++ b/tests/github-rest.test.ts
@@ -80,6 +80,62 @@ test('REST reader opens a circuit after rate limiting and reports the reset time
   assert.equal(fake.commands.length, 1)
 })
 
+test('an open secondary-rate circuit preserves retry-after classification on queued reads', async () => {
+  const fake = shellWith([
+    {
+      exitCode: 1,
+      stdout: [
+        'HTTP/2.0 403 Forbidden',
+        'retry-after: 60',
+        'x-ratelimit-remaining: 5000',
+        '',
+        JSON.stringify({ message: 'You have exceeded a secondary rate limit' }),
+      ].join('\n'),
+    },
+  ])
+  const reader = new GithubRestReader(fake as never)
+  await assert.rejects(() => reader.json('repos/o/r/issues/1'), GithubRateLimitError)
+  await assert.rejects(
+    () => reader.json('repos/o/r/issues/2'),
+    (error: unknown) => error instanceof GithubRateLimitError && error.kind === 'secondary',
+  )
+  assert.equal(fake.commands.length, 1)
+})
+
+test('host REST requests are serialized across resources and respect a minimum start interval', async () => {
+  const starts: number[] = []
+  let releaseFirst: (() => void) | null = null
+  const firstBlocked = new Promise<void>((resolve) => {
+    releaseFirst = resolve
+  })
+  const fake = {
+    shell: {
+      resolve(spec: unknown) {
+        return spec
+      },
+      async run() {
+        starts.push(Date.now())
+        if (starts.length === 1) await firstBlocked
+        return { exitCode: 0, stdout: { text: included({ ok: true }) }, stderr: { text: '' } }
+      },
+    },
+  }
+  const reader = new GithubRestReader(fake as never, { minimumIntervalMs: 20 })
+  const first = reader.json('repos/o/r/issues/1')
+  const second = reader.json('repos/o/r/issues/2')
+  try {
+    for (let attempt = 0; attempt < 100 && starts.length === 0; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 5))
+    }
+    assert.equal(starts.length, 1, 'the second resource must wait for the first request to settle')
+  } finally {
+    releaseFirst?.()
+  }
+  await Promise.all([first, second])
+  assert.equal(starts.length, 2)
+  assert.ok(starts[1] - starts[0] >= 20, `requests started only ${starts[1] - starts[0]}ms apart`)
+})
+
 test('review decision uses each reviewer latest decisive review', () => {
   assert.equal(
     deriveReviewDecision([

--- a/tests/prompt.test.ts
+++ b/tests/prompt.test.ts
@@ -6,6 +6,7 @@ import {
   snapshotWithoutReviewFeedback,
   type PromptSnapshot,
 } from '../src/agent/prompt.ts'
+import { DEVELOPMENT_REQUIREMENTS, GITHUB_USAGE_REQUIREMENT } from '../src/agent/prompts.ts'
 
 const snapshot: PromptSnapshot = {
   url: 'https://github.com/o/r/issues/20',
@@ -54,6 +55,14 @@ test('persisted fallback is explicit about possible staleness', () => {
   assert.match(prompt, /刷新失败: gh unavailable/)
   assert.match(prompt, /PR: #9/)
   assert.match(prompt, /commit: abc123/)
+})
+
+test('development and review requirements avoid repeated GraphQL-heavy gh context reads', () => {
+  assert.ok(DEVELOPMENT_REQUIREMENTS.includes(GITHUB_USAGE_REQUIREMENT))
+  assert.match(GITHUB_USAGE_REQUIREMENT, /gh api/)
+  assert.match(GITHUB_USAGE_REQUIREMENT, /gh pr view/)
+  assert.match(GITHUB_USAGE_REQUIREMENT, /gh issue view/)
+  assert.match(GITHUB_USAGE_REQUIREMENT, /同一资源.*一次/)
 })
 
 test('resume keeps session memory but explicitly makes the current snapshot authoritative', () => {

--- a/tests/prompt.test.ts
+++ b/tests/prompt.test.ts
@@ -6,7 +6,12 @@ import {
   snapshotWithoutReviewFeedback,
   type PromptSnapshot,
 } from '../src/agent/prompt.ts'
-import { buildDevelopPrompt, buildResumePrompt, buildReviewPrompt, GITHUB_USAGE_REQUIREMENT } from '../src/agent/prompts.ts'
+import {
+  buildDevelopPrompt,
+  buildResumePrompt,
+  buildReviewPrompt,
+  GITHUB_USAGE_REQUIREMENT,
+} from '../src/agent/prompts.ts'
 
 const snapshot: PromptSnapshot = {
   url: 'https://github.com/o/r/issues/20',

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -4,7 +4,7 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { createServer, request, type RequestListener } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import test from 'node:test'
+import test, { after } from 'node:test'
 import { apply, fetchRepositoryIssues } from '../src/index.ts'
 import { decodeLiveLogLine, encodeLiveLogEvent } from '../src/infra/live-output.ts'
 import {
@@ -18,6 +18,17 @@ import {
   type IssueWorkflow,
 } from '../src/infra/state.ts'
 import { createFakeJobs } from './fake-jobs.ts'
+
+// Route tests exercise /state background reconciliation; never let that controller
+// discover or mutate the developer's real ~/.clickvibe workflow files.
+const routesOriginalHome = process.env.HOME
+const routesTestHome = await mkdtemp(join(tmpdir(), 'clickvibe-routes-home-'))
+process.env.HOME = routesTestHome
+after(async () => {
+  if (routesOriginalHome === undefined) delete process.env.HOME
+  else process.env.HOME = routesOriginalHome
+  await rm(routesTestHome, { recursive: true, force: true })
+})
 
 function included(body: unknown, status = 200, headers: Record<string, string> = {}): string {
   return [

--- a/tests/state-view-integration.test.ts
+++ b/tests/state-view-integration.test.ts
@@ -417,7 +417,7 @@ test('metadata-only updatedAt drift does not invalidate an unchanged issue body'
   }
 })
 
-test('/state enrichment checks configured branches and runs GitHub lookups concurrently', async () => {
+test('/state enrichment checks configured branches while the host serializes GitHub request bursts', async () => {
   const root = await mkdtemp(join(tmpdir(), 'clickvibe-state-enrich-'))
   const repo = join(root, 'repo')
   await mkdir(repo)
@@ -477,7 +477,7 @@ test('/state enrichment checks configured branches and runs GitHub lookups concu
       repos: { 'o/r': repo },
       worktreeRoot: root,
     })
-    assert.equal(maxGithub, 2)
+    assert.equal(maxGithub, 1)
     assert.deepEqual(githubTimeouts, [5000, 5000])
     assert.deepEqual(
       enriched.map((item) => item.derived.nextAction.label),

--- a/tests/workflow-fixture.ts
+++ b/tests/workflow-fixture.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'node:crypto'
 import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { isDeepStrictEqual } from 'node:util'
-import { type IssueWorkflow, statePath, WorkflowConflictError } from '../src/infra/state.ts'
+import { type IssueWorkflow, issueKey, statePath, WorkflowConflictError } from '../src/infra/state.ts'
 
 const TASK_STATE_FIELDS = [
   'stage',
@@ -19,6 +19,54 @@ const TASK_STATE_FIELDS = [
   'reviewSessionAgent',
   'reviewResult',
 ] as const satisfies readonly (keyof IssueWorkflow)[]
+
+export function autoRunWorkflowFixture(
+  tempHome: string,
+  number: string,
+  overrides: Partial<IssueWorkflow> = {},
+): IssueWorkflow {
+  return {
+    key: issueKey('owner/repo', number),
+    url: `https://github.com/owner/repo/issues/${number}`,
+    repoKey: 'owner/repo',
+    worktree: tempHome,
+    branch: `clickvibe-issue-${number}`,
+    stage: 'idle',
+    devAgent: null,
+    devTaskId: null,
+    devHostJobId: null,
+    devSessionId: null,
+    devSessionAgent: null,
+    devInterrupted: false,
+    reviewAgent: null,
+    reviewTaskId: null,
+    reviewHostJobId: null,
+    reviewSessionId: null,
+    reviewSessionAgent: null,
+    reviewResult: null,
+    prNumber: null,
+    issueState: 'OPEN',
+    baseRef: 'origin/main @ b9c6dea',
+    autoRun: {
+      status: 'running',
+      autoMerge: false,
+      devAgent: 'codex',
+      reviewAgent: 'codex',
+      maxRounds: 20,
+      budgetHours: 24,
+      startedAt: new Date().toISOString(),
+      deadline: new Date(Date.now() + 60_000).toISOString(),
+      step: 1,
+      rounds: 0,
+      unresolved: [],
+      lastObservedAt: null,
+      pausedReason: null,
+    },
+    updatedAt: Date.now(),
+    events: [],
+    ...overrides,
+  }
+}
 
 /** Test setup only: writes an otherwise unreachable persisted lifecycle fixture. */
 export async function commitWorkflowFixture(workflow: IssueWorkflow, expectedRevision: number | null): Promise<void> {


### PR DESCRIPTION
## Summary

- 基础设施异常按无次数上限的指数退避与抖动重试；GitHub 限流按 reset 恢复
- 相同错误栈连续 3 次熔断；看门狗仅恢复 controller-error，并受冷却、每小时 10 次、ownership 与原始预算门禁约束
- 宿主 GitHub REST 串行节流，agent 提示词限制 GraphQL 重复查询，重试/熔断/重挂诊断持久化
- Review 返工：删除中文错误文本启发式，仅确定性 Issue 契约不匹配显式标记 authorization-denied；未分类动作失败一律按 controller-error 恢复
- 公共 reconcile 队列补齐熔断、并发重挂、语义暂停回归，并修复 catch 期间残留入队信号丢失竞态
- CI 对抗修复：最小请求间隔以请求实际启动后为锚点，消除计时边界的 1ms 短缺

## Verification

- pnpm run typecheck
- pnpm run build
- pnpm test (507 passed)
- pnpm run coverage (lines 93.90%, branches 85.39%, functions 90.11%)
- pnpm run lint
- pnpm run format:check
- pnpm run check:size
- pnpm run check:layers
- pnpm run check:style-tokens (89.35%)
- pnpm run check:state-writes
- git diff --check

Closes #120