### PR TITLE
docs(v0.2): define clean-break identity and binding baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ ClickVibe 是一个 DSH Web 插件和 Issue-to-Merge 交付控制面:右侧面�
 1. **测试全绿**:`pnpm run typecheck && pnpm run build && pnpm test` 必须全绿;拆分 PR 中测试只允许改 import 路径,断言 / fixture / 行为一律不动。
 2. **导出面锚点**:以下被测试直接引用的导出必须继续从 `src/index.ts` re-export,不得转移后断供:`apply`、`fetchRepositoryIssues`、`deriveWorkflowState`、`enrichWorkflowStates`、`buildMergePreface`、`resumeDevelop`、`syncWorktree`、`assertReviewHeadMatchesPr`、`isSyncEquivalentMerge`。
 3. **构建入口固定**:`src/index.ts`、`src/invariant.ts`、`src/client/index.tsx`(`tsdown.config.ts`),搬移不得移动这三个文件本身。
-4. **对外契约不变**:17 个 `/clickvibe/api/*` method(fetch/projects/repo/issues/state/authorize/develop/develop/poll/history/stream/review/resume/stop/sync/merge/command)、响应形状、`~/.clickvibe/state/` 持久化格式、agent 两阶段授权命令(预览→一次性 2 分钟授权→执行)与文本命令语法。
+4. **对外契约默认不变**:17 个 `/clickvibe/api/*` method(fetch/projects/repo/issues/state/authorize/develop/develop/poll/history/stream/review/resume/stop/sync/merge/command)、响应形状、`~/.clickvibe/state/` 当前代次格式、agent 两阶段授权命令(预览→一次性 2 分钟授权→执行)与文本命令语法。只有 Accepted ADR + 显式 preview/authorization/backup/recovery/read-back 升级协议可以授权持久化代次切换；ADR-0009 仅授权一次 v0.1→v0.2 clean break，不授权普通功能 PR 随意改格式或长期双写。
 5. **状态推导纪律**:git/GitHub 原生事实是门槛,workflow 文件与 comment meta 只是缓存/增强器(见 `docs/state-model.md`);review 结论必须绑定其审查的 commit 与契约指纹,不得冒充。
 6. **错误不埋葬**:任何被捕获、降级或归类处理的错误,原始信息(动作/错误文本)必须同时落盘(本地事件持久)并可在面板展示;可以处理,不可抹去。归类标签(如 controller-error)是分类,不是替代证据(#90 两次暂停不可追溯的教训,2026-08-25)。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # ClickVibe 当前有效架构
 
-> Status: Accepted | Owner: ClickVibe maintainers | Last updated: 2026-08-26 | Scope: target architecture; implementation order is governed by [roadmap](roadmap.md)
+> Status: Accepted | Owner: ClickVibe maintainers | Last updated: 2026-08-27 | Scope: target architecture; implementation order is governed by [roadmap](roadmap.md)
 
 本文是 ClickVibe 架构的唯一入口。它回答“当前系统由什么组成、事实由谁拥有、变化如何进入系统”。详细设计放在 `docs/architecture/`，重要取舍放在 `docs/architecture/decisions/`；带日期的 `docs/plans/` 只记录一次实施过程，不自动成为当前架构。
 
@@ -69,6 +69,7 @@ v0.1 已验证部分事实推导、Agent 流程和持久化能力，但它没有
 - [系统上下文](architecture/system-context.md)：DSH、ClickVibe、Agent、Git 与 GitHub 的责任边界。
 - [Canonical Domain Model](architecture/canonical-domain-model.md)：目标 Domain、关系、生命周期、事实所有者与稳定等级；实现顺序见 roadmap。
 - [核心数据契约](architecture/core-contracts.md)：跨平台身份、DeliveryBasis、Run、Review、Decision、Event，以及 v0.1 本地状态冷备份与 v0.2 clean-break 边界。
+- [v0.2 本地配置与状态升级协议](architecture/v02-upgrade-protocol.md)：升级锁、旧运行时代次门禁、durable journal、原子 cutover 与恢复矩阵。
 - [核心数据流](architecture/core-data-flow.md)：从 Issue 到合并/暂停的数据流，以及读缓存和写后回读。
 - [事实源与状态权威](architecture/authority-model.md)：哪些事实可以决定动作，哪些只是缓存或证据增强。
 - [交付状态机](architecture/workflow-state-machine.md)：Observe → Decide → Apply → Re-observe 的收敛循环。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,7 +68,7 @@ v0.1 已验证部分事实推导、Agent 流程和持久化能力，但它没有
 - [产品演进路线](roadmap.md)：v0.2.0 至 v0.10.0 的主矛盾、顺序与退出标准。
 - [系统上下文](architecture/system-context.md)：DSH、ClickVibe、Agent、Git 与 GitHub 的责任边界。
 - [Canonical Domain Model](architecture/canonical-domain-model.md)：目标 Domain、关系、生命周期、事实所有者与稳定等级；实现顺序见 roadmap。
-- [核心数据契约](architecture/core-contracts.md)：跨平台身份、DeliveryBasis、Run、Review、Decision、Event 和 v0.1 迁移语义。
+- [核心数据契约](architecture/core-contracts.md)：跨平台身份、DeliveryBasis、Run、Review、Decision、Event，以及 v0.1 本地状态冷备份与 v0.2 clean-break 边界。
 - [核心数据流](architecture/core-data-flow.md)：从 Issue 到合并/暂停的数据流，以及读缓存和写后回读。
 - [事实源与状态权威](architecture/authority-model.md)：哪些事实可以决定动作，哪些只是缓存或证据增强。
 - [交付状态机](architecture/workflow-state-machine.md)：Observe → Decide → Apply → Re-observe 的收敛循环。

--- a/docs/architecture/canonical-domain-model.md
+++ b/docs/architecture/canonical-domain-model.md
@@ -1,6 +1,6 @@
 # ClickVibe Canonical Domain Model
 
-> Status: Accepted | Parent: [当前有效架构](../architecture.md) | Decisions: [ADR-0006](decisions/0006-canonical-domain-model-and-contracts.md), [ADR-0007](decisions/0007-three-git-github-access-planes.md) | Detailed schemas: [核心数据契约](core-contracts.md)
+> Status: Accepted | Parent: [当前有效架构](../architecture.md) | Decisions: [ADR-0006](decisions/0006-canonical-domain-model-and-contracts.md), [ADR-0007](decisions/0007-three-git-github-access-planes.md), [ADR-0009](decisions/0009-v02-clean-break-local-state-and-config.md) | Detailed schemas: [核心数据契约](core-contracts.md)
 
 ## 目的
 

--- a/docs/architecture/canonical-domain-model.md
+++ b/docs/architecture/canonical-domain-model.md
@@ -224,16 +224,16 @@ stateDiagram-v2
 1. 任何外部读取失败都产生 `unknown` Observation 或 DiagnosticRecord，不能合成为“没有依赖/任务已死/检查已通过”。
 2. 动作返回成功只表示请求完成；必须重新观察目标事实。
 3. generation、revision、sequence、round、step 是不同坐标，禁止互换。
-4. 旧 schema 的兼容读取只用于迁移；新旧模型不得长期双写为两个事实源。
+4. v0.1 本地 config/state 依 ADR-0009 冷备份后 clean break，v0.2 active runtime 不做兼容读取；v0.2 及后续正式 schema 的升级使用显式迁移，新旧模型不得长期双写为两个事实源。
 5. 原始证据保留 ArtifactRef，结构化摘要和分类标签不能覆盖原文。
 6. 凭据值不进入任何核心契约；只保存 credential ref、provider/model 标识和脱敏后的诊断。
 
 ## 分阶段实施
 
-1. **v0.2 可信访问与身份地基**：实现 WorkItemIdentity、ProjectBinding、WorkItemContractSnapshot、Local Git Snapshot、Remote Git Coordinator、GitHub REST Gateway、最小 DiagnosticRecord/ArtifactRef 和逐类迁移。WorkItemContract 在本版本落地，因为现有 `issueSnapshot` 已参与读取与授权，缓存 freshness 和旧授权失效直接消费它。
-2. **v0.3 自主交付安全边界**：实现 DeliveryBasis、WorkflowControlState、generation、CapabilityLease、最小 Policy、判别式 EventEnvelope 因果链和纯规则 Loop Guard。v0.2 只保留并映射 legacy WorkflowEvent 的有效语义，不建立无消费者的完整自主事件总包。
+1. **v0.2 可信访问与身份地基**：实现 WorkItemIdentity、ProjectBinding、WorkItemContractSnapshot、Local Git Snapshot、Remote Git Coordinator、GitHub REST Gateway、最小 DiagnosticRecord/ArtifactRef，并依 ADR-0009 显式切换本地 config/state。WorkItemContract 在本版本落地，因为新的读取、授权、Coding 和 Review 路径需要共享需求快照、freshness 和失效语义。
+2. **v0.3 自主交付安全边界**：实现 DeliveryBasis、WorkflowControlState、generation、CapabilityLease、最小 Policy、判别式 EventEnvelope 因果链和纯规则 Loop Guard。v0.2 不迁移 legacy WorkflowEvent，也不预建无消费者的完整自主事件总包。
 3. **v0.4–v0.5 可恢复再并行**：先完成全因果链恢复与复盘，再扩大到同仓库多 Work Item 的 baseline、冲突和合并顺序协调。
 4. **v0.6 介入产品化**：面板提供证据查看、指令修改和受控恢复；模型型 Runtime Observer 仅在数据证明能降低人工时间时启用。
-5. 每一步都按资产决定保留、重构、迁移、归档或废弃；任何数据处置先有备份和回滚边界，已切换状态不得形成长期双写。
+5. 每一步都按资产决定保留、重构、迁移、归档或废弃；v0.1 本地 config/state 使用 ADR-0009 的 cold-backup clean break，Git/Provider 事实原样保留。任何数据处置先有备份和回滚边界，已切换状态不得形成长期双写。
 
 任何一步都不允许“为了迁移方便”恢复公开的无条件整对象写入口。

--- a/docs/architecture/core-contracts.md
+++ b/docs/architecture/core-contracts.md
@@ -1,6 +1,6 @@
 # ClickVibe 核心数据契约
 
-> Status: Accepted | Parent: [Canonical Domain Model](canonical-domain-model.md) | Decision: [ADR-0006](decisions/0006-canonical-domain-model-and-contracts.md)
+> Status: Accepted | Parent: [Canonical Domain Model](canonical-domain-model.md) | Decisions: [ADR-0006](decisions/0006-canonical-domain-model-and-contracts.md), [ADR-0009](decisions/0009-v02-clean-break-local-state-and-config.md)
 
 本文中的 TypeScript 是持久化/wire 语义草图，不承诺物理文件位置，也不等于全部契约在 v0.2 一次实现或立即修改公开 API。每个字段必须先有唯一语义，再按[产品演进路线](../roadmap.md)随真实消费者进入实现。
 
@@ -16,11 +16,11 @@
 
 ### 实现版本边界
 
-- **v0.2**：WorkItemIdentity、ProjectBinding、WorkItemContractSnapshot、Observation/Cache、ArtifactRef、DiagnosticRecord 与三个访问平面需要的作用域；保留并迁移 legacy WorkflowEvent 的有效语义。
+- **v0.2**：WorkItemIdentity、ProjectBinding、WorkItemContractSnapshot、Observation/Cache、ArtifactRef、DiagnosticRecord 与三个访问平面需要的作用域；依 ADR-0009 对 v0.1 本地 config/state 做 cold-backup clean break，不迁移 legacy WorkflowEvent。
 - **v0.3**：DeliveryBasis、AutomationPolicySnapshot、WorkflowControlState、CapabilityLease、Run、ReviewConclusion、Decision/ActionResult、完整判别式 EventEnvelope 和 Loop Guard。
 - **v0.4+**：在上述契约上补齐完整恢复/复盘、并行协调、介入产品化和后续 Provider 验证，不另造同义身份、SHA、generation 或 evidence。
 
-WorkItemContract 与 EventEnvelope 的排期差异来自真实消费者，不来自“迁移目标天然算消费者”：现有 `issueSnapshot` 已在读取、授权、Coding 和 Review 路径生效；完整因果 EventEnvelope 的首个生产者是 v0.3 自主决策链。legacy WorkflowEvent 仍被部分现行控制逻辑读取，v0.2 必须保留和映射其有效语义，不能静默删除。
+WorkItemContract 与 EventEnvelope 的排期差异来自真实消费者：新的读取、授权、Coding 和 Review 路径在 v0.2 直接消费 WorkItemContract；完整因果 EventEnvelope 的首个生产者是 v0.3 自主决策链。v0.1 `issueSnapshot`、WorkflowEvent 和 task/session 只保存在冷备份中，不进入 v0.2 active state，也不授权当前动作。
 
 ## 1. 平台与 Work Item 身份
 
@@ -444,7 +444,7 @@ type WorkflowEvent =
 | `observer.completed` | 必须非空 | 诊断只能作用于触发它的 generation 与 evidence |
 | `delivery.merged` | 必须非空 | 交付记录必须证明合并的是通过门禁的 exact head |
 
-DiagnosticRecord 不使用 EventEnvelope 的 `basis` 表达前置基础设施错误；它通过可空 workflow、operation、原始错误和 ArtifactRef 保存证据。迁移后的 legacy event 若无法恢复完整 basis，必须标记 legacy/unknown，只能展示和复盘，不能授权当前动作。
+DiagnosticRecord 不使用 EventEnvelope 的 `basis` 表达前置基础设施错误；它通过可空 workflow、operation、原始错误和 ArtifactRef 保存证据。v0.1 legacy event 不进入 active projection；需要复盘时只从只读冷备份人工提取，不能授权当前动作。
 
 事件用于审计与投影，不意味着所有当前状态都必须从零重放。WorkflowControlState 仍由串行命令域原子持久化，事件追加失败必须作为明确错误处理，不能静默丢失因果链。
 
@@ -452,27 +452,24 @@ DiagnosticRecord 不使用 EventEnvelope 的 `basis` 表达前置基础设施错
 
 1. 只在持久化/wire 边界设置 schemaVersion；当前首版为 `1`。
 2. 新增可选展示字段可以向前兼容；改变身份、权威、状态语义必须升级版本。
-3. 每个版本提供显式、幂等迁移函数；迁移前备份，失败保留原文件并停止写入。
-4. 旧记录读取后进入目标内存模型，但新写入只使用目标 schema，禁止长期双写。
+3. v0.1 → v0.2 依 ADR-0009 做 cold-backup clean break；v0.2 及后续正式 schema 的升级提供显式、幂等迁移函数，迁移前备份，失败保留原文件并停止写入。
+4. v0.1 旧记录不进入 v0.2 active 内存模型；后续 schema 迁移完成后只写目标 schema，禁止长期双写。
 5. 未知 event type 原样保留并跳过 Projection，不能删除或解释成成功。
 6. Hash 输入包含 schema/canonicalization 版本，算法变化不会冒充相同 fingerprint。
 
-## 14. v0.1 → Canonical Contract 迁移映射
+## 14. v0.1 cold archive 与 v0.2 重建映射
 
-下表是“决定保留该资产时如何迁移”的映射，不是对全部 v0.1 内部结构的兼容承诺。实施前先把每类代码和持久数据标记为保留、重构、迁移、归档或废弃；废弃项必须说明理由、影响范围和备份位置。
+v0.1 本地 config/state 整体冷备份，不由 v0.2 active runtime 读取。下表定义新 state 如何从当前 Provider/Git 事实重新建立语义，以及哪些旧字段只留在冷备份。它不是 legacy reader 规格。
 
-| v0.1 字段/结构 | 目标契约 | 迁移规则 |
+| v0.1 字段/结构 | v0.2 目标 | clean-break 规则 |
 |---|---|---|
-| `repoKey: owner/repo` | WorkItem `provider/instance/container` | 当前映射为 `github/github.com/repoKey` |
-| Issue URL 中的 number | `WorkItemIdentity.id` | 转为十进制字符串；URL 保留为 locator |
-| `IssueWorkflow.key` | WorkflowIdentity 的存储键 | 兼容读取旧 key；新 canonical key 包含 provider/instance/container/id |
-| `worktree/branch` | ProjectBinding + Run scope/Projection | path 是 locator，不进入身份 |
-| `baseRef` 拼接字符串 | `DeliveryBasis.baseline.ref/sha` | 能可靠解析才迁移；不完整则标记 unknown，禁止猜 |
-| `issueSnapshot` | WorkItemContractSnapshot | 原文进入 ArtifactRef；缺 AC/Non-Goals 等按 legacy/unknown 处理 |
-| dev/review task/session 字段 | RunRecord + CapabilityLease | 迁移当前引用；没有 generation 证据的旧 Run 不获得新写权限 |
-| `reviewResult.passed/issues` | legacy ReviewConclusion | 缺 exact basis/theme/evidence 时只能展示，不能授权自动 merge |
-| `autoRun` | AutomationPolicySnapshot + WorkflowControlState | 配置与进度拆分；旧状态保留原始 ArtifactRef |
-| `WorkflowEvent` 可选字段对象 | 判别式 EventEnvelope | 按 kind 映射；无法判定的字段进入 legacy payload，不丢弃 |
-| `stage` | Workflow Projection | 作为迁移提示，不提升为 Git/GitHub 事实 |
+| `repoKey`、Issue URL、旧 workflow key | WorkItemIdentity + canonical key | 不读旧 state；从当前 Provider item 经 Adapter 生成新四元组和 key |
+| 未版本化 `config.yaml.repos` | schema 1 ProjectBinding config | 升级器精确预览、备份并一次性转换；普通 runtime 不兼容读取 |
+| `worktree/branch` | Git fact + 新 Run locator | Git 现场原样保留；冲突时阻止新任务，不自动导入或覆盖 |
+| `baseRef` 拼接字符串 | 新 DeliveryBasis | 不导入；新动作重新观察 remote ref 与 exact SHA |
+| `issueSnapshot` | WorkItemContractSnapshot | 不导入；从当前 Provider contract 重新抓取并保存新 ArtifactRef |
+| dev/review task/session 字段 | 新 Run/CapabilityLease | 不导入；旧 session/task 不获得 v0.2 写权限 |
+| `reviewResult`、`WorkflowEvent`、`stage` | 冷备份 | 不进入 active projection；需要复盘时只读人工提取 |
+| `autoRun` | 新 AutomationPolicy/ControlState | 不导入；v0.3 按新契约创建 |
 
-迁移完成标准不是“新类型能读取旧 JSON”，而是：旧记录不会获得比原来更多的权限，unknown 不被补成确定值，且新写入只有一个事实源。
+clean break 完成标准是：旧 config/state 有可验证冷备份，新 `~/.clickvibe/state` 与 schema 1 config 逐项回读通过，v0.2 没有 active legacy reader，Git/Provider 事实未被删除或覆盖，且新写入只有一个事实源。

--- a/docs/architecture/core-contracts.md
+++ b/docs/architecture/core-contracts.md
@@ -69,6 +69,15 @@ interface ProjectBinding {
     primaryRemote: string
   }
 }
+
+interface ClickVibeConfigV1 {
+  schemaVersion: 1
+  /** Single source of truth for generated worktree paths and collision guards. */
+  worktreeRoot: string
+  fetchTtlSeconds?: number
+  diagnosticsMaxBytes?: number
+  projectBindings: ProjectBinding[]
+}
 ```
 
 | 字段 | 说人话 |
@@ -80,6 +89,8 @@ interface ProjectBinding {
 | `primaryRemote` | 远端协调默认使用哪个 Git remote，通常是 `origin` |
 
 `ProjectBinding` 是机器/部署配置，不是 Git/GitHub 事实。一个外部项目没有本地 binding 时仍可只读展示，但不能启动需要 worktree 的 Run。
+
+config schema、WorkItem/Binding tuple schema 与 hash policy 独立版本化。v0.1 的合法 `worktreeRoot`、`fetchTtlSeconds`、`diagnosticsMaxBytes` 在 schema 1 转换时保留；缺失 `worktreeRoot` 固定为 `~/.clickvibe/worktrees`。完整 cutover、逐条排除和恢复规则见[v0.2 升级协议](v02-upgrade-protocol.md)。
 
 ## 3. WorkflowIdentity
 

--- a/docs/architecture/decisions/0006-canonical-domain-model-and-contracts.md
+++ b/docs/architecture/decisions/0006-canonical-domain-model-and-contracts.md
@@ -1,6 +1,6 @@
 # ADR-0006：Canonical Domain Model 与核心契约
 
-> Status: Accepted | Date: 2026-08-26
+> Status: Accepted | Date: 2026-08-26 | Partially superseded by: [ADR-0009](0009-v02-clean-break-local-state-and-config.md) for v0.1 local config/state cutover
 
 ## Context
 
@@ -17,7 +17,7 @@ ClickVibe 当前以 GitHub Issue 为交付入口，但未来可能接入 GitLab�
 3. 所有判断共享 `DeliveryBasis`：Workflow、需求指纹、架构版本、baseline ref/SHA 和 exact head SHA。
 4. Fact、Observation、Evidence、Cache、Event 与 Projection 是不同概念，缓存或投影不得提升事实等级。
 5. 每个 Domain 拥有自己的契约；跨 Domain 只传 identity、ref、冻结快照或明确 command/result，不共享可变超级对象。
-6. 目标持久化事件使用带 schemaVersion 的判别式 `EventEnvelope<type, payload>`，不继续扩展一个拥有大量可选字段的通用事件对象；v0.2 保留并迁移 legacy `WorkflowEvent` 的有效语义，完整因果事件链随 v0.3 自主决策生产者落地。
+6. 目标持久化事件使用带 schemaVersion 的判别式 `EventEnvelope<type, payload>`，不继续扩展一个拥有大量可选字段的通用事件对象；完整因果事件链随 v0.3 自主决策生产者落地。v0.1 本地 config/state 的 v0.2 切换由 ADR-0009 部分替代本 ADR 的原迁移方向。
 7. 事件用于审计、因果链和投影；不要求把整个系统重写成 Event Sourcing。控制状态仍由单一串行 workflow 命令域持久化。
 8. UI DTO、缓存 TTL、模型/provider 选择、prompt 文本和展示状态属于可替换投影或策略，不纳入长期冻结核心。
 9. v0.1 实现没有保留特权。每类资产按目标不变量和证据决定复用、重构、迁移、归档或废弃；需要保留的数据显式迁移，内部坏结构不以兼容为由进入 v0.2。
@@ -33,21 +33,21 @@ ClickVibe 当前以 GitHub Issue 为交付入口，但未来可能接入 GitLab�
 
 ### Negative
 
-- v0.1 资产需要逐项处置；保留数据必须显式、可回滚地迁移或兼容读取，废弃数据必须先备份和说明边界。
-- 若切换期同时存在 legacy `IssueWorkflow` 与目标契约，必须限制过渡期限并防止双写变成两个事实源。
+- v0.1 本地 config/state 需要一次显式 clean break；旧 task/session/Review/event 不能在 v0.2 中直接恢复。
+- 升级器必须跨 config、state 和多个 Git common-dir 管理可恢复阶段，不能依赖单文件原子性。
 - Provider-neutral 核心会增加少量适配映射和类型数量。
 
 ### Neutral
 
 - “GitHub-native”仍是产品与首个适配器定位，不等于核心类型只能表示 GitHub。
 - 类型文档先于代码落地；物理目录和模块拆分在实现 Issue 中按现有单向依赖规则决定。
-- v0.2 实现身份、ProjectBinding、WorkItemContract 和访问平面；DeliveryBasis、WorkflowControlState、CapabilityLease 与完整 EventEnvelope 随 v0.3 的首个运行时消费者落地。契约已 Accepted 不等于要求 v0.2 预建无消费者类型。
+- v0.2 实现身份、ProjectBinding、WorkItemContract 和访问平面，并依 ADR-0009 从空 active state 开始；DeliveryBasis、WorkflowControlState、CapabilityLease 与完整 EventEnvelope 随 v0.3 的首个运行时消费者落地。契约已 Accepted 不等于要求 v0.2 预建无消费者类型。
 
 ## Alternatives Considered
 
 - **继续使用 `issueNumber: number`**：拒绝。无法自然表达 Jira key、UUID 或其他字符串身份。
 - **直接用 URL 当身份**：拒绝。URL 是可变 locator，仓库/项目改名或平台路由变化会破坏关联。
-- **原样冻结 `IssueWorkflow`**：拒绝。它是 v0.1 迁移来源，不是长期领域边界。
+- **原样冻结 `IssueWorkflow`**：拒绝。它只用于 v0.1 历史资产盘点和冷备份说明，不是 v0.2 active migration 来源，也不是长期领域边界。
 - **建立一个全局 `common/types.ts` 超级模块**：拒绝。统一语言不等于共享可变对象；契约必须由 Domain 拥有。
 - **立即全面 Event Sourcing**：拒绝。当前没有需求证明其复杂度；分阶段追加审计事件与控制快照已经满足恢复和复盘目标。
 
@@ -58,3 +58,4 @@ ClickVibe 当前以 GitHub Issue 为交付入口，但未来可能接入 GitLab�
 - [事实源与状态权威](../authority-model.md)
 - [可观测性与复盘](../observability.md)
 - [产品演进路线](../../roadmap.md)
+- [v0.2 本地状态与配置 clean break](0009-v02-clean-break-local-state-and-config.md)

--- a/docs/architecture/decisions/0009-v02-clean-break-local-state-and-config.md
+++ b/docs/architecture/decisions/0009-v02-clean-break-local-state-and-config.md
@@ -1,0 +1,80 @@
+# ADR-0009：v0.2 本地状态与配置 clean break
+
+> Status: Draft | Date: 2026-08-27 | Maintainer direction: clean break confirmed | Proposed partial supersession: [ADR-0006](0006-canonical-domain-model-and-contracts.md)
+
+## Context
+
+ADR-0006 将 v0.1 的 `IssueWorkflow`、`WorkflowEvent`、`repoKey` 和 Issue URL 视为迁移来源，并要求 v0.2 保留、迁移 legacy `WorkflowEvent` 的有效语义。该方向适合已有多用户安装或必须在线升级的产品，但 ClickVibe 当前仍是单用户使用的 0.x 实验版本。为了兼容未公开的本地格式而长期保留双解析、双身份和迁移分支，会让身份地基从第一天就背负无真实消费者的兼容成本。
+
+当前本地状态还可能包含任务日志、Review 证据、冲突 worktree 和未推送提交。clean break 不能被解释为无备份删除，也不能覆盖 Git/GitHub 权威事实。配置、ClickVibe state、Git worktree/branch 和 Provider 事实必须分别处置。
+
+## Decision
+
+如果本 ADR 被接受，v0.2 按以下规则切换：
+
+1. v0.2 active runtime 只接受 v0.2 `config.yaml` 和 state schema，不包含 v0.1 `repos`、`IssueWorkflow`、legacy workflow key 或 `WorkflowEvent` 的兼容读取/写入分支。
+2. 升级前将整个 `~/.clickvibe/state` 原子改名为唯一的 `~/.clickvibe/state-v0.1-backup-<timestamp>-<nonce>`；随后在原路径创建新的空 `~/.clickvibe/state`。冷备份不参与 v0.2 运行，也不自动删除。
+3. 旧 `config.yaml` 在精确预览和用户显式授权后一次性转换为 v0.2 ProjectBinding 格式；转换前保留原文件备份。v0.2 不把长期双格式解析当迁移方案。
+4. Git worktree、local branch、remote branch、commit 和未提交文件不属于 ClickVibe state。升级只盘点并展示，不删除、不移动、不自动导入。新任务与既有 path/branch 冲突时 fail-closed，要求显式采用或清理。
+5. GitHub Issue、PR、Review、CI 和 merge 继续由 Provider 回读；clean break 不修改这些事实。
+6. 升级不是启动时的隐式副作用。流程必须是检测、精确预览、显式授权、分阶段执行、逐项回读；任一步不确定时 v0.2 保持不可写。
+7. 冷备份仅作为人工恢复和审计材料。它不授权 v0.2 动作，旧 Review、task/session、stage 或 event 不自动进入新 state。
+
+本 ADR 只改变 v0.1 本地状态和配置的升级策略。它不改变 ADR-0006 的 provider-neutral 身份、Domain 边界、事实等级和未来事件契约。
+
+## Required Baseline Changes Before Acceptance
+
+接受本 ADR 前必须在同一设计变更中同步：
+
+- `docs/roadmap.md` 中“v0.2 保留并迁移 legacy WorkflowEvent”的要求；
+- `docs/architecture/canonical-domain-model.md`、`core-contracts.md` 和 `observability.md` 的 legacy event 排期；
+- Issue #134 的旧 key 兼容/迁移验收与 L3 baseline；
+- Issue #136 对 legacy `WorkflowEvent` 的验收标准；
+- Issue #137 对 v0.1 资产逐类迁移的范围，使其区分 active migration、cold archive 和 Git 现场处置。
+
+本地文档提案与 GitHub Issue #132、#134、#136、#137 已在 2026-08-27 按 clean break 方向同步；在本设计 PR 的 exact-SHA Review 通过并合入前，本 ADR 保持 Draft，不能作为 Coding Agent 的基线。
+
+## Consequences
+
+### Positive
+
+- v0.2 从第一天只有一个身份模型、一个配置 schema 和一个 active state 写入模型。
+- 删除长期兼容代码、双写和旧 key 猜测，缩小 #134、#136 和后续访问平面的状态空间。
+- 原始本地数据仍有冷备份；Git/GitHub 事实不因控制状态重置而丢失。
+- 升级机制本身形成可预览、可恢复、可回读的产品边界。
+
+### Negative
+
+- v0.1 task/session、Review 结论和 workflow stage 不能在 v0.2 中直接恢复。
+- 旧 worktree 只作为外部 Git 现场保留；需要继续时必须重新观察、重新授权并重新 Review。
+- 用户必须完成一次显式升级，不能直接用 v0.2 打开 v0.1 state。
+- 当前 Accepted 文档和 #136/#137 必须重新对齐，设计工作量前置。
+
+### Neutral
+
+- 冷备份可在 v0.2 稳定验收后由用户另行授权删除；本 ADR 不规定自动保留期限。
+- 多机器绑定只要求相同 Work Item identity 和不同 ProjectBinding；机器注册、在线状态与执行路由仍属于后续版本。
+
+## Failure Modes and Required Handling
+
+- **仍有 live task**：升级停止；持久化 `running` 不是活性证明，必须检查当前进程 handle 与宿主 job。
+- **旧配置无效或仓库不可验证**：不生成可执行计划，不改任何文件。
+- **升级中途失败**：保留阶段 journal 和所有备份；不得进入普通运行模式。允许按已验证阶段继续或回滚。
+- **Git common-dir 不可写**：对应 Binding 失败，其他 Binding 不得掩盖该失败。
+- **repositoryId 缺失或不一致**：首次注册可原子创建；已绑定后的缺失/不一致必须显式 rebind。
+- **旧 worktree dirty/conflicted/ahead**：原样保留并展示，不能自动 reset、stash、删除或推送。
+- **备份目标已存在**：生成新的 timestamp + nonce 目标，禁止覆盖。
+
+## Alternatives Considered
+
+- **继续 ADR-0006 的兼容读取与逐条迁移**：保留更多运行历史，但为单用户 0.x 格式引入长期双 schema、双身份和测试矩阵；本提案拒绝。
+- **启动时自动升级**：少一次确认，但会在普通启动中改 `.git`、配置和本地状态；拒绝。
+- **直接删除 v0.1 state**：最简单，但不可恢复地丢失任务与审计证据；拒绝。
+- **自动导入既有 worktree**：可能恢复部分现场，但无法可靠恢复 task ownership、Review basis 和 session；拒绝，保留显式采用入口作为未来需求。
+
+## References
+
+- [#134 WorkItemIdentity 与 ProjectBinding L3 设计](../../plans/2026-08-27-work-item-identity-project-binding-design.md)
+- [事实源与状态权威](../authority-model.md)
+- [核心数据契约](../core-contracts.md)
+- [Issue 架构门禁](0003-issue-architecture-gate.md)

--- a/docs/architecture/decisions/0009-v02-clean-break-local-state-and-config.md
+++ b/docs/architecture/decisions/0009-v02-clean-break-local-state-and-config.md
@@ -1,6 +1,6 @@
 # ADR-0009：v0.2 本地状态与配置 clean break
 
-> Status: Draft | Date: 2026-08-27 | Maintainer direction: clean break confirmed | Proposed partial supersession: [ADR-0006](0006-canonical-domain-model-and-contracts.md)
+> Status: Accepted | Date: 2026-08-27 | Partially supersedes: [ADR-0006](0006-canonical-domain-model-and-contracts.md) for v0.1 local config/state cutover | Protocol: [v0.2 本地配置与状态升级协议](../v02-upgrade-protocol.md)
 
 ## Context
 
@@ -10,7 +10,7 @@ ADR-0006 将 v0.1 的 `IssueWorkflow`、`WorkflowEvent`、`repoKey` 和 Issue UR
 
 ## Decision
 
-如果本 ADR 被接受，v0.2 按以下规则切换：
+v0.2 按以下规则切换：
 
 1. v0.2 active runtime 只接受 v0.2 `config.yaml` 和 state schema，不包含 v0.1 `repos`、`IssueWorkflow`、legacy workflow key 或 `WorkflowEvent` 的兼容读取/写入分支。
 2. 升级前将整个 `~/.clickvibe/state` 原子改名为唯一的 `~/.clickvibe/state-v0.1-backup-<timestamp>-<nonce>`；随后在原路径创建新的空 `~/.clickvibe/state`。冷备份不参与 v0.2 运行，也不自动删除。
@@ -22,9 +22,9 @@ ADR-0006 将 v0.1 的 `IssueWorkflow`、`WorkflowEvent`、`repoKey` 和 Issue UR
 
 本 ADR 只改变 v0.1 本地状态和配置的升级策略。它不改变 ADR-0006 的 provider-neutral 身份、Domain 边界、事实等级和未来事件契约。
 
-## Required Baseline Changes Before Acceptance
+## Coordinated Baseline Changes
 
-接受本 ADR 前必须在同一设计变更中同步：
+本 ADR 与以下基线在同一设计变更中同步，main 上不得只出现其中一半：
 
 - `docs/roadmap.md` 中“v0.2 保留并迁移 legacy WorkflowEvent”的要求；
 - `docs/architecture/canonical-domain-model.md`、`core-contracts.md` 和 `observability.md` 的 legacy event 排期；
@@ -32,7 +32,7 @@ ADR-0006 将 v0.1 的 `IssueWorkflow`、`WorkflowEvent`、`repoKey` 和 Issue UR
 - Issue #136 对 legacy `WorkflowEvent` 的验收标准；
 - Issue #137 对 v0.1 资产逐类迁移的范围，使其区分 active migration、cold archive 和 Git 现场处置。
 
-本地文档提案与 GitHub Issue #132、#134、#136、#137 已在 2026-08-27 按 clean break 方向同步；在本设计 PR 的 exact-SHA Review 通过并合入前，本 ADR 保持 Draft，不能作为 Coding Agent 的基线。
+本地文档提案与 GitHub Issue #132、#134、#136、#137 已在 2026-08-27 按 clean break 方向同步。ADR 文件在 PR 中标为 `Accepted`，是为了让合入后的 main 树没有治理中间态；PR 分支本身仍不是 Coding baseline，只有 exact-SHA Review 通过并合入后才生效。
 
 ## Consequences
 
@@ -75,6 +75,7 @@ ADR-0006 将 v0.1 的 `IssueWorkflow`、`WorkflowEvent`、`repoKey` 和 Issue UR
 ## References
 
 - [#134 WorkItemIdentity 与 ProjectBinding L3 设计](../../plans/2026-08-27-work-item-identity-project-binding-design.md)
+- [v0.2 本地配置与状态升级协议](../v02-upgrade-protocol.md)
 - [事实源与状态权威](../authority-model.md)
 - [核心数据契约](../core-contracts.md)
 - [Issue 架构门禁](0003-issue-architecture-gate.md)

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -11,6 +11,8 @@ ADR 记录长期有效的架构取舍，不记录普通实现步骤。每个 ADR
 - `Superseded`：由新 ADR 替代，保留用于解释历史代码。
 - `Rejected`：评估过但未采用。
 
+状态只对 `main` 中已合入的 exact SHA 生效。PR 分支中的 `Accepted` 表示“若此 exact SHA 经 Review 后合入，合入后的树应立即自洽”，不使未合入分支提前成为 Coding baseline；计划生效的 ADR 必须在合入前把文件状态和本索引一起改为 `Accepted`，避免 main 出现“Accepted 架构引用 Draft ADR”的中间态。
+
 ## 当前决策
 
 | ADR | 状态 | 决策 |
@@ -23,4 +25,4 @@ ADR 记录长期有效的架构取舍，不记录普通实现步骤。每个 ADR
 | [0006](0006-canonical-domain-model-and-contracts.md) | Accepted | provider-neutral 核心身份、Domain 自有契约与判别式事件 |
 | [0007](0007-three-git-github-access-planes.md) | Accepted | Local Git、Remote Git 与 GitHub REST 三访问平面及 Agent 调用边界 |
 | [0008](0008-deterministic-loop-guard-and-optional-runtime-observer.md) | Accepted | Loop Guard 独立停机，Runtime Observer 按数据与策略可选启用 |
-| [0009](0009-v02-clean-break-local-state-and-config.md) | Draft | maintainer 已确认 v0.2 本地 state/config clean break；待 Issue 契约同步、Review 与设计 PR 合入后生效 |
+| [0009](0009-v02-clean-break-local-state-and-config.md) | Accepted | v0.2 本地 state/config cold-backup clean break 与显式升级边界 |

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -23,3 +23,4 @@ ADR 记录长期有效的架构取舍，不记录普通实现步骤。每个 ADR
 | [0006](0006-canonical-domain-model-and-contracts.md) | Accepted | provider-neutral 核心身份、Domain 自有契约与判别式事件 |
 | [0007](0007-three-git-github-access-planes.md) | Accepted | Local Git、Remote Git 与 GitHub REST 三访问平面及 Agent 调用边界 |
 | [0008](0008-deterministic-loop-guard-and-optional-runtime-observer.md) | Accepted | Loop Guard 独立停机，Runtime Observer 按数据与策略可选启用 |
+| [0009](0009-v02-clean-break-local-state-and-config.md) | Draft | maintainer 已确认 v0.2 本地 state/config clean break；待 Issue 契约同步、Review 与设计 PR 合入后生效 |

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -53,7 +53,7 @@
 }
 ```
 
-这是目标契约，不等于 v0.2 一次实现全部事件。v0.2 先统一 DiagnosticRecord、ArtifactRef、请求指标和 legacy event 迁移语义；v0.3 为自主决策链写入完整判别式 EventEnvelope；v0.4 才以恢复和复盘为退出标准补齐全因果链。旧日志按复盘价值决定迁移、兼容读取、归档或备份后废弃，不为无价值旧格式建立永久兼容层。
+这是目标契约，不等于 v0.2 一次实现全部事件。v0.2 先统一新 state 的 DiagnosticRecord、ArtifactRef 和请求指标；v0.3 为自主决策链写入完整判别式 EventEnvelope；v0.4 才以恢复和复盘为退出标准补齐全因果链。v0.1 日志随 state 整体冷备份，不进入 v0.2 active runtime；需要复盘时只读人工提取，不为旧格式建立兼容层。
 
 ## 复盘必须回答的问题
 

--- a/docs/architecture/v02-upgrade-protocol.md
+++ b/docs/architecture/v02-upgrade-protocol.md
@@ -1,0 +1,182 @@
+# v0.2 本地配置与状态升级协议
+
+> Status: Accepted | Decision: [ADR-0009](decisions/0009-v02-clean-break-local-state-and-config.md) | Scope: v0.1 local config/state to v0.2 clean break
+
+本文是 #134 Slice 2 的实现规格。它只处理 ClickVibe 本地配置、state、仓库绑定和升级恢复；Git worktree、branch、commit、dirty/conflict 与 Provider 事实只观察、不搬迁。
+
+## 1. 事实源与不变量
+
+- v0.1 config 的原始字节、hash 和解析结果共同定义升级输入；解析失败不能按默认空配置继续。
+- v0.1 state 的路径身份、目录清单、文件数、字节数和 hash 清单定义待冷备份输入；`ENOENT` 是显式观察值，不自动等于空状态。
+- Git common-dir 与其中的 `clickvibe/repository-id` 回答 clone 身份；config 只保存 expected pin。
+- upgrade journal 是阶段事实源；文件系统回读用于验证 journal，不得用“看起来像成功”覆盖 journal 的未知或损坏状态。
+- preview 零写入；authorization 只授权一个完整 plan fingerprint。
+- authorization 后到 `verified` 或 `rolled_back` 前，升级器必须独占升级锁并持有宿主进程代次门禁。
+- 任何 unknown schema、损坏 journal、部分切换或 identity mismatch 都禁止普通 v0.1/v0.2 写入。
+- v0.1 config/state 必须成对可运行，或 v0.2 config/state 必须成对可运行；不允许把混合代次解释成空项目。
+
+## 2. 固定路径与保留策略
+
+| 资产 | 路径 |
+|---|---|
+| active config | `~/.clickvibe/config.yaml` |
+| config cold backup | `~/.clickvibe/config-v0.1-backup-<timestamp>-<nonce>.yaml` |
+| active state | `~/.clickvibe/state` |
+| state cold backup | `~/.clickvibe/state-v0.1-backup-<timestamp>-<nonce>` |
+| staged v0.2 config | `~/.clickvibe/config-v0.2-staging-<nonce>.yaml` |
+| staged v0.2 state | `~/.clickvibe/state-v0.2-staging-<nonce>` |
+| upgrade journal | `~/.clickvibe/upgrade-v0.2.json` |
+| cross-process lock | `~/.clickvibe/upgrade-v0.2.lock` |
+
+所有 backup/staging 名称在 preview 中确定并进入 fingerprint，使用 exclusive create，禁止覆盖或跟随 symlink。config backup 与 state cold backup 不自动删除；删除必须是本 Issue 之外的独立预览和授权动作。成功或回滚后 journal 仍保留用于审计。
+
+## 3. 升级锁与旧运行时代次门禁
+
+### 3.1 两种机制缺一不可
+
+升级锁负责阻止两个 v0.2 upgrader 并发。实现复用 `src/infra/workflow-persistence.ts` 的 link 型跨进程锁模式：候选文件写入完整 owner token 后通过 hard link 争抢固定锁；只在确认 owner 进程已死亡后回收 stale lock。锁 token、PID、进程启动标识和 plan fingerprint 写入 journal，模糊存活状态一律不抢锁。
+
+锁本身不能约束不认识它的 v0.1 二进制。因此 apply 还必须取得宿主提供的 generation fence：
+
+1. 阻止宿主再启动任何 v0.1 task/job 或旧插件进程；
+2. 等待现有 v0.1 host、agent 子进程和 live job 全部退出；persisted `running` 只作警告，不能代替活性检查；
+3. 在 fence 内重新枚举进程和任务，并重新计算完整 plan fingerprint；
+4. 持有 fence，直到 v0.2 bundle 已替换旧入口且升级进入 `verified`，或旧 config/state 已配对恢复为 `rolled_back`。
+
+如果安装环境不能证明“旧入口已停用且不会在临界区重启”，apply 必须拒绝，要求关闭宿主后由离线升级入口执行。直接再次运行已被替换的 v0.1 二进制属于显式 downgrade：必须先走 rollback preview/authorization，不能把 v0.2 state 当作空 v0.1 state 打开。
+
+### 3.2 临界区顺序
+
+apply 的顺序固定为：取得升级锁 → 取得 generation fence → 临界区内活性检查 → 重算 fingerprint → 写 durable journal → prepare → cutover → read-back → `verified`/`rolled_back` → 释放 fence 和锁。任何失败都保持锁和 fence，直到进程退出或进入明确终态；新进程看到未完成 journal 时只能进入 recovery。
+
+## 4. repositoryId 与 Binding 准备
+
+repositoryId 最终文件为 `<git-common-dir>/clickvibe/repository-id`。首次创建必须保证内容原子，而不只是“路径抢占成功”：
+
+1. 在同一 `clickvibe/` 目录 exclusive-create 唯一 temp；
+2. 写入完整 `repo_<UUID>`、设置权限并 fsync temp；
+3. 用 hard link 将完整 temp 竞争性发布到最终路径；
+4. fsync `clickvibe/` 目录并删除 temp；
+5. 失败者读取、校验赢家的完整内容。空、半写、格式错误或 symlink 最终文件一律 fail-closed，禁止自动覆盖。
+
+路径移动不改变 ID。`cp -r` 整个 clone 会复制 sidecar，因此 preview、启动和每次高风险动作都必须检查目标 config 内 repositoryId 唯一：同一 ID 指向不同 real common-dir 时，两条 Binding 都不可写。用户必须选择其中一个 clone 进行独立的 regenerate/rebind preview；该动作生成新 ID、重算 bindingId，并要求没有其他 Binding 仍引用旧的 common-dir/ID 配对。
+
+v0.2 active Binding 只接受有工作树的顶层 repository。bare repository 和 submodule 在当前 Slice fail-closed，不创建 ID；支持它们需要新的真实需求和边界设计。
+
+## 5. config schema 1 转换
+
+顶层 config schema 1 保留当前有效的非仓库设置：
+
+```yaml
+schemaVersion: 1
+worktreeRoot: /Users/example/.clickvibe/worktrees
+fetchTtlSeconds: 45
+diagnosticsMaxBytes: 10485760
+projectBindings: []
+```
+
+- v0.1 显式 `worktreeRoot` 规范化后原值保留；缺失时固定为 `~/.clickvibe/worktrees`。§8 worktree collision guard 只使用这个目标值。
+- `fetchTtlSeconds`、`diagnosticsMaxBytes` 在现有合法范围内原值保留；缺失则继续使用运行时默认值，非法则 preview 阻断，不静默丢弃。
+- 每个可验证的 `repos[owner/repo] = localPath` 转成一个 ProjectBinding，并显式选择/验证 `primaryRemote`。
+- 当前机器同一 container 只能有一个 active Binding，repositoryId 在目标 config 中也必须唯一。
+
+一个已删除 clone、未挂载卷或其他无法验证的 v0.1 repos 条目不再阻塞其余条目，但绝不能被静默丢弃。preview 必须逐条列为 `blocked`，用户可修复后重试，或显式选择 `exclude`；排除项的旧 key、path、观察错误、选择理由和 hash 都进入 plan fingerprint/journal。目标 config 不包含被排除条目，旧 config backup 永久保留原值。
+
+## 6. 版本轴
+
+- canonical tuple 中的 `1` 与 `wi1_`/`pb1_` 表示各自序列化 schema version；两种 tuple 独立演化。
+- config `schemaVersion: 1` 表示 config schema，和 tuple 版本、产品 v0.2 无绑定关系。
+- `sha256-v1` 表示 hash policy version；它规定 digest/base64url 细节，不等于上述任一 schema version。
+
+版本不匹配必须显式迁移，不能因数字恰好相同而联动升级。
+
+## 7. 状态机
+
+```mermaid
+stateDiagram-v2
+  [*] --> detected
+  detected --> blocked: 配置/仓库/进程不可验证
+  blocked --> detected: 修复事实或重选逐条排除
+  detected --> previewed: 只读盘点 + fingerprint
+  previewed --> detected: 事实变化
+  previewed --> authorized: 用户确认精确计划
+  authorized --> previewed: 临界区复核变化，授权失效
+  authorized --> prepared: 锁 + fence + durable prepare
+  prepared --> cutting_over: 仅执行已准备 rename
+  cutting_over --> verified: 配对回读通过
+  prepared --> failed
+  cutting_over --> failed
+  failed --> recovery_preview: 只读探测 journal + 文件系统
+  recovery_preview --> prepared: 授权 resume
+  recovery_preview --> rolled_back: 授权 rollback
+  rolled_back --> detected: 可重新升级
+  verified --> [*]
+```
+
+已存在未完成 journal 时，它优先于全新 preview。系统不得重新扫描后覆盖旧 journal，也不得假装第一次升级；只能展示 recovery preview。
+
+## 8. Preview 与 plan fingerprint
+
+preview 至少包含：baseline SHA；旧 config 原始 hash、完整目标 config、固定 backup/staging 路径；旧 state 是 present/absent/error、目录身份、文件数/字节数、cold backup；每个 Binding 的 container、real localPath、real common-dir、repositoryId、primaryRemote；重复 ID；逐条排除；宿主/进程活性；完整 `git worktree list` 现场；所有将创建、link、rename、replace 的路径。
+
+fingerprint 覆盖上述全部内容、升级器版本和预期起始 journal 状态。apply 在锁与 generation fence 内重新读取所有输入；任何变化走 `authorized → previewed`，且在 durable journal/sidecar/backup 产生前结束。
+
+## 9. Durable prepare 与 cutover
+
+### 9.1 原子持久化配方
+
+journal、config backup、staged config 和所有 schema marker 都使用同一配方：在目标同目录 exclusive-create temp → 写完整内容 → 权限收紧为不宽于原 config（新文件默认 `0600`）→ fsync 文件 → rename/link 发布 → fsync 父目录。更新 journal 使用新的唯一 temp 原子 replace，绝不原地 truncate。每个 destructive rename 前先写并 fsync `*-intent`，完成后回读真实路径再写 `*-done`。
+
+目录树准备完成后必须 fsync 其中 marker 及目录；父目录 fsync 是 cutover 成功条件，不可省略。
+
+### 9.2 prepare（不破坏 v0.1 配对）
+
+1. 创建 durable journal，记录初始 active state 是 present 还是 absent。
+2. 原子保存 config cold backup，并校验字节/hash。
+3. 为所有未排除仓库原子创建或读取 repositoryId；这些无授权能力，rollback 后允许保留。
+4. 生成 staged v0.2 config，完整解析并验证 bindingId、ID 唯一性、remote 和设置字段。
+5. 创建 staged v0.2 state、schema marker 并完整回读。
+
+prepare 任一步失败时，v0.1 config/state 仍保持原配对；只需保留 journal、config backup、合法 ID sidecar 和 staging 证据，进入 recovery。
+
+### 9.3 cutover（只剩已准备的本地 rename/replace）
+
+1. 若 preview 观察到旧 state present，写 `state-backup-intent` 后将 active state rename 到唯一 cold backup并 fsync 父目录；若最初就是 absent，则记录 `state-initially-absent`，不得执行或伪造 rename。
+2. 写 `state-activate-intent`，将 staged state rename 为 active state，fsync 父目录并回读 schema marker。
+3. 写 `config-activate-intent`，将 staged config 原子 replace active config，fsync 父目录并完整解析回读。
+4. 验证 config/state 代次配对、config pin/common-dir ID、primaryRemote、cold backup（若有）和全部排除记录；写 `verified`。
+
+所有易失败的内容生成、仓库验证和配置解析都在破坏性 state rename 前完成。cutover 中失败不尝试猜测下一步，进入 recovery。
+
+## 10. Recovery 决策表
+
+| 观察 | 结论 | 允许动作 |
+|---|---|---|
+| 无 journal；legacy config 有效；state 初始 present/absent 已明确 | 尚未 apply | 全新 preview |
+| journal 完整，阶段为 prepare，v0.1 config/state 仍配对 | prepare 未完成 | 授权 resume，或清理仅由 journal 证明的 staging 后 `rolled_back` |
+| `state-backup-intent`，active state 与 cold backup 状态不确定 | cutover 未决 | 按 inode/marker/hash 回读判定 rename 前后；不按路径缺失猜测 |
+| config 仍为 v0.1，active state 缺失，cold backup 存在 | state 已搬走但新 state 未激活 | 授权恢复 cold backup，或继续激活已验证 staging |
+| config 仍为 v0.1，active state 为 v0.2 | config 激活前失败 | 授权恢复 v0.1 state 配对，或继续原子激活已验证 staged config |
+| config 为 v0.2，active state 缺失/非 v0.2 | 非法混合代次 | 普通 runtime 全部不可写；只允许按 journal resume/rollback |
+| config/state 均为 v0.2，但 journal 未 verified | 结果未获证 | 完整 read-back 后授权 resume 写 verified；不能直接放行 |
+| journal verified 但任何 read-back 不一致 | 事后损坏/漂移 | fail-closed，生成新 recovery preview |
+| journal torn/corrupt/unknown schema，即使暂未发现其他升级资产 | 无法证明“尚未写入” | 保留原文件并进入只读 recovery inventory；只有精确回读证明 v0.1 配对未变后，才可授权重建初始 journal 或 rollback |
+| journal 缺失/损坏/未知 schema，且存在 backup/staging/混合代次证据 | 恢复依据不完整 | 保留原文件；只读 recovery inventory。用户可授权由精确 inode/path/hash 重建 journal，或选择明确 rollback |
+| repositoryId 空、半写、重复或 mismatch | Binding 身份不可信 | 对相关 Binding fail-closed；显式 regenerate/rebind preview |
+
+rollback 用 config backup 生成同目录 temp，再按 fsync + atomic replace + parent fsync 恢复；state rollback 只移动 journal 精确证明的本次 v0.2 active/staging 目录，再把 cold backup 恢复到 active path。不得递归删除不明目录。已经成功创建且格式正确的 repositoryId sidecar 保留；任何清理都只针对 journal 证明为本次创建且未承载业务数据的 staging。
+
+损坏或缺失 journal 时，recovery inventory 必须展示所有候选 config/state/backup/staging 的 inode、schema、hash、mtime 和配对判断，零写入。重建 journal 与 rollback 都需要新的精确 preview/authorization，原始损坏 journal 不得覆盖。
+
+## 11. 实现与测试门禁
+
+- 双 upgrader 竞争只能有一个锁赢家；stale recovery 不得删除新 owner 的锁。
+- 在临界区活性检查前后尝试启动 v0.1 job，generation fence 必须拒绝；无法取得 fence 时 apply 为零写入。
+- 在每次 file fsync、rename、directory fsync 和 journal replace 前后注入真实文件系统失败，证明状态可 resume 或 rollback。
+- repositoryId 在 temp write、fsync、link 和目录 fsync 各窗口崩溃后，最终文件只能是完整合法值或不存在；不得出现空/半写最终文件。
+- `cp -r` 复制 sidecar、相同 remote 的独立 clone、linked worktree、路径移动、bare repository 和 submodule 均有真实 Git 测试。
+- v0.1 `worktreeRoot`、`fetchTtlSeconds`、`diagnosticsMaxBytes` 的保留/默认/非法输入有转换测试；逐条 exclude 进入 fingerprint。
+- 覆盖 state 最初 absent、rename `ENOENT`、config/state 混合代次、journal torn/corrupt/missing/unknown、resume、rollback 和 read-back 后漂移。
+- cold backup、Git worktree、branch、commit、dirty/conflict/ahead 在成功、失败、恢复后均未被自动删除、reset、stash 或 push。
+
+实现 PR 必须遵守 `AGENTS.md` 的 state 格式红线；本设计 PR 已先将其改为“只有 Accepted ADR + 显式升级协议可授权代次切换”，避免实现门禁与 ADR-0009 自相矛盾。

--- a/docs/plans/2026-08-27-work-item-identity-project-binding-design.md
+++ b/docs/plans/2026-08-27-work-item-identity-project-binding-design.md
@@ -1,0 +1,409 @@
+# #134 WorkItemIdentity 与 ProjectBinding L3 设计
+
+> Status: Draft | Maintainer direction: clean break confirmed | Issue: [#134](https://github.com/ai-daming/clickvibe/issues/134) | Code baseline: `dc19103fa67bfbea60010038117f971f1e68d930` | Architecture baseline: `9f841f1bc93604e8d802e3776997016140840e47` | Required decision: [ADR-0009](../architecture/decisions/0009-v02-clean-break-local-state-and-config.md)
+
+## 0. 结论
+
+#134 不只是新增四个字符串类型。它要把当前同时承担身份职责的 `repoKey`、Issue URL、workflow key 和本地 path 拆开，并建立两个唯一回答：
+
+- “这是哪个外部 Work Item”只由 `WorkItemIdentity(provider, instance, container, id)` 回答；
+- “这台机器用哪个 Git clone 执行”只由 `ProjectBinding` 回答。
+
+本设计选择 v0.2 clean break：v0.1 state 冷备份，新的空 v0.2 state 继续使用 `~/.clickvibe/state`；旧 Git worktree/branch 原样保留但不自动导入。它推翻了已发布基线中的 legacy event 迁移要求；本地文档与 GitHub Issue #132、#134、#136、#137 已作为一组协调提案同步，但在 ADR-0009 与本设计 PR 的 exact-SHA review 通过并合入前，本文仍是 Draft，禁止 Coding。
+
+## 1. 范围
+
+### 1.1 目标
+
+1. 落地 provider-neutral `WorkItemIdentity`，并成为领域层唯一 Work Item 身份。
+2. 落地机器本地 `ProjectBinding`，明确 provider container、clone-stable `repositoryId`、当前 path 与显式 primary remote。
+3. 定义 canonical serialization、hash、持久化 key 和冲突校验。
+4. 定义 v0.1 → v0.2 配置/state clean-break 升级的事实源、不变量、阶段、失败和回滚。
+5. 为 #122、#131、#135 和 #136 提供稳定作用域，不提前实现这些 Issue。
+
+### 1.2 非目标
+
+- 不实现跨机器注册、心跳、远程下单、任务迁移或执行地选择。
+- 不改变 GitHub rename 语义；需要改变 `container` 稳定性时另立 superseding ADR。
+- 不实现 WorkItemContractSnapshot、三个访问平面或 v0.3 EventEnvelope。
+- 不自动迁移、删除、reset、stash 或 push 旧 worktree/branch。
+- 不把本地 `repositoryId`、`bindingId` 或 host identity 放进 WorkItemIdentity。
+- 不保留 v0.1 active runtime 的 state/config 兼容解析器；该点必须先由 ADR-0009 生效。
+
+## 2. 现状事实与问题
+
+当前 `IssueWorkflow` 同时持有：
+
+```ts
+interface IssueWorkflow {
+  key: string
+  url: string
+  repoKey: string
+  worktree: string
+  branch: string
+  // task/review/delivery/events ...
+}
+```
+
+仓库中约有 95 处 `repoKey` 使用、22 个 `issueKey(...)` 调用；`config.yaml` 使用未版本化的 `owner/repo -> localPath` 映射。当前 state path 又从 `repoKey + Issue URL number` 推导。结果是：
+
+- URL、repoKey、workflow key 和 path 都在不同位置冒充身份；
+- GitHub number 验证渗入 workflow/infra；
+- 相同 remote 的不同 clone 无法形成独立本地作用域；
+- path 移动会影响绑定，remote 相同又可能错误合并 clone；
+- 新旧 key 并存时没有唯一冲突应答源。
+
+Git/GitHub 仍是代码、worktree、refs、Issue、PR、Review 和 CI 的权威；ProjectBinding 只是机器本地配置，不能提升事实等级。
+
+## 3. 已确认决策与取舍
+
+| 决策 | 采用 | 拒绝及原因 |
+|---|---|---|
+| Work Item 权威 | v0.2 领域层只认 WorkItemIdentity | types-only facade 会让 repoKey 继续当第二身份源 |
+| repositoryId 单位 | 一个真实 clone 一个 ID；其 worktree 共用 | remote 级 ID 会合并独立 clone；path 级 ID 会随移动漂移 |
+| repositoryId 存储 | Git common-dir 的 `clickvibe/repository-id` | config-only 无法证明 path 指向原 clone；path/remote hash 不稳定或不隔离 |
+| v0.1 state | 整体冷备份；新 state 仍为 `~/.clickvibe/state` | 永久兼容增加双 schema；直接删除不可恢复 |
+| 多机器 | 同 container 可有多个 Binding；每台机器当前启用一个 | 当前实现 clone picker 或远程调度是无消费者设计 |
+| config | 显式授权后一次性转 v0.2 schema | 永久兼容 `repos` 把 legacy 债务带回运行时 |
+| primary remote | Binding 明确保存 | upstream/顺序自动猜测会把读写路由到不同 remote |
+| Binding mismatch | fail-closed + explicit rebind | 自动改 config 或仓库 ID 会把错误绑定伪装为成功 |
+| 升级触发 | detect → preview → authorize → apply → read-back | 启动时隐式升级越过用户授权；手工改文件易错 |
+| 旧 worktree | 保留、不导入；碰撞时阻止新任务 | 自动导入无法恢复写凭证/Review basis；删除会丢真实代码 |
+
+## 4. 权威与不变量
+
+### 4.1 权威表
+
+| 问题 | 唯一应答源 | 其他数据的角色 |
+|---|---|---|
+| 外部 Work Item 是谁 | Provider Adapter 产出的 WorkItemIdentity | URL/displayKey 是 locator/展示 |
+| 本地 clone 是谁 | Git common-dir 中的 repositoryId 文件 | config 中的值是 expected pin |
+| container 绑定哪个 clone | 当前机器 v0.2 config 的 ProjectBinding | localPath 是 locator，可变化 |
+| primary remote 是谁 | ProjectBinding.primaryRemote | current upstream 只作观察，不自动覆盖 |
+| worktree/branch/dirty/conflict | 本地 Git | state 只保存观察或关联线索 |
+| Issue/PR/Review/CI | Provider（当前 GitHub） | state/cache 不能覆盖 Provider |
+| v0.2 task/session/log | 新 `~/.clickvibe/state` | v0.1 冷备份不授权动作 |
+
+### 4.2 强制不变量
+
+1. 四元组全部是非空字符串；GitHub number 只在 GitHub Adapter 转为十进制字符串。
+2. core 不从 URL 猜 provider、instance、container 或 id。
+3. WorkItemIdentity 不含 host、path、remote、repositoryId、branch 或 run id。
+4. 一个 Git common-dir 只有一个 repositoryId；主 checkout 与 linked worktree 必须读到同一值。
+5. 不同 clone 即使 primary remote URL 相同，也不得共用 repositoryId。
+6. 当前机器同一 container 最多一个 active Binding；系统层允许其他机器拥有不同 Binding。
+7. config pin、common-dir repositoryId、bindingId 推导必须一致；不一致时所有 Git 写和 Provider 写 fail-closed。
+8. primaryRemote 必须存在于目标 clone；不得因当前 branch upstream 改变而漂移。
+9. preview 阶段零写入；authorization 只覆盖 preview 指纹绑定的精确升级计划。
+10. v0.1 state 冷备份和 Git 现场不被自动删除；新 v0.2 runtime 不读取冷备份授权动作。
+11. 既有 worktree/path/branch 冲突时拒绝创建或覆盖；dirty、conflicted、ahead 均保持原样。
+12. unknown schema、损坏记录、缺失 identity 或部分升级不能解释成空状态或成功。
+
+## 5. 核心契约
+
+### 5.1 WorkItemIdentity
+
+沿用 ADR-0006：
+
+```ts
+interface WorkItemIdentity {
+  provider: string
+  instance: string
+  container: string
+  id: string
+}
+```
+
+Provider Adapter 负责 provider-specific normalization；core serializer 不自行 trim、lowercase 或解释字段。GitHub Adapter 至少保证：
+
+- `provider = "github"`；
+- `instance` 为规范化 host；
+- `container` 使用 Adapter 返回的 canonical owner/repository 表达；
+- `id` 为正整数的十进制字符串。
+
+### 5.2 Canonical serialization 与 key
+
+序列化输入固定为无空白 JSON array：
+
+```json
+["clickvibe.work-item-identity",1,"github","github.com","ai-daming/clickvibe","134"]
+```
+
+规则：
+
+- UTF-8；
+- 固定 array 顺序，不按对象键枚举；
+- 四字段缺失、空串或非字符串直接拒绝；
+- JSON escaping 负责换行、引号和反斜杠，不使用分隔符拼接；
+- hash algorithm version 固定为 `sha256-v1`；
+- durable key 为 `wi1_<sha256 bytes 的 base64url>`。
+
+state root 使用：
+
+```text
+~/.clickvibe/state/work-items/<durable-key>/
+```
+
+根记录必须同时保存完整 WorkItemIdentity；读取时重算 key 并核对，避免 hash/path 被当作无需验证的身份。
+
+### 5.3 Repository identity
+
+真实位置通过以下命令获得，不得拼接字面量 `.git`：
+
+```bash
+git rev-parse --path-format=absolute --git-common-dir
+```
+
+repositoryId 文件：
+
+```text
+<git-common-dir>/clickvibe/repository-id
+```
+
+首次注册用 exclusive create 原子生成 `repo_<UUID>`；已存在时只读并验证格式，禁止覆盖。并发注册只能有一个创建者，其他调用读取赢家结果。路径移动不改变 ID；重新 clone 得到新的 common-dir 和新的 ID。
+
+### 5.4 ProjectBinding 与 config
+
+运行时契约沿用 core-contracts：
+
+```ts
+interface ProjectBinding {
+  schemaVersion: 1
+  bindingId: string
+  container: {
+    provider: string
+    instance: string
+    id: string
+  }
+  repository: {
+    repositoryId: string
+    localPath: string
+    primaryRemote: string
+  }
+}
+```
+
+bindingId 对以下 canonical tuple 计算 `sha256-v1`：
+
+```json
+["clickvibe.project-binding",1,"github","github.com","ai-daming/clickvibe","repo_<UUID>"]
+```
+
+config v0.2 示例（这是第一版带版本的 config schema，因此从 `1` 开始；不与产品版本号绑定）：
+
+```yaml
+schemaVersion: 1
+projectBindings:
+  - schemaVersion: 1
+    bindingId: pb1_<base64url-sha256>
+    container:
+      provider: github
+      instance: github.com
+      id: ai-daming/clickvibe
+    repository:
+      repositoryId: repo_<UUID>
+      localPath: /Users/example/work/clickvibe
+      primaryRemote: origin
+```
+
+config 中的 repositoryId 是 expected pin，不是 clone 身份源。启动和每次高风险动作前至少验证：path 是 Git repository、common-dir ID 匹配、primaryRemote 存在。缺少 Binding 时 Provider 只读展示仍可用，需要 worktree/Git 的动作不可用。
+
+## 6. 数据流
+
+### 6.1 Provider Work Item
+
+```mermaid
+flowchart LR
+  raw[GitHub URL / REST item] --> adapter[GitHub Adapter 验证与规范化]
+  adapter --> identity[WorkItemIdentity]
+  identity --> key[canonical serialization + wi1 hash]
+  key --> state[v0.2 state lookup]
+  identity --> binding[按 container 查当前机器 Binding]
+  binding --> git[验证 repositoryId + remote]
+```
+
+workflow、cache、authorization、diagnostic 和后续 access plane 只接收 identity/key，不自行解析 URL 或重造 repoKey。
+
+### 6.2 多机器边界
+
+同一 Work Item 在 Mac 与 Ubuntu 上得到相同四元组；两台机器各自拥有不同 repositoryId/bindingId。当前版本不引入 host registry。未来执行路由可使用 `hostId + bindingId`，但 hostId 不进入 WorkItemIdentity，也不改变本设计的 key。
+
+## 7. v0.1 → v0.2 显式升级
+
+全新安装没有 legacy config/state 时不进入升级状态机：通过同样的 Binding preview/authorization 创建 repositoryId、schema 1 config 和空 state。只有检测到未版本化 config、v0.1 state 或未完成 upgrade journal 时，才进入以下升级流程并阻止普通写操作。
+
+### 7.1 原子边界
+
+state rename、config replace 和多个 Git common-dir 写入无法组成单个文件系统原子事务。升级必须用位于 active state 之外的 journal：
+
+```text
+~/.clickvibe/upgrade-v0.2.json
+```
+
+journal 带 schemaVersion、plan fingerprint、授权标识、每阶段状态、目标/备份路径和原始错误。只有 journal 为 `verified` 且所有 read-back 通过时，普通 v0.2 runtime 才可写入。
+
+### 7.2 状态机
+
+```mermaid
+stateDiagram-v2
+  [*] --> detected
+  detected --> previewed: 只读盘点 + 计划指纹
+  previewed --> authorized: 用户确认精确计划
+  authorized --> backed_up: config/state 备份
+  backed_up --> repositories_bound: 原子创建/读取 repo IDs
+  repositories_bound --> config_written: 写 v0.2 config
+  config_written --> state_created: 创建新 ~/.clickvibe/state
+  state_created --> verified: 逐项回读
+  verified --> [*]
+  backed_up --> failed
+  repositories_bound --> failed
+  config_written --> failed
+  state_created --> failed
+```
+
+### 7.3 Preview 内容
+
+preview 至少显示：
+
+- code/architecture baseline SHA；
+- 旧 config hash、目标 config 完整内容和备份路径；
+- 旧 state 路径、文件数/字节数、目标冷备份路径和新 state 路径；
+- 每个 Binding 的 container、localPath、common-dir、repositoryId 现状、primaryRemote；
+- live process/job 检查；
+- `git worktree list` 中每个 worktree 的 path、branch、HEAD、dirty/conflict、ahead/behind；
+- 会被写入、创建、rename 的每个路径；
+- plan fingerprint 和明确不可逆项（本方案无自动删除）。
+
+执行前重新读取 config hash、state identity 和 worktree inventory；与 preview 不同则授权失效，必须重新预览。
+
+### 7.4 Apply 与 read-back
+
+1. 再次确认没有 live task/job；旧 persisted `running` 只作为警告。
+2. 写入 upgrade journal，并保存旧 config 备份。
+3. 将旧 state rename 到唯一 cold-backup 目标；禁止覆盖。
+4. 为每个已验证 repository 原子创建或读取 repositoryId。
+5. 写临时 v0.2 config、设置权限、fsync/rename，再完整解析回读。
+6. 创建新的空 `~/.clickvibe/state` 和 schema marker。
+7. 验证 config pin/common-dir ID、primaryRemote、新 state schema 和 cold backup 可读。
+8. journal 标记 `verified`；此后才允许普通写操作。
+
+升级不删除旧 config backup、cold state backup、worktree、branch 或 remote ref。
+
+### 7.5 失败与恢复
+
+| 失败 | 系统状态 | 恢复 |
+|---|---|---|
+| preview 前配置/仓库无效 | 零写入 | 修复事实后重新 preview |
+| 授权后 config/state 已变化 | 零业务写入 | 授权失效，重新 preview |
+| state backup rename 失败 | 旧运行态不变 | 保留错误，停止 |
+| 部分 repo ID 已创建 | 旧 state 已备份，ID sidecar 可存在 | journal 记录；重试读取同一 ID，不覆盖 |
+| v0.2 config 写失败 | 不进入普通 runtime | 从 config backup 回滚；按 journal 恢复旧 state 路径或继续 |
+| 新 state 创建/验证失败 | cold backup 保留 | 删除仅限本次创建且经 journal 证明的空/无效新目录，再恢复或重试 |
+| read-back 不一致 | fail-closed | 不猜测成功；人工选择 resume/rollback |
+| repositoryId mismatch | Binding 不可写 | 显式 rebind，新 preview/authorization |
+| worktree dirty/conflicted/ahead | Git 现场原样保留 | 不阻塞升级，但阻止冲突的新任务，逐个处理 |
+
+回滚不会删除已成功创建的 repositoryId sidecar；它没有授予动作的能力，后续注册可复用。回滚必须恢复旧 config 与旧 state 路径的配对，不能产生两个 active state。
+
+## 8. 旧 worktree 与新任务
+
+v0.2 启动时从 Git 实时读取 worktree/branch，而不是从 cold state 推断。若目标 Issue 的默认 worktree path、branch 或 Git branch 已存在：
+
+- 展示实际 path、branch、HEAD 和 dirty/conflict/ahead 状态；
+- 禁止覆盖、reset、stash、删除、自动 push 或自动关联为当前 workflow；
+- 返回 `existing-unmanaged-worktree`（命名可在实现中确定）的明确阻断；
+- “采用”旧现场属于新的显式动作，必须重新观察 Issue/PR/HEAD、建立新 v0.2 workflow，并让旧 Review/授权失效。本 Issue 不实现采用动作。
+
+## 9. 安全与运维要求
+
+- `config.yaml` 和 upgrade journal 权限不得放宽；repositoryId 不是 secret，但仍禁止通过不受控 symlink 写出 common-dir。
+- 所有路径来自 Git/config 验证结果，不拼接未验证 shell 字符串。
+- primaryRemote 是显式名字；写动作仍需各自授权和远端回读，Binding 验证不授予 push/merge 权限。
+- 原始升级错误写入 journal/diagnostic；分类不能覆盖错误文本、动作和目标。
+- 普通启动检测到旧 schema、未完成 journal 或 Binding mismatch 时必须可解释地拒绝写，而不是显示为空项目。
+
+## 10. TDD 与验证矩阵
+
+### 10.1 纯逻辑 RED
+
+- WorkItemIdentity 四字段缺失、空串、非字符串拒绝。
+- GitHub Adapter 的数字边界与 provider-neutral core 分离。
+- canonical JSON 对引号、反斜杠、换行和字段边界无碰撞。
+- 相同 identity 得到相同 `wi1` key；任一字段变化 key 变化。
+- bindingId 对 path/primaryRemote 变化保持稳定，对 repositoryId/container 变化失效。
+- config pin/common-dir ID/remote 校验返回明确 unknown/error，不返回 false success。
+
+### 10.2 真实 Git 集成 RED
+
+使用临时 HOME 和真实 Git repository，不引入 mock library：
+
+- 主 checkout 与 linked worktree 读取同一 repositoryId；
+- 两个相同 remote 的独立 clone 得到不同 ID；
+- repository 目录移动后 ID 不变；
+- 并发首次注册只产生一个 ID；
+- 已存在无效/不一致 ID fail-closed；
+- 显式 primaryRemote 缺失时 Binding 不可写；
+- dirty/conflicted/ahead worktree 在 preview/apply 后字节、HEAD、refs 不变。
+
+### 10.3 升级集成 RED
+
+- preview 对 config、state、common-dir、worktree 零写入；
+- plan fingerprint 绑定全部目标，任一事实变化使授权失效；
+- 成功升级生成 config backup、cold state backup、新同路径 state 和 verified journal；
+- 每个 apply 阶段注入真实文件系统失败，证明可重试或可回滚；
+- 旧 config/state 不被 v0.2 active runtime 兼容读取；
+- 未完成 journal、未知 schema、live task、ID mismatch 均阻止写；
+- 备份目标重名不覆盖；cold backup 永不自动删除；
+- 既有 worktree/branch 不被导入或清理，新任务碰撞时明确拒绝。
+
+### 10.4 工程门禁
+
+实现 PR 必须通过：
+
+```bash
+pnpm run typecheck
+pnpm run build
+pnpm test
+pnpm run coverage
+pnpm run lint
+pnpm run check:size
+pnpm run check:layers
+pnpm run check:state-writes
+```
+
+覆盖率保持 statements/lines/branches/functions 全部满足仓库阈值；Review 绑定实现 PR exact head 与本设计合入后的 baseline SHA。
+
+## 11. 实施切片与门禁
+
+### Slice 0：架构生效（本设计 PR）
+
+- 审查 ADR-0009；
+- 若接受，同步 roadmap、canonical-domain-model、core-contracts、observability、#136 和 #137；
+- 更新 #134 的架构影响等级、baseline SHA、约束和验收；
+- 合入后记录 exact architecture baseline SHA。
+
+### Slice 1：纯身份与 Binding 契约
+
+- 先写 canonicalization/hash/config validation RED；
+- 最小实现 WorkItemIdentity、repositoryId、ProjectBinding 纯契约与 infra adapter；
+- 不混入三个访问平面。
+
+### Slice 2：显式升级器与 state cutover
+
+- 先写 preview/apply/recovery 和真实 Git/文件系统 RED；
+- 实现 journal、备份、config 转换、新 state 创建和 read-back；
+- 保留 worktree collision guard，不实现旧现场采用。
+
+Slice 1/2 是否拆为两个实现 PR，由设计 PR Review 根据实际 diff 与迁移原子边界决定；不得把设计变更和功能实现放进同一 PR。
+
+## 12. 完成标准
+
+本文可从 Draft 进入 implementation-ready 的前提是：
+
+1. ADR-0009 被明确 Accepted，且所有 Required Baseline Changes 同步合入；或维护者撤回 clean-break 决策，本文按 ADR-0006 重写迁移部分。
+2. #134 body 明确 L3、Accepted baseline SHA、事实源、不变量、迁移和回滚入口。
+3. Review 证明 WorkItemIdentity/ProjectBinding 没有泄漏 GitHub 专属响应类型或 host identity。
+4. 升级协议对每个写目标有 preview、authorization、journal、read-back 和恢复路径。
+5. 旧 worktree/branch 的保留边界与碰撞阻断有真实 Git 测试。
+
+在以上条件满足前，#134 仍是设计阶段，不得开始 Coding。

--- a/docs/plans/2026-08-27-work-item-identity-project-binding-design.md
+++ b/docs/plans/2026-08-27-work-item-identity-project-binding-design.md
@@ -1,6 +1,6 @@
 # #134 WorkItemIdentity 与 ProjectBinding L3 设计
 
-> Status: Draft | Maintainer direction: clean break confirmed | Issue: [#134](https://github.com/ai-daming/clickvibe/issues/134) | Code baseline: `dc19103fa67bfbea60010038117f971f1e68d930` | Architecture baseline: `9f841f1bc93604e8d802e3776997016140840e47` | Required decision: [ADR-0009](../architecture/decisions/0009-v02-clean-break-local-state-and-config.md)
+> Status: Review candidate | Maintainer direction: clean break confirmed | Issue: [#134](https://github.com/ai-daming/clickvibe/issues/134) | Code baseline: `dc19103fa67bfbea60010038117f971f1e68d930` | Architecture baseline: `9f841f1bc93604e8d802e3776997016140840e47` | Required decision: [ADR-0009](../architecture/decisions/0009-v02-clean-break-local-state-and-config.md) | Upgrade protocol: [v0.2 本地配置与状态升级协议](../architecture/v02-upgrade-protocol.md)
 
 ## 0. 结论
 
@@ -9,7 +9,7 @@
 - “这是哪个外部 Work Item”只由 `WorkItemIdentity(provider, instance, container, id)` 回答；
 - “这台机器用哪个 Git clone 执行”只由 `ProjectBinding` 回答。
 
-本设计选择 v0.2 clean break：v0.1 state 冷备份，新的空 v0.2 state 继续使用 `~/.clickvibe/state`；旧 Git worktree/branch 原样保留但不自动导入。它推翻了已发布基线中的 legacy event 迁移要求；本地文档与 GitHub Issue #132、#134、#136、#137 已作为一组协调提案同步，但在 ADR-0009 与本设计 PR 的 exact-SHA review 通过并合入前，本文仍是 Draft，禁止 Coding。
+本设计选择 v0.2 clean break：v0.1 state 冷备份，新的空 v0.2 state 继续使用 `~/.clickvibe/state`；旧 Git worktree/branch 原样保留但不自动导入。它推翻了已发布基线中的 legacy event 迁移要求；本地文档与 GitHub Issue #132、#134、#136、#137 已作为一组协调提案同步。PR 分支不是架构事实源；只有 exact-SHA review 通过并合入 `main` 后，这组 `Accepted` 文档才成为 Coding baseline。
 
 ## 1. 范围
 
@@ -45,7 +45,7 @@ interface IssueWorkflow {
 }
 ```
 
-仓库中约有 95 处 `repoKey` 使用、22 个 `issueKey(...)` 调用；`config.yaml` 使用未版本化的 `owner/repo -> localPath` 映射。当前 state path 又从 `repoKey + Issue URL number` 推导。结果是：
+当前 `src/` 中 `repoKey` 分布在 39 个文件、262 行、共 290 次文本匹配，另有 22 行 `issueKey(...)` 调用；口径分别由 `rg -l 'repoKey' src`、`rg -n 'repoKey' src`、`rg -o 'repoKey' src` 和 `rg -n 'issueKey\(' src` 复核。`config.yaml` 使用未版本化的 `owner/repo -> localPath` 映射。当前 state path 又从 `repoKey + Issue URL number` 推导。结果是：
 
 - URL、repoKey、workflow key 和 path 都在不同位置冒充身份；
 - GitHub number 验证渗入 workflow/infra；
@@ -98,6 +98,9 @@ Git/GitHub 仍是代码、worktree、refs、Issue、PR、Review 和 CI 的权威
 10. v0.1 state 冷备份和 Git 现场不被自动删除；新 v0.2 runtime 不读取冷备份授权动作。
 11. 既有 worktree/path/branch 冲突时拒绝创建或覆盖；dirty、conflicted、ahead 均保持原样。
 12. unknown schema、损坏记录、缺失 identity 或部分升级不能解释成空状态或成功。
+13. apply 从授权复核到 `verified`/`rolled_back` 必须持有跨进程升级锁与宿主 generation fence；单靠新版本锁不能声称阻止旧二进制。
+14. journal 与 config/state 必须内容原子且 durable；路径存在不等于内容完整，rename 成功不等于父目录已经持久化。
+15. 同机目标 config 中 repositoryId 必须唯一；复制 clone 产生的重复 ID 必须显式 regenerate/rebind，禁止静默认作同一 clone。
 
 ## 5. 核心契约
 
@@ -135,8 +138,10 @@ Provider Adapter 负责 provider-specific normalization；core serializer 不自
 - 固定 array 顺序，不按对象键枚举；
 - 四字段缺失、空串或非字符串直接拒绝；
 - JSON escaping 负责换行、引号和反斜杠，不使用分隔符拼接；
-- hash algorithm version 固定为 `sha256-v1`；
+- hash policy version 固定为 `sha256-v1`；它与 tuple、config 和产品版本各自独立；
 - durable key 为 `wi1_<sha256 bytes 的 base64url>`。
+
+tuple 中的 `1` 与 `wi1_`/`pb1_` 表示各自 canonical serialization schema；config `schemaVersion: 1` 只表示 config schema；`sha256-v1` 只表示 hash policy。三根版本轴数字相同不代表联动升级。
 
 state root 使用：
 
@@ -160,7 +165,9 @@ repositoryId 文件：
 <git-common-dir>/clickvibe/repository-id
 ```
 
-首次注册用 exclusive create 原子生成 `repo_<UUID>`；已存在时只读并验证格式，禁止覆盖。并发注册只能有一个创建者，其他调用读取赢家结果。路径移动不改变 ID；重新 clone 得到新的 common-dir 和新的 ID。
+首次注册生成 `repo_<UUID>` 时，必须先在同目录 exclusive-create temp、写完整内容并 fsync，再用 hard link 竞争性发布最终路径并 fsync 父目录；不能把 `O_EXCL open` 与“内容原子”混为一谈。已存在时只读并验证完整格式，禁止覆盖；空/半写/symlink 文件 fail-closed。并发注册只能有一个发布者，其他调用读取赢家结果。路径移动不改变 ID；重新 clone 得到新的 common-dir 和新的 ID。
+
+preview、启动和高风险动作必须检查目标 config 内 repositoryId 唯一。同一 ID 指向不同 real common-dir（典型原因是 `cp -r` clone）时，两条 Binding 都不可写，必须显式 regenerate/rebind 其中一个 clone。当前 Slice 只接受带工作树的顶层 repository；bare repository 和 submodule fail-closed。
 
 ### 5.4 ProjectBinding 与 config
 
@@ -193,6 +200,9 @@ config v0.2 示例（这是第一版带版本的 config schema，因此从 `1` �
 
 ```yaml
 schemaVersion: 1
+worktreeRoot: /Users/example/.clickvibe/worktrees
+fetchTtlSeconds: 45
+diagnosticsMaxBytes: 10485760
 projectBindings:
   - schemaVersion: 1
     bindingId: pb1_<base64url-sha256>
@@ -206,7 +216,7 @@ projectBindings:
       primaryRemote: origin
 ```
 
-config 中的 repositoryId 是 expected pin，不是 clone 身份源。启动和每次高风险动作前至少验证：path 是 Git repository、common-dir ID 匹配、primaryRemote 存在。缺少 Binding 时 Provider 只读展示仍可用，需要 worktree/Git 的动作不可用。
+config 中的 repositoryId 是 expected pin，不是 clone 身份源。v0.1 的合法 `worktreeRoot`、`fetchTtlSeconds`、`diagnosticsMaxBytes` 在转换中保留；`worktreeRoot` 缺失时目标值固定为 `~/.clickvibe/worktrees`，也是 worktree collision guard 的唯一根路径。启动和每次高风险动作前至少验证：path 是带工作树的顶层 Git repository、common-dir ID 匹配且同机唯一、primaryRemote 存在。缺少 Binding 时 Provider 只读展示仍可用，需要 worktree/Git 的动作不可用。
 
 ## 6. 数据流
 
@@ -230,80 +240,17 @@ workflow、cache、authorization、diagnostic 和后续 access plane 只接收 i
 
 ## 7. v0.1 → v0.2 显式升级
 
-全新安装没有 legacy config/state 时不进入升级状态机：通过同样的 Binding preview/authorization 创建 repositoryId、schema 1 config 和空 state。只有检测到未版本化 config、v0.1 state 或未完成 upgrade journal 时，才进入以下升级流程并阻止普通写操作。
+[v0.2 本地配置与状态升级协议](../architecture/v02-upgrade-protocol.md)是 Slice 2 的规范性实现规格；本节只保留决策摘要，避免历史 plan 与当前架构各自维护一套恢复规则。
 
-### 7.1 原子边界
+全新安装没有 legacy config/state 时不进入 legacy 状态机，但创建 Binding、repositoryId、schema 1 config 和空 state 仍走 preview/authorization。检测到未版本化 config、v0.1 state 或未完成/损坏 journal 时，普通写操作全部阻断。
 
-state rename、config replace 和多个 Git common-dir 写入无法组成单个文件系统原子事务。升级必须用位于 active state 之外的 journal：
+升级不是“先检查再搬目录”：apply 必须先取得跨进程升级锁和宿主 generation fence，在临界区重新确认旧进程不能启动并重算 fingerprint。单靠 v0.2 新锁无法约束旧二进制；无法停用旧入口的环境必须退出宿主并使用离线升级。
 
-```text
-~/.clickvibe/upgrade-v0.2.json
-```
+所有易失败准备先完成：durable journal、精确 config backup、内容原子的 repositoryId、可完整解析的 staged config、带 marker 的 staged state。只有准备全部回读通过，才允许把旧 state rename 到 cold backup、激活 staged state、原子替换 config。每次 journal/config/marker 写入都使用同目录 temp + file fsync + rename/link + parent-directory fsync。
 
-journal 带 schemaVersion、plan fingerprint、授权标识、每阶段状态、目标/备份路径和原始错误。只有 journal 为 `verified` 且所有 read-back 通过时，普通 v0.2 runtime 才可写入。
+状态机显式包含 facts changed 后 `authorized → previewed`、prepare/cutover 失败后的 recovery preview、以及经新授权的 resume/rollback。未完成 journal 优先于全新 preview；journal torn/corrupt/missing/unknown 或 config/state 混合代次都只能进入只读 recovery inventory，不能解释成空项目。
 
-### 7.2 状态机
-
-```mermaid
-stateDiagram-v2
-  [*] --> detected
-  detected --> previewed: 只读盘点 + 计划指纹
-  previewed --> authorized: 用户确认精确计划
-  authorized --> backed_up: config/state 备份
-  backed_up --> repositories_bound: 原子创建/读取 repo IDs
-  repositories_bound --> config_written: 写 v0.2 config
-  config_written --> state_created: 创建新 ~/.clickvibe/state
-  state_created --> verified: 逐项回读
-  verified --> [*]
-  backed_up --> failed
-  repositories_bound --> failed
-  config_written --> failed
-  state_created --> failed
-```
-
-### 7.3 Preview 内容
-
-preview 至少显示：
-
-- code/architecture baseline SHA；
-- 旧 config hash、目标 config 完整内容和备份路径；
-- 旧 state 路径、文件数/字节数、目标冷备份路径和新 state 路径；
-- 每个 Binding 的 container、localPath、common-dir、repositoryId 现状、primaryRemote；
-- live process/job 检查；
-- `git worktree list` 中每个 worktree 的 path、branch、HEAD、dirty/conflict、ahead/behind；
-- 会被写入、创建、rename 的每个路径；
-- plan fingerprint 和明确不可逆项（本方案无自动删除）。
-
-执行前重新读取 config hash、state identity 和 worktree inventory；与 preview 不同则授权失效，必须重新预览。
-
-### 7.4 Apply 与 read-back
-
-1. 再次确认没有 live task/job；旧 persisted `running` 只作为警告。
-2. 写入 upgrade journal，并保存旧 config 备份。
-3. 将旧 state rename 到唯一 cold-backup 目标；禁止覆盖。
-4. 为每个已验证 repository 原子创建或读取 repositoryId。
-5. 写临时 v0.2 config、设置权限、fsync/rename，再完整解析回读。
-6. 创建新的空 `~/.clickvibe/state` 和 schema marker。
-7. 验证 config pin/common-dir ID、primaryRemote、新 state schema 和 cold backup 可读。
-8. journal 标记 `verified`；此后才允许普通写操作。
-
-升级不删除旧 config backup、cold state backup、worktree、branch 或 remote ref。
-
-### 7.5 失败与恢复
-
-| 失败 | 系统状态 | 恢复 |
-|---|---|---|
-| preview 前配置/仓库无效 | 零写入 | 修复事实后重新 preview |
-| 授权后 config/state 已变化 | 零业务写入 | 授权失效，重新 preview |
-| state backup rename 失败 | 旧运行态不变 | 保留错误，停止 |
-| 部分 repo ID 已创建 | 旧 state 已备份，ID sidecar 可存在 | journal 记录；重试读取同一 ID，不覆盖 |
-| v0.2 config 写失败 | 不进入普通 runtime | 从 config backup 回滚；按 journal 恢复旧 state 路径或继续 |
-| 新 state 创建/验证失败 | cold backup 保留 | 删除仅限本次创建且经 journal 证明的空/无效新目录，再恢复或重试 |
-| read-back 不一致 | fail-closed | 不猜测成功；人工选择 resume/rollback |
-| repositoryId mismatch | Binding 不可写 | 显式 rebind，新 preview/authorization |
-| worktree dirty/conflicted/ahead | Git 现场原样保留 | 不阻塞升级，但阻止冲突的新任务，逐个处理 |
-
-回滚不会删除已成功创建的 repositoryId sidecar；它没有授予动作的能力，后续注册可复用。回滚必须恢复旧 config 与旧 state 路径的配对，不能产生两个 active state。
+无效 repos 条目必须逐条修复或显式 exclude，选择与原因进入 fingerprint；旧 config backup 保留完整原值。固定备份路径为 `config-v0.1-backup-<timestamp>-<nonce>.yaml` 与 `state-v0.1-backup-<timestamp>-<nonce>`，均不自动删除。
 
 ## 8. 旧 worktree 与新任务
 
@@ -339,9 +286,10 @@ v0.2 启动时从 Git 实时读取 worktree/branch，而不是从 cold state 推
 
 - 主 checkout 与 linked worktree 读取同一 repositoryId；
 - 两个相同 remote 的独立 clone 得到不同 ID；
+- `cp -r` 复制出的重复 repositoryId 在目标 config 校验时 fail-closed，显式 regenerate 后恢复唯一；
 - repository 目录移动后 ID 不变；
-- 并发首次注册只产生一个 ID；
-- 已存在无效/不一致 ID fail-closed；
+- 并发首次注册只产生一个完整 ID；temp write/fsync/link 各窗口失败不能留下空/半写最终文件；
+- 已存在无效/不一致/symlink ID fail-closed；bare repository 与 submodule 不注册；
 - 显式 primaryRemote 缺失时 Binding 不可写；
 - dirty/conflicted/ahead worktree 在 preview/apply 后字节、HEAD、refs 不变。
 
@@ -349,8 +297,12 @@ v0.2 启动时从 Git 实时读取 worktree/branch，而不是从 cold state 推
 
 - preview 对 config、state、common-dir、worktree 零写入；
 - plan fingerprint 绑定全部目标，任一事实变化使授权失效；
+- 两个 upgrader 只能有一个锁赢家；旧 v0.1 job 在 generation fence 内无法启动；
 - 成功升级生成 config backup、cold state backup、新同路径 state 和 verified journal；
-- 每个 apply 阶段注入真实文件系统失败，证明可重试或可回滚；
+- 每次 file fsync、rename、directory fsync 和 journal replace 前后注入真实文件系统失败，证明可 resume 或 rollback；
+- journal torn/corrupt/missing/unknown 与 config/state 混合代次只进入 recovery inventory；
+- 旧 state 初始缺失与 cutover 后缺失可由 durable journal 明确区分；
+- v0.1 `worktreeRoot`、`fetchTtlSeconds`、`diagnosticsMaxBytes` 保留/默认/非法输入与 dead repo 逐条 exclude 均有转换测试；
 - 旧 config/state 不被 v0.2 active runtime 兼容读取；
 - 未完成 journal、未知 schema、live task、ID mismatch 均阻止写；
 - 备份目标重名不覆盖；cold backup 永不自动删除；
@@ -390,8 +342,9 @@ pnpm run check:state-writes
 
 ### Slice 2：显式升级器与 state cutover
 
-- 先写 preview/apply/recovery 和真实 Git/文件系统 RED；
-- 实现 journal、备份、config 转换、新 state 创建和 read-back；
+- 先按[规范升级协议](../architecture/v02-upgrade-protocol.md)写锁/generation fence、preview/apply/recovery 和真实 Git/文件系统 RED；
+- 实现 durable journal、内容原子 repositoryId、精确备份、完整 config 转换、staged state、cutover 和 read-back；
+- 遵守本设计 PR 已同步的 `AGENTS.md` state 格式红线；只有 Accepted ADR + 显式升级协议可以授权代次切换；
 - 保留 worktree collision guard，不实现旧现场采用。
 
 Slice 1/2 是否拆为两个实现 PR，由设计 PR Review 根据实际 diff 与迁移原子边界决定；不得把设计变更和功能实现放进同一 PR。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # ClickVibe 产品演进路线
 
-> Status: Accepted | Updated: 2026-08-26 | Current execution: [v0.2.0 Milestone](https://github.com/ai-daming/clickvibe/milestone/2) / [Tracking Issue #132](https://github.com/ai-daming/clickvibe/issues/132)
+> Status: Accepted | Updated: 2026-08-27 | Current execution: [v0.2.0 Milestone](https://github.com/ai-daming/clickvibe/milestone/2) / [Tracking Issue #132](https://github.com/ai-daming/clickvibe/issues/132)
 
 本文是版本方向、先后依赖、用户结果和退出标准的唯一事实源。架构约束以[当前有效架构](architecture.md)和 Accepted ADR 为准；GitHub Milestone 只保存一句范围摘要并链接本文，Tracking Issue 只管理当前版本的切片、依赖和退出证据。
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -58,13 +58,14 @@ Controller-owned 调用必须经过对应平面。Agent 可以直接使用真实
 ### P2：Work Item 契约与最小证据
 
 - 落 WorkItemContractSnapshot、规范化 fingerprint 和原始 ArtifactRef。
-- WorkItemContract 留在 v0.2，因为现有 `issueSnapshot` 已参与读取、授权、Coding 和 Review，缓存 freshness 与旧授权失效直接消费它。
-- v0.2 保留并迁移 legacy WorkflowEvent 的有效语义，但不建立完整自主决策事件总包；判别式 EventEnvelope 及首条 Decision→Action→Re-observe 因果链在 v0.3 随真实生产者落地。
+- WorkItemContract 留在 v0.2，因为新的读取、授权、Coding 和 Review 路径需要共享同一需求快照、freshness 与失效语义；v0.1 `issueSnapshot` 不进入 v0.2 active state。
+- v0.2 按 ADR-0009 对本地 config/state 做显式 clean break：旧 state 整体冷备份但不进入 active runtime；不迁移 legacy WorkflowEvent，也不建立完整自主决策事件总包。判别式 EventEnvelope 及首条 Decision→Action→Re-observe 因果链在 v0.3 随真实生产者落地。
 - 所有被捕获、降级或归类的错误保存 DiagnosticRecord 与原始证据引用。
 
 ### P3：迁移与退出验收
 
-- v0.1 资产逐项决定保留、重构、迁移、归档或废弃；数据处置先备份并定义回滚边界。
+- v0.1 代码资产逐项决定保留、重构、归档或废弃；本地 config/state 依 ADR-0009 先精确预览和备份，再切换到单一 v0.2 schema。冷备份不参与运行，也不自动删除。
+- Git worktree、branch、commit、dirty/conflict 和 Provider 事实不属于旧 state：升级只盘点并保留，既有现场冲突时阻止新任务，不自动导入、删除、reset、stash 或 push。
 - 每类已切换状态只有一个写入模型；尚未进入 v0.2 的状态类别不得冒充已完成切换，新旧结构不得长期双写。
 - 并发验收在编码前冻结 Work Item 数、请求基线和目标阈值；记录总请求、上游请求、命中率、P50/P95 等待、rate-limit 消耗和失败数，禁止验收后补阈值。
 


### PR DESCRIPTION
## Summary

- add ADR-0009 for the v0.2 local config/state clean break
- define the L3 WorkItemIdentity, ProjectBinding, repositoryId, upgrade journal, failure and rollback design for #134
- synchronize roadmap, canonical contracts, observability and ADR-0006 with the confirmed clean-break direction
- preserve Git worktrees, branches, commits and Provider facts while cold-archiving v0.1 state

## Decision

v0.2 does not carry legacy repoKey, workflow key, IssueWorkflow or WorkflowEvent readers into the active runtime. The upgrade is explicit: detect → exact preview → authorize → staged apply → authoritative read-back. Existing Git state is observed and preserved, never automatically imported or deleted.

## Issue mapping

- Design baseline for #134
- Relates to #132
- Provides the required baseline for #136 and #137
- Does not close #134; implementation remains blocked until this design is accepted and its merge SHA is written back to #134

## Validation

- markdown links and code fences validated
- `git diff --check`
- `pnpm run check`
- `pnpm run build`
- `pnpm test` — 522/522 passed
- `pnpm run coverage` — lines 92.85%, branches 85.22%, functions 89.52%

## Review gate

ADR-0009 and the #134 design remain Draft on this head. Coding must not start until an exact-SHA design review passes, the accepted status is recorded on a final reviewed head, and this PR is merged.