### PR TITLE
feat(identity): add WorkItemIdentity and ProjectBinding contracts

### DIFF
--- a/src/github/work-item-identity.ts
+++ b/src/github/work-item-identity.ts
@@ -1,0 +1,44 @@
+/** GitHub-specific normalization at the provider adapter boundary. */
+import type { WorkItemIdentity } from '../infra/contracts.ts'
+import { parseWorkItemIdentity } from '../infra/work-item-identity.ts'
+
+export interface GithubWorkItemCoordinates {
+  instance: string
+  owner: string
+  repository: string
+  number: unknown
+}
+
+function githubIssueId(number: unknown): string {
+  if (typeof number === 'number') {
+    if (!Number.isSafeInteger(number) || number <= 0) throw new Error('GitHub issue number must be a positive integer')
+    return String(number)
+  }
+  if (typeof number !== 'string' || !/^[1-9]\d*$/.test(number)) {
+    throw new Error('GitHub issue number must be a positive integer')
+  }
+  return number
+}
+
+function githubName(value: unknown, field: 'owner' | 'repository'): string {
+  if (typeof value !== 'string' || !/^[\w.-]+$/.test(value)) {
+    throw new Error(`GitHub ${field} must be a non-empty canonical name`)
+  }
+  return value
+}
+
+function githubInstance(value: unknown): string {
+  if (typeof value !== 'string' || value.length === 0) throw new Error('GitHub instance must be a non-empty host')
+  return value.toLowerCase()
+}
+
+export function githubWorkItemIdentity(input: GithubWorkItemCoordinates): WorkItemIdentity {
+  const owner = githubName(input.owner, 'owner')
+  const repository = githubName(input.repository, 'repository')
+  return parseWorkItemIdentity({
+    provider: 'github',
+    instance: githubInstance(input.instance),
+    container: `${owner}/${repository}`,
+    id: githubIssueId(input.number),
+  })
+}

--- a/src/github/work-item-identity.ts
+++ b/src/github/work-item-identity.ts
@@ -14,22 +14,54 @@ function githubIssueId(number: unknown): string {
     if (!Number.isSafeInteger(number) || number <= 0) throw new Error('GitHub issue number must be a positive integer')
     return String(number)
   }
-  if (typeof number !== 'string' || !/^[1-9]\d*$/.test(number)) {
+  if (typeof number !== 'string' || number.length > 16 || !/^[1-9]\d*$/.test(number)) {
     throw new Error('GitHub issue number must be a positive integer')
+  }
+  if (BigInt(number) > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error('GitHub issue number must be a positive integer within the safe range')
   }
   return number
 }
 
 function githubName(value: unknown, field: 'owner' | 'repository'): string {
-  if (typeof value !== 'string' || !/^[\w.-]+$/.test(value)) {
+  const validOwner =
+    field === 'owner' &&
+    typeof value === 'string' &&
+    value.length <= 39 &&
+    /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(value)
+  const validRepository =
+    field === 'repository' &&
+    typeof value === 'string' &&
+    value.length <= 100 &&
+    value !== '.' &&
+    value !== '..' &&
+    /^[\w.-]+$/.test(value)
+  if (!validOwner && !validRepository) {
     throw new Error(`GitHub ${field} must be a non-empty canonical name`)
   }
-  return value
+  return (value as string).toLowerCase()
 }
 
 function githubInstance(value: unknown): string {
-  if (typeof value !== 'string' || value.length === 0) throw new Error('GitHub instance must be a non-empty host')
-  return value.toLowerCase()
+  if (typeof value !== 'string' || value.length === 0 || value !== value.trim() || value.length > 255) {
+    throw new Error('GitHub instance must be a canonical host')
+  }
+  try {
+    const url = new URL(`https://${value}`)
+    if (
+      url.username !== '' ||
+      url.password !== '' ||
+      url.pathname !== '/' ||
+      url.search !== '' ||
+      url.hash !== '' ||
+      url.host === ''
+    ) {
+      throw new Error('not a host')
+    }
+    return url.host.toLowerCase()
+  } catch {
+    throw new Error('GitHub instance must be a canonical host')
+  }
 }
 
 export function githubWorkItemIdentity(input: GithubWorkItemCoordinates): WorkItemIdentity {

--- a/src/infra/contracts.ts
+++ b/src/infra/contracts.ts
@@ -1,6 +1,40 @@
 /** Plain-data contracts shared by adapters and upper-layer workflows. */
 export type AgentKind = 'codex' | 'claude'
 
+/** Provider-neutral identity of one external work item. */
+export interface WorkItemIdentity {
+  provider: string
+  instance: string
+  container: string
+  id: string
+}
+
+export interface ProjectContainerIdentity {
+  provider: string
+  instance: string
+  id: string
+}
+
+/** Machine-local binding between one provider container and one real Git clone. */
+export interface ProjectBinding {
+  schemaVersion: 1
+  bindingId: string
+  container: ProjectContainerIdentity
+  repository: {
+    repositoryId: string
+    localPath: string
+    primaryRemote: string
+  }
+}
+
+export interface ClickVibeConfigV1 {
+  schemaVersion: 1
+  worktreeRoot: string
+  fetchTtlSeconds?: number
+  diagnosticsMaxBytes?: number
+  projectBindings: ProjectBinding[]
+}
+
 export interface PromptSnapshot {
   url: string
   title: string

--- a/src/infra/project-binding.ts
+++ b/src/infra/project-binding.ts
@@ -1,0 +1,129 @@
+/** Pure ProjectBinding construction and schema-1 config validation. */
+import { createHash } from 'node:crypto'
+import { isAbsolute } from 'node:path'
+import type { ClickVibeConfigV1, ProjectBinding, ProjectContainerIdentity } from './contracts.ts'
+
+const TUPLE_TAG = 'clickvibe.project-binding'
+const TUPLE_VERSION = 1
+const REPOSITORY_ID = /^repo_[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function objectValue(value: unknown, contract: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error(`${contract} must be an object`)
+  return value as Record<string, unknown>
+}
+
+function nonEmptyString(value: unknown, field: string, contract: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${contract}.${field} must be a non-empty string`)
+  }
+  return value
+}
+
+function positiveInteger(value: unknown, field: string): number | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`ClickVibeConfigV1.${field} must be a positive integer`)
+  }
+  return value
+}
+
+function absolutePath(value: unknown, field: string, contract: string): string {
+  const path = nonEmptyString(value, field, contract)
+  if (!isAbsolute(path)) throw new Error(`${contract}.${field} must be an absolute path`)
+  return path
+}
+
+function parseContainer(value: unknown): ProjectContainerIdentity {
+  const input = objectValue(value, 'ProjectBinding.container')
+  return {
+    provider: nonEmptyString(input.provider, 'provider', 'ProjectBinding.container'),
+    instance: nonEmptyString(input.instance, 'instance', 'ProjectBinding.container'),
+    id: nonEmptyString(input.id, 'id', 'ProjectBinding.container'),
+  }
+}
+
+export function isRepositoryId(value: unknown): value is string {
+  return typeof value === 'string' && REPOSITORY_ID.test(value)
+}
+
+export function canonicalProjectBindingIdentity(containerValue: unknown, repositoryIdValue: unknown): string {
+  const container = parseContainer(containerValue)
+  if (!isRepositoryId(repositoryIdValue)) throw new Error('ProjectBinding.repository.repositoryId is invalid')
+  return JSON.stringify([
+    TUPLE_TAG,
+    TUPLE_VERSION,
+    container.provider,
+    container.instance,
+    container.id,
+    repositoryIdValue,
+  ])
+}
+
+export function projectBindingKey(container: unknown, repositoryId: unknown): string {
+  const canonical = canonicalProjectBindingIdentity(container, repositoryId)
+  return `pb1_${createHash('sha256').update(canonical, 'utf8').digest('base64url')}`
+}
+
+export function parseProjectBinding(value: unknown): ProjectBinding {
+  const input = objectValue(value, 'ProjectBinding')
+  if (input.schemaVersion !== 1) throw new Error('ProjectBinding.schemaVersion must be 1')
+  const container = parseContainer(input.container)
+  const repository = objectValue(input.repository, 'ProjectBinding.repository')
+  const repositoryId = nonEmptyString(repository.repositoryId, 'repositoryId', 'ProjectBinding.repository')
+  if (!isRepositoryId(repositoryId)) throw new Error('ProjectBinding.repository.repositoryId is invalid')
+  const bindingId = nonEmptyString(input.bindingId, 'bindingId', 'ProjectBinding')
+  const expectedBindingId = projectBindingKey(container, repositoryId)
+  if (bindingId !== expectedBindingId) throw new Error(`ProjectBinding.bindingId does not match ${expectedBindingId}`)
+  return {
+    schemaVersion: 1,
+    bindingId,
+    container,
+    repository: {
+      repositoryId,
+      localPath: absolutePath(repository.localPath, 'localPath', 'ProjectBinding.repository'),
+      primaryRemote: nonEmptyString(repository.primaryRemote, 'primaryRemote', 'ProjectBinding.repository'),
+    },
+  }
+}
+
+export function createProjectBinding(value: Omit<ProjectBinding, 'schemaVersion' | 'bindingId'>): ProjectBinding {
+  return parseProjectBinding({
+    ...value,
+    schemaVersion: 1,
+    bindingId: projectBindingKey(value.container, value.repository.repositoryId),
+  })
+}
+
+export function parseClickVibeConfigV1(value: unknown): ClickVibeConfigV1 {
+  const input = objectValue(value, 'ClickVibeConfigV1')
+  if (input.schemaVersion !== 1) throw new Error('ClickVibeConfigV1.schemaVersion must be 1')
+  if (!Array.isArray(input.projectBindings)) {
+    throw new Error('ClickVibeConfigV1.projectBindings must be an array')
+  }
+  const projectBindings = input.projectBindings.map(parseProjectBinding)
+  const containers = new Set<string>()
+  const repositoryIds = new Set<string>()
+  for (const binding of projectBindings) {
+    const containerKey = JSON.stringify([binding.container.provider, binding.container.instance, binding.container.id])
+    if (containers.has(containerKey)) {
+      throw new Error(`ProjectBinding container ${binding.container.id} has more than one active Binding`)
+    }
+    if (repositoryIds.has(binding.repository.repositoryId)) {
+      throw new Error(`ProjectBinding repositoryId ${binding.repository.repositoryId} must be unique`)
+    }
+    containers.add(containerKey)
+    repositoryIds.add(binding.repository.repositoryId)
+  }
+  const fetchTtlSeconds = positiveInteger(input.fetchTtlSeconds, 'fetchTtlSeconds')
+  if (fetchTtlSeconds !== undefined && (fetchTtlSeconds < 30 || fetchTtlSeconds > 60)) {
+    throw new Error('ClickVibeConfigV1.fetchTtlSeconds must be between 30 and 60')
+  }
+  const diagnosticsMaxBytes = positiveInteger(input.diagnosticsMaxBytes, 'diagnosticsMaxBytes')
+  return {
+    schemaVersion: 1,
+    worktreeRoot: absolutePath(input.worktreeRoot, 'worktreeRoot', 'ClickVibeConfigV1'),
+    ...(fetchTtlSeconds === undefined ? {} : { fetchTtlSeconds }),
+    ...(diagnosticsMaxBytes === undefined ? {} : { diagnosticsMaxBytes }),
+    projectBindings,
+  }
+}

--- a/src/infra/project-binding.ts
+++ b/src/infra/project-binding.ts
@@ -12,6 +12,11 @@ function objectValue(value: unknown, contract: string): Record<string, unknown> 
   return value as Record<string, unknown>
 }
 
+function exactKeys(input: Record<string, unknown>, allowed: readonly string[], contract: string): void {
+  const surplus = Object.keys(input).filter((key) => !allowed.includes(key))
+  if (surplus.length > 0) throw new Error(`${contract} contains unknown field(s): ${surplus.join(', ')}`)
+}
+
 function nonEmptyString(value: unknown, field: string, contract: string): string {
   if (typeof value !== 'string' || value.length === 0) {
     throw new Error(`${contract}.${field} must be a non-empty string`)
@@ -35,6 +40,7 @@ function absolutePath(value: unknown, field: string, contract: string): string {
 
 function parseContainer(value: unknown): ProjectContainerIdentity {
   const input = objectValue(value, 'ProjectBinding.container')
+  exactKeys(input, ['provider', 'instance', 'id'], 'ProjectBinding.container')
   return {
     provider: nonEmptyString(input.provider, 'provider', 'ProjectBinding.container'),
     instance: nonEmptyString(input.instance, 'instance', 'ProjectBinding.container'),
@@ -66,9 +72,11 @@ export function projectBindingKey(container: unknown, repositoryId: unknown): st
 
 export function parseProjectBinding(value: unknown): ProjectBinding {
   const input = objectValue(value, 'ProjectBinding')
+  exactKeys(input, ['schemaVersion', 'bindingId', 'container', 'repository'], 'ProjectBinding')
   if (input.schemaVersion !== 1) throw new Error('ProjectBinding.schemaVersion must be 1')
   const container = parseContainer(input.container)
   const repository = objectValue(input.repository, 'ProjectBinding.repository')
+  exactKeys(repository, ['repositoryId', 'localPath', 'primaryRemote'], 'ProjectBinding.repository')
   const repositoryId = nonEmptyString(repository.repositoryId, 'repositoryId', 'ProjectBinding.repository')
   if (!isRepositoryId(repositoryId)) throw new Error('ProjectBinding.repository.repositoryId is invalid')
   const bindingId = nonEmptyString(input.bindingId, 'bindingId', 'ProjectBinding')
@@ -96,6 +104,11 @@ export function createProjectBinding(value: Omit<ProjectBinding, 'schemaVersion'
 
 export function parseClickVibeConfigV1(value: unknown): ClickVibeConfigV1 {
   const input = objectValue(value, 'ClickVibeConfigV1')
+  exactKeys(
+    input,
+    ['schemaVersion', 'worktreeRoot', 'fetchTtlSeconds', 'diagnosticsMaxBytes', 'projectBindings'],
+    'ClickVibeConfigV1',
+  )
   if (input.schemaVersion !== 1) throw new Error('ClickVibeConfigV1.schemaVersion must be 1')
   if (!Array.isArray(input.projectBindings)) {
     throw new Error('ClickVibeConfigV1.projectBindings must be an array')

--- a/src/infra/repository-identity.ts
+++ b/src/infra/repository-identity.ts
@@ -1,0 +1,151 @@
+/** Durable clone identity stored in the real Git common directory. */
+import { randomUUID } from 'node:crypto'
+import { execFile } from 'node:child_process'
+import { link, lstat, mkdir, open, readFile, realpath, unlink } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { promisify } from 'node:util'
+import type { ProjectBinding } from './contracts.ts'
+import { isRepositoryId, parseProjectBinding } from './project-binding.ts'
+
+const execFileAsync = promisify(execFile)
+
+export interface RepositoryIdentityLocation {
+  localPath: string
+  commonDir: string
+  repositoryIdPath: string
+}
+
+export interface VerifiedProjectBindingRepository extends RepositoryIdentityLocation {
+  repositoryId: string
+  primaryRemoteUrl: string
+}
+
+async function git(repositoryPath: string, ...args: string[]): Promise<string> {
+  try {
+    const result = await execFileAsync('git', ['-C', repositoryPath, ...args], { encoding: 'utf8' })
+    return result.stdout.trim()
+  } catch (reason) {
+    const detail = reason as { stderr?: string; message?: string }
+    throw new Error(detail.stderr?.trim() || detail.message || String(reason))
+  }
+}
+
+export async function inspectRepositoryIdentityLocation(repositoryPath: string): Promise<RepositoryIdentityLocation> {
+  const requestedPath = resolve(repositoryPath)
+  const bare = await git(requestedPath, 'rev-parse', '--is-bare-repository')
+  if (bare === 'true') throw new Error(`repository identity does not support bare repository: ${requestedPath}`)
+  const superproject = await git(requestedPath, 'rev-parse', '--show-superproject-working-tree')
+  if (superproject !== '') throw new Error(`repository identity does not support submodule: ${requestedPath}`)
+  const topLevel = await realpath(await git(requestedPath, 'rev-parse', '--show-toplevel'))
+  const actualPath = await realpath(requestedPath)
+  if (actualPath !== topLevel) {
+    throw new Error(`repository identity requires the top-level checkout path: ${topLevel}`)
+  }
+  const commonDir = await realpath(await git(requestedPath, 'rev-parse', '--path-format=absolute', '--git-common-dir'))
+  return {
+    localPath: topLevel,
+    commonDir,
+    repositoryIdPath: join(commonDir, 'clickvibe', 'repository-id'),
+  }
+}
+
+async function readRepositoryIdPath(path: string): Promise<string> {
+  const metadata = await lstat(path)
+  if (metadata.isSymbolicLink()) throw new Error(`repositoryId path is a symlink: ${path}`)
+  if (!metadata.isFile()) throw new Error(`repositoryId path is not a regular file: ${path}`)
+  const raw = await readFile(path, 'utf8')
+  const value = raw.endsWith('\n') ? raw.slice(0, -1) : raw
+  if (!isRepositoryId(value) || (raw !== value && raw !== `${value}\n`)) {
+    throw new Error(`invalid repositoryId file: ${path}`)
+  }
+  return value
+}
+
+async function existingRepositoryId(path: string): Promise<string | null> {
+  try {
+    return await readRepositoryIdPath(path)
+  } catch (reason) {
+    if ((reason as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw reason
+  }
+}
+
+async function ensureIdentityDirectory(path: string): Promise<void> {
+  try {
+    await mkdir(path, { mode: 0o700 })
+  } catch (reason) {
+    if ((reason as NodeJS.ErrnoException).code !== 'EEXIST') throw reason
+  }
+  const metadata = await lstat(path)
+  if (metadata.isSymbolicLink()) throw new Error(`repository identity directory is a symlink: ${path}`)
+  if (!metadata.isDirectory()) throw new Error(`repository identity path is not a directory: ${path}`)
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  const handle = await open(path, 'r')
+  try {
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+}
+
+export async function readRepositoryId(repositoryPath: string): Promise<string> {
+  const location = await inspectRepositoryIdentityLocation(repositoryPath)
+  const repositoryId = await existingRepositoryId(location.repositoryIdPath)
+  if (repositoryId === null) throw new Error(`repositoryId is missing: ${location.repositoryIdPath}`)
+  return repositoryId
+}
+
+export async function ensureRepositoryId(repositoryPath: string): Promise<string> {
+  const location = await inspectRepositoryIdentityLocation(repositoryPath)
+  const identityDirectory = dirname(location.repositoryIdPath)
+  await ensureIdentityDirectory(identityDirectory)
+  const existing = await existingRepositoryId(location.repositoryIdPath)
+  if (existing !== null) return existing
+
+  const repositoryId = `repo_${randomUUID()}`
+  const temporary = join(identityDirectory, `.repository-id.tmp-${process.pid}-${randomUUID()}`)
+  const handle = await open(temporary, 'wx', 0o600)
+  try {
+    await handle.writeFile(`${repositoryId}\n`, 'utf8')
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+
+  let published = false
+  try {
+    try {
+      await link(temporary, location.repositoryIdPath)
+      published = true
+      await syncDirectory(identityDirectory)
+    } catch (reason) {
+      if ((reason as NodeJS.ErrnoException).code !== 'EEXIST') throw reason
+    }
+  } finally {
+    await unlink(temporary).catch(() => {})
+    if (published) await syncDirectory(identityDirectory)
+  }
+  return published ? repositoryId : readRepositoryIdPath(location.repositoryIdPath)
+}
+
+export async function verifyProjectBindingRepository(value: unknown): Promise<VerifiedProjectBindingRepository> {
+  const binding = parseProjectBinding(value)
+  const location = await inspectRepositoryIdentityLocation(binding.repository.localPath)
+  const repositoryId = await readRepositoryIdPath(location.repositoryIdPath)
+  if (repositoryId !== binding.repository.repositoryId) {
+    throw new Error(
+      `repositoryId mismatch: config pins ${binding.repository.repositoryId}, clone contains ${repositoryId}`,
+    )
+  }
+  let primaryRemoteUrl: string
+  try {
+    primaryRemoteUrl = await git(location.localPath, 'remote', 'get-url', binding.repository.primaryRemote)
+  } catch (reason) {
+    throw new Error(
+      `ProjectBinding primaryRemote ${binding.repository.primaryRemote} does not exist: ${reason instanceof Error ? reason.message : String(reason)}`,
+    )
+  }
+  return { ...location, repositoryId, primaryRemoteUrl }
+}

--- a/src/infra/repository-identity.ts
+++ b/src/infra/repository-identity.ts
@@ -20,13 +20,53 @@ export interface VerifiedProjectBindingRepository extends RepositoryIdentityLoca
   primaryRemoteUrl: string
 }
 
+export interface RepositoryIdentityWriteHandle {
+  writeFile(value: string): Promise<void>
+  sync(): Promise<void>
+  close(): Promise<void>
+}
+
+export interface RepositoryIdentityDirectoryHandle {
+  sync(): Promise<void>
+  close(): Promise<void>
+}
+
+/** Narrow file-operation boundary for deterministic durability failure testing. */
+export interface RepositoryIdentityPublicationOperations {
+  openTemporary(path: string): Promise<RepositoryIdentityWriteHandle>
+  publish(temporary: string, destination: string): Promise<void>
+  openDirectory(path: string): Promise<RepositoryIdentityDirectoryHandle>
+  remove(path: string): Promise<void>
+}
+
+const nodePublicationOperations: RepositoryIdentityPublicationOperations = {
+  async openTemporary(path) {
+    const handle = await open(path, 'wx', 0o600)
+    return {
+      writeFile: (value) => handle.writeFile(value, 'utf8'),
+      sync: () => handle.sync(),
+      close: () => handle.close(),
+    }
+  },
+  publish: link,
+  async openDirectory(path) {
+    const handle = await open(path, 'r')
+    return {
+      sync: () => handle.sync(),
+      close: () => handle.close(),
+    }
+  },
+  remove: unlink,
+}
+
 async function git(repositoryPath: string, ...args: string[]): Promise<string> {
   try {
     const result = await execFileAsync('git', ['-C', repositoryPath, ...args], { encoding: 'utf8' })
     return result.stdout.trim()
   } catch (reason) {
     const detail = reason as { stderr?: string; message?: string }
-    throw new Error(detail.stderr?.trim() || detail.message || String(reason))
+    const command = ['git', '-C', repositoryPath, ...args].join(' ')
+    throw new Error(`${command} failed: ${detail.stderr?.trim() || detail.message || String(reason)}`)
   }
 }
 
@@ -42,6 +82,21 @@ export async function inspectRepositoryIdentityLocation(repositoryPath: string):
     throw new Error(`repository identity requires the top-level checkout path: ${topLevel}`)
   }
   const commonDir = await realpath(await git(requestedPath, 'rev-parse', '--path-format=absolute', '--git-common-dir'))
+  const dotGitPath = join(topLevel, '.git')
+  const dotGit = await lstat(dotGitPath)
+  if (dotGit.isSymbolicLink()) throw new Error(`untrusted gitdir symlink: ${dotGitPath}`)
+  if (dotGit.isDirectory()) {
+    if ((await realpath(dotGitPath)) !== commonDir) {
+      throw new Error(`untrusted gitdir outside checkout: ${dotGitPath}`)
+    }
+  } else if (dotGit.isFile()) {
+    const gitDir = await realpath(await git(requestedPath, 'rev-parse', '--path-format=absolute', '--git-dir'))
+    if (dirname(gitDir) !== join(commonDir, 'worktrees')) {
+      throw new Error(`untrusted gitdir outside registered worktrees: ${gitDir}`)
+    }
+  } else {
+    throw new Error(`untrusted gitdir type: ${dotGitPath}`)
+  }
   return {
     localPath: topLevel,
     commonDir,
@@ -81,13 +136,30 @@ async function ensureIdentityDirectory(path: string): Promise<void> {
   if (!metadata.isDirectory()) throw new Error(`repository identity path is not a directory: ${path}`)
 }
 
-async function syncDirectory(path: string): Promise<void> {
-  const handle = await open(path, 'r')
+function errorMessage(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason)
+}
+
+async function captureFailure(failures: unknown[], operation: () => Promise<void>): Promise<void> {
   try {
-    await handle.sync()
-  } finally {
-    await handle.close()
+    await operation()
+  } catch (reason) {
+    failures.push(reason)
   }
+}
+
+function throwFailures(failures: unknown[], action: string): void {
+  if (failures.length === 0) return
+  if (failures.length === 1) throw failures[0]
+  throw new AggregateError(failures, `${action}: ${failures.map(errorMessage).join('; ')}`)
+}
+
+async function syncDirectory(path: string, operations: RepositoryIdentityPublicationOperations): Promise<void> {
+  const handle = await operations.openDirectory(path)
+  const failures: unknown[] = []
+  await captureFailure(failures, () => handle.sync())
+  await captureFailure(failures, () => handle.close())
+  throwFailures(failures, `directory sync failed for ${path}`)
 }
 
 export async function readRepositoryId(repositoryPath: string): Promise<string> {
@@ -97,7 +169,10 @@ export async function readRepositoryId(repositoryPath: string): Promise<string> 
   return repositoryId
 }
 
-export async function ensureRepositoryId(repositoryPath: string): Promise<string> {
+export async function ensureRepositoryId(
+  repositoryPath: string,
+  operations: RepositoryIdentityPublicationOperations = nodePublicationOperations,
+): Promise<string> {
   const location = await inspectRepositoryIdentityLocation(repositoryPath)
   const identityDirectory = dirname(location.repositoryIdPath)
   await ensureIdentityDirectory(identityDirectory)
@@ -106,27 +181,31 @@ export async function ensureRepositoryId(repositoryPath: string): Promise<string
 
   const repositoryId = `repo_${randomUUID()}`
   const temporary = join(identityDirectory, `.repository-id.tmp-${process.pid}-${randomUUID()}`)
-  const handle = await open(temporary, 'wx', 0o600)
-  try {
-    await handle.writeFile(`${repositoryId}\n`, 'utf8')
-    await handle.sync()
-  } finally {
-    await handle.close()
+  const handle = await operations.openTemporary(temporary)
+  const preparationFailures: unknown[] = []
+  await captureFailure(preparationFailures, () => handle.writeFile(`${repositoryId}\n`))
+  if (preparationFailures.length === 0) await captureFailure(preparationFailures, () => handle.sync())
+  await captureFailure(preparationFailures, () => handle.close())
+  if (preparationFailures.length > 0) {
+    await captureFailure(preparationFailures, () => operations.remove(temporary))
+    throwFailures(preparationFailures, `repositoryId temporary preparation failed for ${temporary}`)
   }
 
   let published = false
+  let contended = false
+  const publicationFailures: unknown[] = []
   try {
-    try {
-      await link(temporary, location.repositoryIdPath)
-      published = true
-      await syncDirectory(identityDirectory)
-    } catch (reason) {
-      if ((reason as NodeJS.ErrnoException).code !== 'EEXIST') throw reason
-    }
-  } finally {
-    await unlink(temporary).catch(() => {})
-    if (published) await syncDirectory(identityDirectory)
+    await operations.publish(temporary, location.repositoryIdPath)
+    published = true
+  } catch (reason) {
+    if ((reason as NodeJS.ErrnoException).code === 'EEXIST') contended = true
+    else publicationFailures.push(reason)
   }
+  if (published || contended) {
+    await captureFailure(publicationFailures, () => syncDirectory(identityDirectory, operations))
+  }
+  await captureFailure(publicationFailures, () => operations.remove(temporary))
+  throwFailures(publicationFailures, `repositoryId publication failed for ${location.repositoryIdPath}`)
   return published ? repositoryId : readRepositoryIdPath(location.repositoryIdPath)
 }
 

--- a/src/infra/work-item-identity.ts
+++ b/src/infra/work-item-identity.ts
@@ -1,0 +1,47 @@
+/** Pure canonicalization and hashing for provider-neutral Work Item identity. */
+import { createHash } from 'node:crypto'
+import type { WorkItemIdentity } from './contracts.ts'
+
+const TUPLE_TAG = 'clickvibe.work-item-identity'
+const TUPLE_VERSION = 1
+
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('WorkItemIdentity must be an object')
+  }
+  return value as Record<string, unknown>
+}
+
+function identityField(value: unknown, field: keyof WorkItemIdentity): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`WorkItemIdentity.${field} must be a non-empty string`)
+  }
+  return value
+}
+
+export function parseWorkItemIdentity(value: unknown): WorkItemIdentity {
+  const input = record(value)
+  return {
+    provider: identityField(input.provider, 'provider'),
+    instance: identityField(input.instance, 'instance'),
+    container: identityField(input.container, 'container'),
+    id: identityField(input.id, 'id'),
+  }
+}
+
+export function canonicalWorkItemIdentity(value: unknown): string {
+  const identity = parseWorkItemIdentity(value)
+  return JSON.stringify([
+    TUPLE_TAG,
+    TUPLE_VERSION,
+    identity.provider,
+    identity.instance,
+    identity.container,
+    identity.id,
+  ])
+}
+
+export function workItemKey(value: unknown): string {
+  const canonical = canonicalWorkItemIdentity(value)
+  return `wi1_${createHash('sha256').update(canonical, 'utf8').digest('base64url')}`
+}

--- a/src/infra/work-item-identity.ts
+++ b/src/infra/work-item-identity.ts
@@ -21,6 +21,8 @@ function identityField(value: unknown, field: keyof WorkItemIdentity): string {
 
 export function parseWorkItemIdentity(value: unknown): WorkItemIdentity {
   const input = record(value)
+  const surplus = Object.keys(input).filter((key) => !['provider', 'instance', 'container', 'id'].includes(key))
+  if (surplus.length > 0) throw new Error(`WorkItemIdentity contains unknown field(s): ${surplus.join(', ')}`)
   return {
     provider: identityField(input.provider, 'provider'),
     instance: identityField(input.instance, 'instance'),

--- a/tests/project-binding.test.ts
+++ b/tests/project-binding.test.ts
@@ -81,7 +81,17 @@ test('schema 1 config rejects unknown shapes instead of treating corruption as e
     { ...base, fetchTtlSeconds: 45.5 },
     { ...base, diagnosticsMaxBytes: -1 },
     { ...base, diagnosticsMaxBytes: 1.5 },
+    { ...base, fetchTtlSecond: 30 },
     { ...base, projectBindings: 'not-an-array' },
+    { ...base, projectBindings: [{ ...binding, unexpected: true }] },
+    {
+      ...base,
+      projectBindings: [{ ...binding, container: { ...binding.container, displayName: 'ClickVibe' } }],
+    },
+    {
+      ...base,
+      projectBindings: [{ ...binding, repository: { ...binding.repository, remoteUrl: 'ignored' } }],
+    },
     {
       ...base,
       projectBindings: [{ ...binding, repository: { ...binding.repository, localPath: 'relative/repo' } }],

--- a/tests/project-binding.test.ts
+++ b/tests/project-binding.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  canonicalProjectBindingIdentity,
+  createProjectBinding,
+  parseClickVibeConfigV1,
+  projectBindingKey,
+} from '../src/infra/project-binding.ts'
+
+const container = { provider: 'github', instance: 'github.com', id: 'ai-daming/clickvibe' }
+const repositoryId = 'repo_123e4567-e89b-42d3-a456-426614174000'
+
+test('bindingId is stable across path and remote changes but scoped by container and clone', () => {
+  const first = createProjectBinding({
+    container,
+    repository: { repositoryId, localPath: '/Users/one/clickvibe', primaryRemote: 'origin' },
+  })
+  const moved = createProjectBinding({
+    container,
+    repository: { repositoryId, localPath: '/Volumes/code/clickvibe', primaryRemote: 'upstream' },
+  })
+
+  assert.equal(
+    canonicalProjectBindingIdentity(container, repositoryId),
+    '["clickvibe.project-binding",1,"github","github.com","ai-daming/clickvibe","repo_123e4567-e89b-42d3-a456-426614174000"]',
+  )
+  assert.equal(first.bindingId, moved.bindingId)
+  assert.equal(first.bindingId, 'pb1_oC1PH9XDXYcMHGp2OnRoYCy5cnY5nbLsrhHWbziYsxQ')
+  assert.notEqual(first.bindingId, projectBindingKey({ ...container, id: 'other/repo' }, repositoryId))
+  assert.notEqual(first.bindingId, projectBindingKey(container, 'repo_123e4567-e89b-42d3-a456-426614174001'))
+})
+
+test('schema 1 config validates binding fingerprints and rejects ambiguous local ownership', () => {
+  const binding = createProjectBinding({
+    container,
+    repository: { repositoryId, localPath: '/work/clickvibe', primaryRemote: 'origin' },
+  })
+  const config = {
+    schemaVersion: 1,
+    worktreeRoot: '/worktrees',
+    fetchTtlSeconds: 45,
+    diagnosticsMaxBytes: 10_485_760,
+    projectBindings: [binding],
+  }
+  assert.deepEqual(parseClickVibeConfigV1(config), config)
+
+  assert.throws(() => parseClickVibeConfigV1({ ...config, schemaVersion: 2 }), /schemaVersion/)
+  assert.throws(
+    () => parseClickVibeConfigV1({ ...config, projectBindings: [{ ...binding, bindingId: 'pb1_wrong' }] }),
+    /bindingId/,
+  )
+  assert.throws(
+    () =>
+      parseClickVibeConfigV1({ ...config, projectBindings: [binding, { ...binding, bindingId: binding.bindingId }] }),
+    /container.*more than one active Binding/,
+  )
+  const secondContainer = createProjectBinding({
+    container: { ...container, id: 'ai-daming/other' },
+    repository: { repositoryId, localPath: '/work/other', primaryRemote: 'origin' },
+  })
+  assert.throws(
+    () => parseClickVibeConfigV1({ ...config, projectBindings: [binding, secondContainer] }),
+    /repositoryId.*unique/,
+  )
+})
+
+test('schema 1 config rejects unknown shapes instead of treating corruption as empty config', () => {
+  const binding = createProjectBinding({
+    container,
+    repository: { repositoryId, localPath: '/work/clickvibe', primaryRemote: 'origin' },
+  })
+  const base = { schemaVersion: 1, worktreeRoot: '/worktrees', projectBindings: [binding] }
+  for (const value of [
+    null,
+    {},
+    { ...base, worktreeRoot: '' },
+    { ...base, worktreeRoot: 'relative/worktrees' },
+    { ...base, fetchTtlSeconds: 0 },
+    { ...base, fetchTtlSeconds: 29 },
+    { ...base, fetchTtlSeconds: 61 },
+    { ...base, fetchTtlSeconds: 45.5 },
+    { ...base, diagnosticsMaxBytes: -1 },
+    { ...base, diagnosticsMaxBytes: 1.5 },
+    { ...base, projectBindings: 'not-an-array' },
+    {
+      ...base,
+      projectBindings: [{ ...binding, repository: { ...binding.repository, localPath: 'relative/repo' } }],
+    },
+    { ...base, projectBindings: [{ ...binding, repository: { ...binding.repository, repositoryId: 'broken' } }] },
+    { ...base, projectBindings: [{ ...binding, repository: { ...binding.repository, primaryRemote: '' } }] },
+  ]) {
+    assert.throws(() => parseClickVibeConfigV1(value), /ClickVibeConfigV1|ProjectBinding/)
+  }
+})

--- a/tests/repository-identity-failures.test.ts
+++ b/tests/repository-identity-failures.test.ts
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { once } from 'node:events'
+import { link, mkdtemp, open, readFile, readdir, rm, unlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { createInterface } from 'node:readline'
+import test from 'node:test'
+import type {
+  RepositoryIdentityPublicationOperations,
+  RepositoryIdentityWriteHandle,
+} from '../src/infra/repository-identity.ts'
+import { ensureRepositoryId, inspectRepositoryIdentityLocation } from '../src/infra/repository-identity.ts'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+async function git(cwd: string, ...args: string[]) {
+  return execFileAsync('git', ['-C', cwd, ...args], { encoding: 'utf8' })
+}
+
+async function initRepository(path: string): Promise<void> {
+  await git(dirname(path), 'init', path)
+  await git(path, 'config', 'user.name', 'clickvibe-test')
+  await git(path, 'config', 'user.email', 'clickvibe-test@example.invalid')
+  await git(path, 'commit', '--allow-empty', '-m', 'base')
+}
+
+type FailureStep = 'temp-write' | 'temp-fsync' | 'link' | 'directory-fsync'
+
+function failureOperations(step: FailureStep): RepositoryIdentityPublicationOperations {
+  return {
+    async openTemporary(path: string): Promise<RepositoryIdentityWriteHandle> {
+      const handle = await open(path, 'wx', 0o600)
+      return {
+        async writeFile(value: string) {
+          if (step === 'temp-write') throw new Error(`forced ${step}`)
+          await handle.writeFile(value, 'utf8')
+        },
+        async sync() {
+          if (step === 'temp-fsync') throw new Error(`forced ${step}`)
+          await handle.sync()
+        },
+        close: () => handle.close(),
+      }
+    },
+    async publish(temporary: string, destination: string) {
+      if (step === 'link') throw new Error(`forced ${step}`)
+      await link(temporary, destination)
+    },
+    async openDirectory(path: string) {
+      const handle = await open(path, 'r')
+      return {
+        async sync() {
+          if (step === 'directory-fsync') throw new Error(`forced ${step}`)
+          await handle.sync()
+        },
+        close: () => handle.close(),
+      }
+    },
+    remove: unlink,
+  }
+}
+
+test('every repositoryId publication failure leaves the final file complete or absent and retryable', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'clickvibe-repository-id-failures-'))
+  try {
+    for (const step of ['temp-write', 'temp-fsync', 'link', 'directory-fsync'] as const) {
+      const repository = join(root, step)
+      await initRepository(repository)
+      const location = await inspectRepositoryIdentityLocation(repository)
+      await assert.rejects(ensureRepositoryId(repository, failureOperations(step)), new RegExp(`forced ${step}`))
+
+      const raw = await readFile(location.repositoryIdPath, 'utf8').catch((reason) => {
+        if ((reason as NodeJS.ErrnoException).code === 'ENOENT') return null
+        throw reason
+      })
+      if (raw !== null) assert.match(raw, /^repo_[0-9a-f-]{36}\n$/)
+      const entries = await readdir(dirname(location.repositoryIdPath))
+      assert.equal(
+        entries.some((entry) => entry.startsWith('.repository-id.tmp-')),
+        false,
+        `${step} left a temporary file`,
+      )
+      const recovered = await ensureRepositoryId(repository)
+      assert.equal(await readFile(location.repositoryIdPath, 'utf8'), `${recovered}\n`)
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+const workerSource = `
+import { existsSync } from 'node:fs'
+import { ensureRepositoryId } from './src/infra/repository-identity.ts'
+console.log('ready')
+while (!existsSync(process.env.START_GATE)) await new Promise((resolve) => setTimeout(resolve, 5))
+try {
+  console.log(JSON.stringify({ ok: true, id: await ensureRepositoryId(process.env.TARGET_REPOSITORY) }))
+} catch (error) {
+  console.log(JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) }))
+}
+`
+
+async function startRepositoryIdWorker(repository: string, gate: string) {
+  const child = spawn(process.execPath, ['--input-type=module', '--eval', workerSource], {
+    cwd: process.cwd(),
+    env: { ...process.env, TARGET_REPOSITORY: repository, START_GATE: gate },
+  })
+  let stderr = ''
+  child.stderr.setEncoding('utf8')
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk
+  })
+  const output = createInterface({ input: child.stdout })[Symbol.asyncIterator]()
+  const ready = await output.next()
+  assert.equal(ready.value, 'ready', stderr)
+  return { child, output, stderr: () => stderr }
+}
+
+test('separate Node processes concurrently publish one complete repositoryId', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'clickvibe-repository-id-processes-'))
+  const repository = join(root, 'repo')
+  const gate = join(root, 'start')
+  const workers: Awaited<ReturnType<typeof startRepositoryIdWorker>>[] = []
+  try {
+    await initRepository(repository)
+    for (let index = 0; index < 8; index += 1) workers.push(await startRepositoryIdWorker(repository, gate))
+    await writeFile(gate, 'go')
+    const results = await Promise.all(
+      workers.map(async (worker) => {
+        const line = await worker.output.next()
+        assert.equal(line.done, false, worker.stderr())
+        return JSON.parse(line.value) as { ok: boolean; id?: string; error?: string }
+      }),
+    )
+    assert.ok(
+      results.every((result) => result.ok),
+      JSON.stringify(results),
+    )
+    assert.equal(new Set(results.map((result) => result.id)).size, 1)
+    const location = await inspectRepositoryIdentityLocation(repository)
+    assert.equal(await readFile(location.repositoryIdPath, 'utf8'), `${results[0].id}\n`)
+  } finally {
+    for (const worker of workers) {
+      if (worker.child.exitCode === null) worker.child.kill()
+      if (worker.child.exitCode === null) await once(worker.child, 'exit')
+    }
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/tests/repository-identity-integration.test.ts
+++ b/tests/repository-identity-integration.test.ts
@@ -170,3 +170,20 @@ test('bare repositories, submodules, symlink and malformed repositoryId files ar
     await rm(root, { recursive: true, force: true })
   }
 })
+
+test('a crafted checkout .git file cannot redirect repositoryId writes to an unrelated Git directory', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'clickvibe-gitdir-escape-'))
+  const unrelated = join(root, 'unrelated')
+  const crafted = join(root, 'crafted')
+  try {
+    await initRepository(unrelated)
+    await mkdir(crafted)
+    await writeFile(join(crafted, '.git'), `gitdir: ${join(unrelated, '.git')}\n`)
+    await assert.rejects(ensureRepositoryId(crafted), /untrusted gitdir/)
+    await assert.rejects(readFile(join(unrelated, '.git', 'clickvibe', 'repository-id'), 'utf8'), {
+      code: 'ENOENT',
+    })
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/tests/repository-identity-integration.test.ts
+++ b/tests/repository-identity-integration.test.ts
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import { cp, mkdir, mkdtemp, readFile, rename, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { promisify } from 'node:util'
+import test from 'node:test'
+import {
+  ensureRepositoryId,
+  inspectRepositoryIdentityLocation,
+  readRepositoryId,
+  verifyProjectBindingRepository,
+} from '../src/infra/repository-identity.ts'
+import { createProjectBinding, parseClickVibeConfigV1 } from '../src/infra/project-binding.ts'
+
+const execFileAsync = promisify(execFile)
+
+async function git(cwd: string, ...args: string[]) {
+  return execFileAsync('git', ['-C', cwd, ...args], { encoding: 'utf8' })
+}
+
+async function initRepository(path: string): Promise<void> {
+  await git(dirname(path), 'init', path)
+  await git(path, 'config', 'user.name', 'clickvibe-test')
+  await git(path, 'config', 'user.email', 'clickvibe-test@example.invalid')
+  await git(path, 'commit', '--allow-empty', '-m', 'base')
+}
+
+test('main checkout and linked worktree share one complete clone-stable repositoryId', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'clickvibe-repository-id-'))
+  const repository = join(root, 'repo')
+  const worktree = join(root, 'linked')
+  try {
+    await initRepository(repository)
+    await git(repository, 'worktree', 'add', '-b', 'linked-test', worktree)
+
+    const ids = await Promise.all(Array.from({ length: 12 }, () => ensureRepositoryId(repository)))
+    assert.equal(new Set(ids).size, 1)
+    assert.match(ids[0], /^repo_[0-9a-f-]{36}$/)
+    assert.equal(await readRepositoryId(worktree), ids[0])
+
+    const mainLocation = await inspectRepositoryIdentityLocation(repository)
+    const linkedLocation = await inspectRepositoryIdentityLocation(worktree)
+    assert.equal(mainLocation.commonDir, linkedLocation.commonDir)
+    assert.equal(await readFile(mainLocation.repositoryIdPath, 'utf8'), `${ids[0]}\n`)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('independent clones with the same remote get different repositoryIds and moving a clone keeps its ID', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'clickvibe-independent-clones-'))
+  const source = join(root, 'source')
+  const remote = join(root, 'remote.git')
+  const first = join(root, 'first')
+  const second = join(root, 'second')
+  const moved = join(root, 'moved')
+  try {
+    await initRepository(source)
+    await execFileAsync('git', ['init', '--bare', remote])
+    await git(source, 'remote', 'add', 'origin', remote)
+    await git(source, 'push', 'origin', 'HEAD:main')
+    await execFileAsync('git', ['clone', remote, first])
+    await execFileAsync('git', ['clone', remote, second])
+
+    const firstId = await ensureRepositoryId(first)
+    const secondId = await ensureRepositoryId(second)
+    assert.notEqual(firstId, secondId)
+    assert.equal(
+      (await git(first, 'remote', 'get-url', 'origin')).stdout,
+      (await git(second, 'remote', 'get-url', 'origin')).stdout,
+    )
+
+    await rename(first, moved)
+    assert.equal(await readRepositoryId(moved), firstId)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('binding verification fails closed on repositoryId mismatch and missing primary remote', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'clickvibe-binding-verify-'))
+  const repository = join(root, 'repo')
+  try {
+    await initRepository(repository)
+    const repositoryId = await ensureRepositoryId(repository)
+    const binding = createProjectBinding({
+      container: { provider: 'github', instance: 'github.com', id: 'o/r' },
+      repository: { repositoryId, localPath: repository, primaryRemote: 'origin' },
+    })
+
+    await assert.rejects(verifyProjectBindingRepository(binding), /primaryRemote.*origin.*does not exist/)
+    await git(repository, 'remote', 'add', 'origin', 'https://github.com/o/r.git')
+    const verified = await verifyProjectBindingRepository(binding)
+    assert.equal(verified.repositoryId, repositoryId)
+    assert.equal(verified.primaryRemoteUrl, 'https://github.com/o/r.git')
+    await assert.rejects(
+      verifyProjectBindingRepository(
+        createProjectBinding({
+          container: binding.container,
+          repository: { ...binding.repository, repositoryId: 'repo_123e4567-e89b-42d3-a456-426614174000' },
+        }),
+      ),
+      /repositoryId mismatch/,
+    )
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('copying a clone copies its sidecar and target config rejects the duplicate repositoryId', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'clickvibe-copied-clone-'))
+  const original = join(root, 'original')
+  const copied = join(root, 'copied')
+  try {
+    await initRepository(original)
+    const repositoryId = await ensureRepositoryId(original)
+    await cp(original, copied, { recursive: true })
+    assert.equal(await readRepositoryId(copied), repositoryId)
+    const first = createProjectBinding({
+      container: { provider: 'github', instance: 'github.com', id: 'o/first' },
+      repository: { repositoryId, localPath: original, primaryRemote: 'origin' },
+    })
+    const second = createProjectBinding({
+      container: { provider: 'github', instance: 'github.com', id: 'o/second' },
+      repository: { repositoryId, localPath: copied, primaryRemote: 'origin' },
+    })
+    assert.throws(
+      () =>
+        parseClickVibeConfigV1({
+          schemaVersion: 1,
+          worktreeRoot: join(root, 'worktrees'),
+          projectBindings: [first, second],
+        }),
+      /repositoryId.*unique/,
+    )
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('bare repositories, submodules, symlink and malformed repositoryId files are rejected without overwrite', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'clickvibe-repository-id-invalid-'))
+  const bare = join(root, 'bare.git')
+  const parent = join(root, 'parent')
+  const child = join(root, 'child')
+  const submodule = join(parent, 'submodule')
+  try {
+    await execFileAsync('git', ['init', '--bare', bare])
+    await assert.rejects(ensureRepositoryId(bare), /bare repository/)
+
+    await initRepository(parent)
+    await initRepository(child)
+    await git(parent, '-c', 'protocol.file.allow=always', 'submodule', 'add', child, 'submodule')
+    await assert.rejects(ensureRepositoryId(submodule), /submodule/)
+
+    const location = await inspectRepositoryIdentityLocation(parent)
+    await mkdir(dirname(location.repositoryIdPath), { recursive: true })
+    const target = join(root, 'outside-id')
+    await writeFile(target, 'repo_123e4567-e89b-42d3-a456-426614174000\n')
+    await symlink(target, location.repositoryIdPath)
+    await assert.rejects(ensureRepositoryId(parent), /symlink/)
+    assert.equal(await readFile(target, 'utf8'), 'repo_123e4567-e89b-42d3-a456-426614174000\n')
+
+    await rm(location.repositoryIdPath)
+    await writeFile(location.repositoryIdPath, 'partial')
+    await assert.rejects(ensureRepositoryId(parent), /invalid repositoryId/)
+    assert.equal(await readFile(location.repositoryIdPath, 'utf8'), 'partial')
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/tests/work-item-identity.test.ts
+++ b/tests/work-item-identity.test.ts
@@ -28,6 +28,7 @@ test('WorkItemIdentity rejects missing, empty and non-string fields without norm
     { provider: 'github', instance: 'github.com', container: '', id: '1' },
     { provider: 'github', instance: 'github.com', container: 'o/r', id: '' },
     { provider: 'github', instance: 'github.com', container: 'o/r', id: 1 },
+    { provider: 'github', instance: 'github.com', container: 'o/r', id: '1', displayKey: '#1' },
   ]) {
     assert.throws(() => parseWorkItemIdentity(value), /WorkItemIdentity/)
   }
@@ -58,7 +59,23 @@ test('GitHub adapter owns positive issue-number validation and host normalizatio
     githubWorkItemIdentity({ instance: 'github.example.com', owner: 'o', repository: 'r', number: '99' }).id,
     '99',
   )
-  for (const number of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '', '0', '01', '1.5', 'abc']) {
+  assert.deepEqual(
+    githubWorkItemIdentity({ instance: 'GITHUB.COM', owner: 'AI-Daming', repository: 'ClickVibe', number: 134 }),
+    githubWorkItemIdentity({ instance: 'github.com', owner: 'ai-daming', repository: 'clickvibe', number: '134' }),
+  )
+  for (const number of [
+    0,
+    -1,
+    1.5,
+    Number.MAX_SAFE_INTEGER + 1,
+    '',
+    '0',
+    '01',
+    '1.5',
+    'abc',
+    String(BigInt(Number.MAX_SAFE_INTEGER) + 1n),
+    '9'.repeat(10_000),
+  ]) {
     assert.throws(
       () => githubWorkItemIdentity({ instance: 'github.com', owner: 'o', repository: 'r', number }),
       /positive integer/,
@@ -67,9 +84,17 @@ test('GitHub adapter owns positive issue-number validation and host normalizatio
   for (const coordinates of [
     { instance: '', owner: 'o', repository: 'r', number: 1 },
     { instance: 1, owner: 'o', repository: 'r', number: 1 },
+    { instance: ' github.com', owner: 'o', repository: 'r', number: 1 },
+    { instance: 'https://github.com', owner: 'o', repository: 'r', number: 1 },
+    { instance: 'github.com/path', owner: 'o', repository: 'r', number: 1 },
+    { instance: 'github.com?query=1', owner: 'o', repository: 'r', number: 1 },
     { instance: 'github.com', owner: '', repository: 'r', number: 1 },
     { instance: 'github.com', owner: 'o', repository: '', number: 1 },
     { instance: 'github.com', owner: 'o/x', repository: 'r', number: 1 },
+    { instance: 'github.com', owner: '.', repository: 'r', number: 1 },
+    { instance: 'github.com', owner: 'o', repository: '..', number: 1 },
+    { instance: 'github.com', owner: 'o'.repeat(40), repository: 'r', number: 1 },
+    { instance: 'github.com', owner: 'o', repository: 'r'.repeat(101), number: 1 },
   ]) {
     assert.throws(() => githubWorkItemIdentity(coordinates as never), /GitHub/)
   }

--- a/tests/work-item-identity.test.ts
+++ b/tests/work-item-identity.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { githubWorkItemIdentity } from '../src/github/work-item-identity.ts'
+import { canonicalWorkItemIdentity, parseWorkItemIdentity, workItemKey } from '../src/infra/work-item-identity.ts'
+
+test('WorkItemIdentity has one stable canonical serialization and durable key', () => {
+  const identity = {
+    provider: 'github',
+    instance: 'github.com',
+    container: 'ai-daming/clickvibe',
+    id: '134',
+  }
+
+  assert.equal(
+    canonicalWorkItemIdentity(identity),
+    '["clickvibe.work-item-identity",1,"github","github.com","ai-daming/clickvibe","134"]',
+  )
+  assert.equal(workItemKey(identity), 'wi1_k8NlXDvPdtgr8pQ8yREG_5KaTn0rKWIllVJnNQZMA6M')
+  assert.deepEqual(parseWorkItemIdentity(identity), identity)
+})
+
+test('WorkItemIdentity rejects missing, empty and non-string fields without normalizing values', () => {
+  for (const value of [
+    null,
+    {},
+    { provider: '', instance: 'github.com', container: 'o/r', id: '1' },
+    { provider: 'github', instance: '', container: 'o/r', id: '1' },
+    { provider: 'github', instance: 'github.com', container: '', id: '1' },
+    { provider: 'github', instance: 'github.com', container: 'o/r', id: '' },
+    { provider: 'github', instance: 'github.com', container: 'o/r', id: 1 },
+  ]) {
+    assert.throws(() => parseWorkItemIdentity(value), /WorkItemIdentity/)
+  }
+
+  const spaced = { provider: ' github ', instance: 'github.com', container: 'o/r', id: '1' }
+  assert.deepEqual(parseWorkItemIdentity(spaced), spaced)
+})
+
+test('canonical JSON keeps field boundaries and JSON escaping unambiguous', () => {
+  const first = { provider: 'a"b', instance: 'c\\d', container: 'e\nf', id: 'g' }
+  const second = { provider: 'a', instance: '"bc\\d', container: 'e\nf', id: 'g' }
+  assert.equal(canonicalWorkItemIdentity(first), '["clickvibe.work-item-identity",1,"a\\"b","c\\\\d","e\\nf","g"]')
+  assert.notEqual(canonicalWorkItemIdentity(first), canonicalWorkItemIdentity(second))
+  assert.notEqual(workItemKey(first), workItemKey(second))
+})
+
+test('GitHub adapter owns positive issue-number validation and host normalization', () => {
+  assert.deepEqual(
+    githubWorkItemIdentity({ instance: 'GitHub.COM', owner: 'ai-daming', repository: 'clickvibe', number: 134 }),
+    {
+      provider: 'github',
+      instance: 'github.com',
+      container: 'ai-daming/clickvibe',
+      id: '134',
+    },
+  )
+  assert.equal(
+    githubWorkItemIdentity({ instance: 'github.example.com', owner: 'o', repository: 'r', number: '99' }).id,
+    '99',
+  )
+  for (const number of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '', '0', '01', '1.5', 'abc']) {
+    assert.throws(
+      () => githubWorkItemIdentity({ instance: 'github.com', owner: 'o', repository: 'r', number }),
+      /positive integer/,
+    )
+  }
+  for (const coordinates of [
+    { instance: '', owner: 'o', repository: 'r', number: 1 },
+    { instance: 1, owner: 'o', repository: 'r', number: 1 },
+    { instance: 'github.com', owner: '', repository: 'r', number: 1 },
+    { instance: 'github.com', owner: 'o', repository: '', number: 1 },
+    { instance: 'github.com', owner: 'o/x', repository: 'r', number: 1 },
+  ]) {
+    assert.throws(() => githubWorkItemIdentity(coordinates as never), /GitHub/)
+  }
+})


### PR DESCRIPTION
## Summary

- add provider-neutral WorkItemIdentity validation, canonical serialization, and stable wi1_ key generation
- add ProjectBinding/pb1_ construction plus strict schema 1 config validation
- persist clone-stable repositoryId under the real Git common-dir using durable, concurrent-safe publication
- fail closed on binding mismatch, missing primary remote, copied IDs, symlinks, bare repositories, and submodules

## Scope

This is #134 Slice 1 only. It does not switch the active v0.1 runtime or implement the Slice 2 clean-break config/state upgrader. It must not close #134.

Architecture baseline: c866399f360fd3505be9b16980e56cc931308d9a (PR #139).

## Verification

- pnpm run typecheck
- pnpm run build
- pnpm test: 534/534 passed
- pnpm run coverage: lines 93.13%, branches 85.67%, functions 89.75%
- pnpm run lint
- pnpm run format:check
- pnpm run check:size
- pnpm run check:layers
- pnpm run check:style-tokens
- pnpm run check:state-writes
