### PR TITLE
feat(upgrade): add explicit v0.2 state cutover and recovery

### DIFF
--- a/docs/architecture/v02-upgrade-protocol.md
+++ b/docs/architecture/v02-upgrade-protocol.md
@@ -34,7 +34,7 @@
 
 ### 3.1 两种机制缺一不可
 
-升级锁负责阻止两个 v0.2 upgrader 并发。实现复用 `src/infra/workflow-persistence.ts` 的 link 型跨进程锁模式：候选文件写入完整 owner token 后通过 hard link 争抢固定锁；只在确认 owner 进程已死亡后回收 stale lock。锁 token、PID、进程启动标识和 plan fingerprint 写入 journal，模糊存活状态一律不抢锁。
+升级锁负责阻止两个 v0.2 upgrader 并发。实现复用 `src/infra/workflow-persistence.ts` 的 link 型跨进程锁模式：候选文件写入完整 owner token 后通过 hard link 争抢固定锁。schema 1 旧 owner 的启动字符串受 locale/timezone 影响：PID 存活时一律不抢，只接受 `ESRCH` 明确死亡；schema 2 owner 使用固定 `LANG/LC_ALL=C`、`TZ=UTC` 的启动身份，PID 对应 zombie 或启动身份变化时才按 PID 复用回收。锁 token、PID、进程启动标识和 plan fingerprint 写入 journal，身份读取不明继续 fail closed。
 
 锁本身不能约束不认识它的 v0.1 二进制。因此 apply 还必须取得宿主提供的 generation fence：
 
@@ -53,7 +53,17 @@
 
 ### 3.2 临界区顺序
 
-apply 的顺序固定为：验证 fence 来自批准 factory → 取得升级锁 → 取得 generation fence → 临界区内活性检查 → 重算 fingerprint → 写 durable journal → prepare → cutover → read-back → `verified`/`rolled_back` → 释放 fence 和锁。任何失败都保持锁和 fence，直到进程退出或进入明确终态；新进程看到未完成 journal 时只能进入 recovery。
+apply 的顺序固定为：验证 fence 来自批准 factory → 取得升级锁 → 取得 generation fence → 临界区内活性检查 → 重算 fingerprint → 写 durable journal → prepare → cutover → read-back → `verified`/`rolled_back` → 释放 fence 和锁。失败时必须先把原始错误和当前阶段写入 journal，再尝试释放 fence 和锁；两个释放动作都必须执行，任一释放失败都向调用方报错。新进程看到未完成 journal 时只能进入 recovery。
+
+### 3.3 人工处理残留锁
+
+只有在自动 recovery 因 `upgrade-v0.2.lock` 残留而无法取得锁时才进入人工处置；journal、backup 和 staging 资产都不得随锁删除。
+
+1. 停止 DSH 宿主和所有 ClickVibe 升级命令，确认处置期间不会自动重启。
+2. 读取 `~/.clickvibe/upgrade-v0.2.lock`，记录 `schemaVersion`、`token`、`pid`、`acquiredAt` 和 `planFingerprint`；文件不是普通文件、JSON 损坏或字段不全时停止，不猜测 owner。
+3. 用操作系统进程查询同时验证该 PID 不存在；只有明确得到 `ESRCH`/“no such process”才可判定 owner 已死。PID 存活、权限不足或查询结果不明时禁止删锁；schema 1 的 `processStart` 不参与人工死亡判断。
+4. 删除前再次回读锁文件，确认 token 与第 2 步一致，避免删掉刚接管的新 owner。随后只删除精确路径 `~/.clickvibe/upgrade-v0.2.lock`，不得使用通配符或递归删除。
+5. 重新运行只读 recovery preview。存在未完成 journal 时只能按其精确 fingerprint 授权 resume/rollback，不能当成全新升级。
 
 ## 4. repositoryId 与 Binding 准备
 

--- a/docs/architecture/v02-upgrade-protocol.md
+++ b/docs/architecture/v02-upgrade-protocol.md
@@ -45,13 +45,15 @@
 
 如果安装环境不能证明“旧入口已停用且不会在临界区重启”，apply 必须拒绝，要求关闭宿主后由离线升级入口执行。直接再次运行已被替换的 v0.1 二进制属于显式 downgrade：必须先走 rollback preview/authorization，不能把 v0.2 state 当作空 v0.1 state 打开。
 
-宿主集成必须提供三个动作：原子关闭 legacy start entry、独立确认该关闭仍生效、按升级终态恢复旧入口或完成新 bundle 接管。fence 在关闭入口后同时读取宿主 live task/job 与操作系统进程表，等待全部退出，并在进入 prepare 前再次确认入口仍关闭。只传入一份调用方声称为空的 activity 列表不构成 fence；缺少任一宿主动作时只能拒绝在线 apply。
+未来的在线宿主集成必须提供三个动作：原子关闭 legacy start entry、独立确认该关闭仍生效、按升级终态恢复旧入口或完成新 bundle 接管。fence 在关闭入口后同时读取宿主 live task/job 与操作系统进程表，等待全部退出，并在进入 prepare 前再次确认入口仍关闭。只传入一份调用方声称为空的 activity 列表不构成 fence；缺少任一宿主动作时只能拒绝在线 apply。
+
+当前 Slice 2 只开放离线 factory：操作者必须显式声明 DSH 宿主已经停止且升级期间不会重启；factory 同时枚举 argv 可识别的独立 legacy 进程作为第二信号。进程内插件无法由 `ps` 的 argv 证明，因此这份离线声明是操作边界，不得包装成在线证明。在线 factory 在宿主 capability 真正接线前固定拒绝；`apply`/`resume`/`rollback` 还会在创建锁候选文件前拒绝任何调用方自造的 fence 对象。
 
 旧进程长期持有已打开文件描述符是 cutover 的危险窗口：仅看路径名无法发现它仍可向 rename 后的 cold backup 写入。因此进程退出必须发生在 state rename 之前；最终 verify 还必须重新计算 cold backup 的 inode、文件数、字节数和内容 hash。任一项漂移都不得写 `verified`。内容校验是第二道伤害检测，不替代先停旧进程，因为已污染的 backup 可能无法自动 rollback。
 
 ### 3.2 临界区顺序
 
-apply 的顺序固定为：取得升级锁 → 取得 generation fence → 临界区内活性检查 → 重算 fingerprint → 写 durable journal → prepare → cutover → read-back → `verified`/`rolled_back` → 释放 fence 和锁。任何失败都保持锁和 fence，直到进程退出或进入明确终态；新进程看到未完成 journal 时只能进入 recovery。
+apply 的顺序固定为：验证 fence 来自批准 factory → 取得升级锁 → 取得 generation fence → 临界区内活性检查 → 重算 fingerprint → 写 durable journal → prepare → cutover → read-back → `verified`/`rolled_back` → 释放 fence 和锁。任何失败都保持锁和 fence，直到进程退出或进入明确终态；新进程看到未完成 journal 时只能进入 recovery。
 
 ## 4. repositoryId 与 Binding 准备
 
@@ -176,8 +178,8 @@ rollback 用 config backup 生成同目录 temp，再按 fsync + atomic replace 
 
 ## 11. 实现与测试门禁
 
-- 双 upgrader 竞争只能有一个锁赢家；stale recovery 不得删除新 owner 的锁。
-- 在临界区活性检查前后尝试启动 v0.1 job，generation fence 必须拒绝；无法取得 fence 时 apply 为零写入。
+- 双 upgrader 竞争只能有一个锁赢家；stale recovery 不得删除新 owner 的锁；PID 复用或 zombie 必须由固定 locale/TZ 的启动身份与进程状态识别，不能永久卡锁。
+- 调用方自造/no-op fence 必须在锁候选文件产生前拒绝；在线 factory 在宿主接线前固定拒绝；离线 factory 必须要求显式 host-stopped 声明并拒绝可枚举的 legacy 进程。
 - 在每次 file fsync、rename、directory fsync 和 journal replace 前后注入真实文件系统失败，证明状态可 resume 或 rollback。
 - repositoryId 在 temp write、fsync、link 和目录 fsync 各窗口崩溃后，最终文件只能是完整合法值或不存在；不得出现空/半写最终文件。
 - `cp -r` 复制 sidecar、相同 remote 的独立 clone、linked worktree、路径移动、bare repository 和 submodule 均有真实 Git 测试。

--- a/docs/architecture/v02-upgrade-protocol.md
+++ b/docs/architecture/v02-upgrade-protocol.md
@@ -45,6 +45,10 @@
 
 如果安装环境不能证明“旧入口已停用且不会在临界区重启”，apply 必须拒绝，要求关闭宿主后由离线升级入口执行。直接再次运行已被替换的 v0.1 二进制属于显式 downgrade：必须先走 rollback preview/authorization，不能把 v0.2 state 当作空 v0.1 state 打开。
 
+宿主集成必须提供三个动作：原子关闭 legacy start entry、独立确认该关闭仍生效、按升级终态恢复旧入口或完成新 bundle 接管。fence 在关闭入口后同时读取宿主 live task/job 与操作系统进程表，等待全部退出，并在进入 prepare 前再次确认入口仍关闭。只传入一份调用方声称为空的 activity 列表不构成 fence；缺少任一宿主动作时只能拒绝在线 apply。
+
+旧进程长期持有已打开文件描述符是 cutover 的危险窗口：仅看路径名无法发现它仍可向 rename 后的 cold backup 写入。因此进程退出必须发生在 state rename 之前；最终 verify 还必须重新计算 cold backup 的 inode、文件数、字节数和内容 hash。任一项漂移都不得写 `verified`。内容校验是第二道伤害检测，不替代先停旧进程，因为已污染的 backup 可能无法自动 rollback。
+
 ### 3.2 临界区顺序
 
 apply 的顺序固定为：取得升级锁 → 取得 generation fence → 临界区内活性检查 → 重算 fingerprint → 写 durable journal → prepare → cutover → read-back → `verified`/`rolled_back` → 释放 fence 和锁。任何失败都保持锁和 fence，直到进程退出或进入明确终态；新进程看到未完成 journal 时只能进入 recovery。
@@ -167,6 +171,8 @@ prepare 任一步失败时，v0.1 config/state 仍保持原配对；只需保留
 rollback 用 config backup 生成同目录 temp，再按 fsync + atomic replace + parent fsync 恢复；state rollback 只移动 journal 精确证明的本次 v0.2 active/staging 目录，再把 cold backup 恢复到 active path。不得递归删除不明目录。已经成功创建且格式正确的 repositoryId sidecar 保留；任何清理都只针对 journal 证明为本次创建且未承载业务数据的 staging。
 
 损坏或缺失 journal 时，recovery inventory 必须展示所有候选 config/state/backup/staging 的 inode、schema、hash、mtime 和配对判断，零写入。重建 journal 与 rollback 都需要新的精确 preview/authorization，原始损坏 journal 不得覆盖。
+
+当前 Slice 2 对“journal 缺失/损坏且存在升级证据”作显式降级：返回 `manual-recovery-required` 与完整只读 inventory，不提供自动重建或无 journal rollback。原因是缺失 journal 时无法从文件名反推出原 plan、排除项和 identity 绑定，自动猜测会制造第二个阶段事实源。后续若实现 journal reconstruction，必须另做 L3 设计并授权精确 inode/path/hash；在此之前普通 preview、apply 和 runtime 一律 fail-closed。没有 journal 且不存在 backup/staging/schema-1 config/v0.2 marker 等升级证据时，才允许视为从未 apply。
 
 ## 11. 实现与测试门禁
 

--- a/docs/plans/2026-08-27-v02-upgrade-slice-2-invariants.md
+++ b/docs/plans/2026-08-27-v02-upgrade-slice-2-invariants.md
@@ -45,8 +45,9 @@
 - 每个 file write/fsync、publish/rename、directory fsync、journal replace 前后可确定性注入失败。
 - 双进程竞争 upgrade lock；owner token 保留进程启动标识用于审计，但 stale 回收只接受 `ESRCH` 明确死亡，活 PID 的启动字符串不匹配一律不抢。
 - fence 建立前后同时尝试启动 ClickVibe task，均不得越过线性化点。
-- fence 必须由宿主关闭 legacy start entry、再次确认入口仍关闭，并独立枚举操作系统进程；无法证明时只允许离线升级。活 PID 即使启动时间字符串不匹配也不可抢锁。
+- 当前 Slice 2 只允许显式声明宿主已停止且不会重启的离线 factory；在线 factory 在宿主 capability 接线前固定拒绝。调用方自造/no-op fence 在锁候选写入前拒绝，OS 进程枚举只作为离线边界的第二信号，不冒充对 DSH 进程内插件的证明。
+- 锁 owner 使用固定 `LANG/LC_ALL=C`、`TZ=UTC` 的启动身份；PID 对应 zombie 或启动身份变化才按 PID 复用回收，身份读取不明继续 fail closed。
 - cold backup 按原 inode、文件数、字节数和目录内容 hash 回读；旧进程长开 fd 污染 rename 后 backup 时不得写 `verified`。
 - preview/apply 之间修改 config/state/repository/worktree 任一输入，apply 必须回到 previewed 且零准备写入。
 - 成功、prepare 失败、cutover 失败、resume、rollback 后对 Git worktree/refs/dirty bytes 做前后快照比较。
-- journal 缺失/损坏且出现 backup/staging/schema-1/v0.2 证据时进入 `manual-recovery-required` 只读 inventory；不得假装首次升级，也不得覆盖原始损坏 journal。
+- journal 缺失/损坏且出现升级器完整时间戳+UUID 格式的 backup/staging、schema-1 config 或 v0.2 marker 时进入 `manual-recovery-required` 只读 inventory；普通撞名前缀文件不是升级证据。

--- a/docs/plans/2026-08-27-v02-upgrade-slice-2-invariants.md
+++ b/docs/plans/2026-08-27-v02-upgrade-slice-2-invariants.md
@@ -31,7 +31,7 @@
 |---|---|---|
 | `~/.clickvibe/config.yaml` legacy `repos` | `src/infra/project-config.ts` | schema/journal generation gate；schema 1 拒绝 legacy mutation |
 | workflow JSON | `src/infra/workflow-persistence.ts` | cross-process workflow lock 内检查 active state generation |
-| legacy workflow 搬移 | `src/infra/state.ts::migrateLegacyState` | v0.2 marker 时禁止扫描和搬移 |
+| legacy workflow 搬移 | `src/infra/state.ts::migrateLegacyState` | 扫描前和每个 mkdir/link/rm 前检查 generation；generation violation 不得被 best-effort catch 吞掉 |
 | task JSONL | `src/infra/task-log-store.ts` 经 `state.ts` | state generation gate；不得吞掉 generation violation |
 | diagnostic JSONL | `src/infra/diagnostic-log-store.ts` 经 `task-diagnostics.ts` | state generation gate；升级错误写专用 journal，不回写 legacy state |
 | agent/host job 启动 | `createLiveTask` → `reserveHostTask` → `attachAgentProcess` | process generation fence + active marker 双检查 |
@@ -43,7 +43,10 @@
 ## 对抗性验证
 
 - 每个 file write/fsync、publish/rename、directory fsync、journal replace 前后可确定性注入失败。
-- 双进程竞争 upgrade lock；PID 复用通过进程启动标识而不是仅 `kill(pid, 0)` 判断。
+- 双进程竞争 upgrade lock；owner token 保留进程启动标识用于审计，但 stale 回收只接受 `ESRCH` 明确死亡，活 PID 的启动字符串不匹配一律不抢。
 - fence 建立前后同时尝试启动 ClickVibe task，均不得越过线性化点。
+- fence 必须由宿主关闭 legacy start entry、再次确认入口仍关闭，并独立枚举操作系统进程；无法证明时只允许离线升级。活 PID 即使启动时间字符串不匹配也不可抢锁。
+- cold backup 按原 inode、文件数、字节数和目录内容 hash 回读；旧进程长开 fd 污染 rename 后 backup 时不得写 `verified`。
 - preview/apply 之间修改 config/state/repository/worktree 任一输入，apply 必须回到 previewed 且零准备写入。
 - 成功、prepare 失败、cutover 失败、resume、rollback 后对 Git worktree/refs/dirty bytes 做前后快照比较。
+- journal 缺失/损坏且出现 backup/staging/schema-1/v0.2 证据时进入 `manual-recovery-required` 只读 inventory；不得假装首次升级，也不得覆盖原始损坏 journal。

--- a/docs/plans/2026-08-27-v02-upgrade-slice-2-invariants.md
+++ b/docs/plans/2026-08-27-v02-upgrade-slice-2-invariants.md
@@ -43,10 +43,10 @@
 ## 对抗性验证
 
 - 每个 file write/fsync、publish/rename、directory fsync、journal replace 前后可确定性注入失败。
-- 双进程竞争 upgrade lock；owner token 保留进程启动标识用于审计，但 stale 回收只接受 `ESRCH` 明确死亡，活 PID 的启动字符串不匹配一律不抢。
+- 双进程竞争 upgrade lock；旧版 schema 1 owner 的启动字符串受 locale/timezone 影响，活 PID 一律不抢，只接受 `ESRCH` 明确死亡；schema 2 owner 才允许用固定 UTC 启动身份识别 PID 复用。
 - fence 建立前后同时尝试启动 ClickVibe task，均不得越过线性化点。
 - 当前 Slice 2 只允许显式声明宿主已停止且不会重启的离线 factory；在线 factory 在宿主 capability 接线前固定拒绝。调用方自造/no-op fence 在锁候选写入前拒绝，OS 进程枚举只作为离线边界的第二信号，不冒充对 DSH 进程内插件的证明。
-- 锁 owner 使用固定 `LANG/LC_ALL=C`、`TZ=UTC` 的启动身份；PID 对应 zombie 或启动身份变化才按 PID 复用回收，身份读取不明继续 fail closed。
+- schema 2 锁 owner 使用固定 `LANG/LC_ALL=C`、`TZ=UTC` 的启动身份；PID 对应 zombie 或启动身份变化才按 PID 复用回收，身份读取不明继续 fail closed。schema 1 保持 ESRCH-only，避免把旧时区字符串误判为 PID 复用。
 - cold backup 按原 inode、文件数、字节数和目录内容 hash 回读；旧进程长开 fd 污染 rename 后 backup 时不得写 `verified`。
 - preview/apply 之间修改 config/state/repository/worktree 任一输入，apply 必须回到 previewed 且零准备写入。
 - 成功、prepare 失败、cutover 失败、resume、rollback 后对 Git worktree/refs/dirty bytes 做前后快照比较。

--- a/docs/plans/2026-08-27-v02-upgrade-slice-2-invariants.md
+++ b/docs/plans/2026-08-27-v02-upgrade-slice-2-invariants.md
@@ -1,0 +1,49 @@
+# #134 Slice 2 升级不变量与写入路径枚举
+
+> Implementation baseline: `553a926405919bd3efc677fbd9bf0388f7c6a26d` | Architecture baseline: `c866399f360fd3505be9b16980e56cc931308d9a` | Protocol: `docs/architecture/v02-upgrade-protocol.md`
+
+本文不是新的架构决策。它把 Accepted 升级协议翻译成 Slice 2 的施工检查表，供 Coding 和 exact-SHA Review 对照。
+
+## 不变量
+
+1. **代次配对只有两种合法答案**：legacy config + legacy state，或 schema-1 config + v0.2 state marker；混合代次、unknown schema 和损坏 journal 都不可写。
+2. **升级阶段只有 journal 回答**：文件存在或缺失只能用于验证 journal，不能自行推导 `prepared`、`verified` 或 `rolled_back`。
+3. **preview 零磁盘写入**：repositoryId 候选、备份名、staging 名和目标 config 都先进入 plan；授权只绑定这一份 plan fingerprint。
+4. **写权限由双凭证构造**：apply/resume/rollback 必须同时持有跨进程 upgrade lock 和当前宿主 generation fence；校验在两者内部完成。
+5. **prepare 不破坏 legacy 配对**：journal、config backup、repositoryId、staged config/state 全部回读成功后才允许 cutover。
+6. **cutover 只执行已记录的本地 rename/replace**：每个破坏性动作先 durable 写 intent，动作后回读，再 durable 写 done。
+7. **事实变化使授权失效**：锁和 fence 内重做完整观察；fingerprint 不一致时零 sidecar、零 backup、零 staging 写入。
+8. **Git 现场只观察**：worktree、branch、HEAD、dirty、conflict、ahead 不自动导入、reset、stash、删除或 push。
+9. **cold backup 永不自动删除**：rollback 只移动 journal 精确证明属于本次升级的路径，不递归清理不明资产。
+10. **v0.2 marker 是 legacy 写入禁令**：一旦 active state 是 v0.2，legacy workflow、task log、diagnostic 和 config `repos` 写入口全部 fail closed。
+
+## 原子提交单元
+
+- plan authorization：完整 `UpgradePlan` + fingerprint，一次性消费。
+- prepare：journal 每个 phase 是独立 durable 原子记录；legacy config/state 仍保持原配对。
+- state cutover：`state-backup-intent/done` 与 `state-activate-intent/done` 分段记录并回读。
+- config cutover：`config-activate-intent/done` 分段记录并完整 parse/read-back。
+- terminal：只有 read-back 全通过才能写 `verified`；只有 legacy 配对恢复并回读才能写 `rolled_back`。
+
+## 写入路径静态枚举
+
+| 路径 | 当前写入口 | Slice 2 保护方式 |
+|---|---|---|
+| `~/.clickvibe/config.yaml` legacy `repos` | `src/infra/project-config.ts` | schema/journal generation gate；schema 1 拒绝 legacy mutation |
+| workflow JSON | `src/infra/workflow-persistence.ts` | cross-process workflow lock 内检查 active state generation |
+| legacy workflow 搬移 | `src/infra/state.ts::migrateLegacyState` | v0.2 marker 时禁止扫描和搬移 |
+| task JSONL | `src/infra/task-log-store.ts` 经 `state.ts` | state generation gate；不得吞掉 generation violation |
+| diagnostic JSONL | `src/infra/diagnostic-log-store.ts` 经 `task-diagnostics.ts` | state generation gate；升级错误写专用 journal，不回写 legacy state |
+| agent/host job 启动 | `createLiveTask` → `reserveHostTask` → `attachAgentProcess` | process generation fence + active marker 双检查 |
+| sync/merge/restore/provider 写 | `src/workflow/dispatch.ts` 统一入口 | generation gate 在动作分发前执行；后台回调仍由 persistence/fence 兜底 |
+| repositoryId | `src/infra/repository-identity.ts` | plan 固定候选 ID；apply 内竞争发布；赢家不同则授权失效 |
+| upgrade journal/config backup/staging/marker | Slice 2 durable adapter | same-directory temp + fsync + atomic publish/replace + parent fsync |
+| state/config destructive rename | Slice 2 cutover/recovery | lock + fence + journal intent + rename + parent fsync + read-back + done |
+
+## 对抗性验证
+
+- 每个 file write/fsync、publish/rename、directory fsync、journal replace 前后可确定性注入失败。
+- 双进程竞争 upgrade lock；PID 复用通过进程启动标识而不是仅 `kill(pid, 0)` 判断。
+- fence 建立前后同时尝试启动 ClickVibe task，均不得越过线性化点。
+- preview/apply 之间修改 config/state/repository/worktree 任一输入，apply 必须回到 previewed 且零准备写入。
+- 成功、prepare 失败、cutover 失败、resume、rollback 后对 Git worktree/refs/dirty bytes 做前后快照比较。

--- a/src/agent/task-supervisor.ts
+++ b/src/agent/task-supervisor.ts
@@ -37,6 +37,7 @@ import {
 } from '../infra/runtime.ts'
 import { appendTaskLog, type IssueWorkflow, startTaskLog } from '../infra/state.ts'
 import { logTaskDiagnostic, waitForTaskDiagnosticPersistence } from '../infra/task-diagnostics.ts'
+import { assertLegacyTaskStartAllowed } from '../infra/v02-generation-fence.ts'
 import {
   type AgentKind,
   lossyAgentOutputNotice,
@@ -147,6 +148,7 @@ export function createLiveTask(
   agent: DevelopAgent,
   sessionId: string | null,
 ): LiveTask {
+  assertLegacyTaskStartAllowed()
   for (const [id, task] of liveTasks) {
     if (liveTasks.size < MAX_TASKS) break
     if (task.closed) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,11 @@ declare module '@deepseek-ai/cordis' {
 }
 
 export { ROUTE } from './infra/http-contract.ts'
-export { createV02GenerationFence } from './infra/v02-generation-fence.ts'
+export {
+  createOfflineV02GenerationFence,
+  createOnlineV02GenerationFence,
+  V02_OFFLINE_HOST_DECLARATION,
+} from './infra/v02-generation-fence.ts'
 export { applyV02Upgrade } from './infra/v02-upgrade-execution.ts'
 export { previewV02UpgradeRecovery, resumeV02Upgrade, rollbackV02Upgrade } from './infra/v02-upgrade-recovery.ts'
 export { previewV02Upgrade, v02UpgradePlanFingerprint } from './infra/v02-upgrade.ts'

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,10 @@ declare module '@deepseek-ai/cordis' {
 }
 
 export { ROUTE } from './infra/http-contract.ts'
+export { createV02GenerationFence } from './infra/v02-generation-fence.ts'
+export { applyV02Upgrade } from './infra/v02-upgrade-execution.ts'
+export { previewV02UpgradeRecovery, resumeV02Upgrade, rollbackV02Upgrade } from './infra/v02-upgrade-recovery.ts'
+export { previewV02Upgrade, v02UpgradePlanFingerprint } from './infra/v02-upgrade.ts'
 
 export const name = 'clickvibe'
 

--- a/src/infra/diagnostic-log-store.ts
+++ b/src/infra/diagnostic-log-store.ts
@@ -1,6 +1,7 @@
 import { appendFile, mkdir, rename, rm, stat } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { diagnosticLogPath } from './state-layout.ts'
+import { assertLegacyStateWriteAllowed } from './v02-generation-fence.ts'
 
 export const DEFAULT_DIAGNOSTIC_MAX_BYTES = 5 * 1024 * 1024
 
@@ -50,6 +51,7 @@ export function appendDiagnosticLine(
   line: string,
   maxBytes: unknown | Promise<unknown>,
 ): Promise<void> {
+  assertLegacyStateWriteAllowed(root)
   const path = diagnosticLogPath(root, workflowKey)
   return enqueue(path, async () => {
     const limit = configuredMaxBytes(await maxBytes)

--- a/src/infra/diagnostic-log-store.ts
+++ b/src/infra/diagnostic-log-store.ts
@@ -54,14 +54,18 @@ export function appendDiagnosticLine(
   assertLegacyStateWriteAllowed(root)
   const path = diagnosticLogPath(root, workflowKey)
   return enqueue(path, async () => {
+    assertLegacyStateWriteAllowed(root)
     const limit = configuredMaxBytes(await maxBytes)
     const record = `${line}\n`
     await mkdir(dirname(path), { recursive: true })
     const existingBytes = await fileSize(path)
     if (existingBytes > 0 && existingBytes + Buffer.byteLength(record, 'utf8') > limit) {
+      assertLegacyStateWriteAllowed(root)
       await rm(rotatedPath(path), { force: true })
+      assertLegacyStateWriteAllowed(root)
       await rename(path, rotatedPath(path))
     }
+    assertLegacyStateWriteAllowed(root)
     await appendFile(path, record, 'utf8')
   })
 }

--- a/src/infra/project-config.ts
+++ b/src/infra/project-config.ts
@@ -36,9 +36,12 @@ export async function addProjectRepoMapping(
   document.setIn(['repos', repoKey], projectPath)
   const next = document.toString()
   const temporary = `${path}.tmp-${process.pid}-${randomBytes(6).toString('hex')}`
+  assertLegacyStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
   await mkdir(dirname(path), { recursive: true })
   try {
+    assertLegacyStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
     await writeFile(temporary, next, { encoding: 'utf8', mode: 0o600 })
+    assertLegacyStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
     await rename(temporary, path)
   } catch (reason) {
     await unlink(temporary).catch(() => {})

--- a/src/infra/project-config.ts
+++ b/src/infra/project-config.ts
@@ -4,11 +4,13 @@ import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { isMap, parseDocument } from 'yaml'
+import { assertLegacyStateWriteAllowed } from './v02-generation-fence.ts'
 
 export async function addProjectRepoMapping(
   repoKey: string,
   projectPath: string,
 ): Promise<{ added: true } | { added: false; error: string }> {
+  assertLegacyStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
   const path = join(homedir(), '.clickvibe', 'config.yaml')
   let raw: string
   try {

--- a/src/infra/repository-identity.ts
+++ b/src/infra/repository-identity.ts
@@ -173,13 +173,36 @@ export async function ensureRepositoryId(
   repositoryPath: string,
   operations: RepositoryIdentityPublicationOperations = nodePublicationOperations,
 ): Promise<string> {
+  return ensureRepositoryIdValue(repositoryPath, null, operations)
+}
+
+/** Publish the exact repositoryId frozen by an authorized upgrade plan. */
+export async function ensurePlannedRepositoryId(
+  repositoryPath: string,
+  plannedRepositoryId: string,
+  operations: RepositoryIdentityPublicationOperations = nodePublicationOperations,
+): Promise<string> {
+  if (!isRepositoryId(plannedRepositoryId)) throw new Error('planned repositoryId is invalid')
+  return ensureRepositoryIdValue(repositoryPath, plannedRepositoryId, operations)
+}
+
+async function ensureRepositoryIdValue(
+  repositoryPath: string,
+  plannedRepositoryId: string | null,
+  operations: RepositoryIdentityPublicationOperations,
+): Promise<string> {
   const location = await inspectRepositoryIdentityLocation(repositoryPath)
   const identityDirectory = dirname(location.repositoryIdPath)
   await ensureIdentityDirectory(identityDirectory)
   const existing = await existingRepositoryId(location.repositoryIdPath)
-  if (existing !== null) return existing
+  if (existing !== null) {
+    if (plannedRepositoryId !== null && existing !== plannedRepositoryId) {
+      throw new Error(`repositoryId changed after preview: planned ${plannedRepositoryId}, found ${existing}`)
+    }
+    return existing
+  }
 
-  const repositoryId = `repo_${randomUUID()}`
+  const repositoryId = plannedRepositoryId ?? `repo_${randomUUID()}`
   const temporary = join(identityDirectory, `.repository-id.tmp-${process.pid}-${randomUUID()}`)
   const handle = await operations.openTemporary(temporary)
   const preparationFailures: unknown[] = []
@@ -206,7 +229,11 @@ export async function ensureRepositoryId(
   }
   await captureFailure(publicationFailures, () => operations.remove(temporary))
   throwFailures(publicationFailures, `repositoryId publication failed for ${location.repositoryIdPath}`)
-  return published ? repositoryId : readRepositoryIdPath(location.repositoryIdPath)
+  const result = published ? repositoryId : await readRepositoryIdPath(location.repositoryIdPath)
+  if (plannedRepositoryId !== null && result !== plannedRepositoryId) {
+    throw new Error(`repositoryId changed during publication: planned ${plannedRepositoryId}, found ${result}`)
+  }
+  return result
 }
 
 export async function verifyProjectBindingRepository(value: unknown): Promise<VerifiedProjectBindingRepository> {

--- a/src/infra/runtime.ts
+++ b/src/infra/runtime.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'node:crypto'
+import { createHash, randomBytes } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import type { IncomingMessage, ServerResponse } from 'node:http'
@@ -27,6 +27,9 @@ import { join, resolve } from 'node:path'
  */
 import type { Context } from '@deepseek-ai/cordis'
 import { parse as parseYaml } from 'yaml'
+import { parseClickVibeConfigV1 } from './project-binding.ts'
+import { verifyProjectBindingRepository } from './repository-identity.ts'
+import { v02UpgradePlanFingerprint, type V02UpgradePlan } from './v02-upgrade.ts'
 import {
   type AgentAuthorization,
   type AgentAuthorizationInput,
@@ -45,6 +48,7 @@ import { ExclusiveTaskGate } from './task-gate.ts'
 const MAX_BODY_BYTES = 64 * 1024
 
 export interface ClickVibeConfig {
+  schemaVersion?: 1
   repos: Record<string, string>
   worktreeRoot: string
   /** Remote-ref refresh interval for read paths. Clamped to 30-60 seconds. */
@@ -123,25 +127,90 @@ export function expandHome(path: string): string {
   return path
 }
 
-/** Read and parse ~/.clickvibe/config.yaml; missing/invalid yields a default. */
-export async function loadConfig(): Promise<ClickVibeConfig> {
-  const path = join(homedir(), '.clickvibe', 'config.yaml')
+async function loadV02Config(home: string, raw: string, parsed: unknown): Promise<ClickVibeConfig> {
+  const root = join(home, '.clickvibe')
+  const config = parseClickVibeConfigV1(parsed)
+  const [journalRaw, markerRaw] = await Promise.all([
+    readFile(join(root, 'upgrade-v0.2.json'), 'utf8'),
+    readFile(join(root, 'state', '.clickvibe-state.json'), 'utf8'),
+  ])
+  const journal = JSON.parse(journalRaw) as {
+    schemaVersion?: unknown
+    phase?: unknown
+    planFingerprint?: unknown
+    plan?: V02UpgradePlan
+  }
+  const marker = JSON.parse(markerRaw) as { schemaVersion?: unknown; generation?: unknown; planFingerprint?: unknown }
+  if (journal.schemaVersion !== 1 || journal.phase !== 'verified' || typeof journal.planFingerprint !== 'string') {
+    throw new Error('v0.2 config is not paired with a verified upgrade journal')
+  }
+  if (!journal.plan || v02UpgradePlanFingerprint(journal.plan) !== journal.planFingerprint) {
+    throw new Error('v0.2 upgrade journal plan fingerprint is invalid')
+  }
+  if (
+    journal.plan.paths.root !== root ||
+    journal.plan.paths.activeConfig !== join(root, 'config.yaml') ||
+    journal.plan.paths.activeState !== join(root, 'state') ||
+    journal.plan.paths.journal !== join(root, 'upgrade-v0.2.json')
+  ) {
+    throw new Error('v0.2 upgrade journal paths do not belong to this ClickVibe home')
+  }
+  if (
+    marker.schemaVersion !== 1 ||
+    marker.generation !== 'v0.2' ||
+    marker.planFingerprint !== journal.planFingerprint
+  ) {
+    throw new Error('v0.2 state marker fingerprint does not match the verified journal')
+  }
+  const digest = createHash('sha256').update(raw).digest('hex')
+  if (journal.plan.targetConfig.sha256 !== digest) throw new Error('v0.2 config fingerprint does not match the journal')
+  const repos: Record<string, string> = {}
+  for (const binding of config.projectBindings) {
+    if (binding.container.provider !== 'github' || binding.container.instance !== 'github.com') {
+      throw new Error(
+        `unsupported active ProjectBinding provider: ${binding.container.provider}@${binding.container.instance}`,
+      )
+    }
+    const verified = await verifyProjectBindingRepository(binding)
+    repos[binding.container.id] = verified.localPath
+  }
+  return {
+    schemaVersion: 1,
+    repos,
+    worktreeRoot: config.worktreeRoot,
+    fetchTtlSeconds: config.fetchTtlSeconds,
+    diagnosticsMaxBytes: config.diagnosticsMaxBytes,
+  }
+}
+
+/** Read config for an explicit home; schema-1 requires a verified config/state pair. */
+export async function loadConfigFromHome(home: string): Promise<ClickVibeConfig> {
+  const path = join(home, '.clickvibe', 'config.yaml')
   try {
     const raw = await readFile(path, 'utf8')
-    const parsed = parseYaml(raw) as Partial<ClickVibeConfig> | null
+    const parsed = parseYaml(raw) as (Partial<ClickVibeConfig> & { schemaVersion?: unknown }) | null
+    if (parsed?.schemaVersion === 1) return loadV02Config(home, raw, parsed)
+    if (parsed?.schemaVersion !== undefined)
+      throw new Error(`unsupported ClickVibe config schemaVersion: ${parsed.schemaVersion}`)
     return {
       repos: parsed?.repos ?? {},
-      worktreeRoot: parsed?.worktreeRoot ? expandHome(parsed.worktreeRoot) : join(homedir(), '.clickvibe', 'worktrees'),
+      worktreeRoot: parsed?.worktreeRoot ? expandHome(parsed.worktreeRoot) : join(home, '.clickvibe', 'worktrees'),
       fetchTtlSeconds: parsed?.fetchTtlSeconds,
       diagnosticsMaxBytes: parsed?.diagnosticsMaxBytes,
     }
-  } catch {
+  } catch (reason) {
+    if ((reason as NodeJS.ErrnoException).code !== 'ENOENT') throw reason
     return {
       repos: {},
-      worktreeRoot: join(homedir(), '.clickvibe', 'worktrees'),
+      worktreeRoot: join(home, '.clickvibe', 'worktrees'),
       fetchTtlSeconds: DEFAULT_FETCH_TTL_SECONDS,
     }
   }
+}
+
+/** Read and strictly validate ~/.clickvibe/config.yaml. */
+export function loadConfig(): Promise<ClickVibeConfig> {
+  return loadConfigFromHome(homedir())
 }
 
 /** Extract owner/repo and issue number from a GitHub issue/PR URL. */

--- a/src/infra/runtime.ts
+++ b/src/infra/runtime.ts
@@ -186,18 +186,9 @@ async function loadV02Config(home: string, raw: string, parsed: unknown): Promis
 /** Read config for an explicit home; schema-1 requires a verified config/state pair. */
 export async function loadConfigFromHome(home: string): Promise<ClickVibeConfig> {
   const path = join(home, '.clickvibe', 'config.yaml')
+  let raw: string
   try {
-    const raw = await readFile(path, 'utf8')
-    const parsed = parseYaml(raw) as (Partial<ClickVibeConfig> & { schemaVersion?: unknown }) | null
-    if (parsed?.schemaVersion === 1) return loadV02Config(home, raw, parsed)
-    if (parsed?.schemaVersion !== undefined)
-      throw new Error(`unsupported ClickVibe config schemaVersion: ${parsed.schemaVersion}`)
-    return {
-      repos: parsed?.repos ?? {},
-      worktreeRoot: parsed?.worktreeRoot ? expandHome(parsed.worktreeRoot) : join(home, '.clickvibe', 'worktrees'),
-      fetchTtlSeconds: parsed?.fetchTtlSeconds,
-      diagnosticsMaxBytes: parsed?.diagnosticsMaxBytes,
-    }
+    raw = await readFile(path, 'utf8')
   } catch (reason) {
     if ((reason as NodeJS.ErrnoException).code !== 'ENOENT') throw reason
     return {
@@ -205,6 +196,18 @@ export async function loadConfigFromHome(home: string): Promise<ClickVibeConfig>
       worktreeRoot: join(home, '.clickvibe', 'worktrees'),
       fetchTtlSeconds: DEFAULT_FETCH_TTL_SECONDS,
     }
+  }
+  const parsed = parseYaml(raw) as (Partial<ClickVibeConfig> & { schemaVersion?: unknown }) | null
+  // Only the config file's own ENOENT selects defaults. Any schema-1 pairing
+  // error (missing journal/marker included) is an explicit fail-closed error.
+  if (parsed?.schemaVersion === 1) return await loadV02Config(home, raw, parsed)
+  if (parsed?.schemaVersion !== undefined)
+    throw new Error(`unsupported ClickVibe config schemaVersion: ${parsed.schemaVersion}`)
+  return {
+    repos: parsed?.repos ?? {},
+    worktreeRoot: parsed?.worktreeRoot ? expandHome(parsed.worktreeRoot) : join(home, '.clickvibe', 'worktrees'),
+    fetchTtlSeconds: parsed?.fetchTtlSeconds,
+    diagnosticsMaxBytes: parsed?.diagnosticsMaxBytes,
   }
 }
 

--- a/src/infra/state.ts
+++ b/src/infra/state.ts
@@ -24,6 +24,7 @@ import {
   workflowRevision,
   workflowStatePath,
 } from './workflow-persistence.ts'
+import { assertLegacyStateWriteAllowed, isV02GenerationViolation } from './v02-generation-fence.ts'
 export { WorkflowConflictError } from './workflow-persistence.ts'
 export type * from './workflow-persistence.ts'
 export { workflowRevision }
@@ -234,14 +235,17 @@ async function storedWorkflowFiles(): Promise<string[]> {
 }
 
 async function migrateWorkflowLogs(workflow: IssueWorkflow): Promise<void> {
+  const root = stateDir()
+  assertLegacyStateWriteAllowed(root)
   for (const kind of ['dev', 'review'] as const) {
     const taskId = kind === 'dev' ? workflow.devTaskId : workflow.reviewTaskId
     if (!taskId) continue
     const storageKeys = [workflow.key, legacyIssueKey(workflow.key)].filter((key): key is string => key !== null)
     for (const storageKey of storageKeys) {
       try {
+        assertLegacyStateWriteAllowed(root)
         await migrateLegacyLog(
-          stateDir(),
+          root,
           workflow,
           kind,
           taskId,
@@ -249,7 +253,8 @@ async function migrateWorkflowLogs(workflow: IssueWorkflow): Promise<void> {
           new Date(workflow.updatedAt || 0).toISOString(),
         )
         break
-      } catch {
+      } catch (reason) {
+        if (isV02GenerationViolation(reason)) throw reason
         // Best effort: try the legacy alias or leave the source for a later retry.
       }
     }
@@ -257,6 +262,8 @@ async function migrateWorkflowLogs(workflow: IssueWorkflow): Promise<void> {
 }
 
 async function migrateLegacyWorkflowFile(path: string): Promise<void> {
+  const root = stateDir()
+  assertLegacyStateWriteAllowed(root)
   const workflow = await readWorkflowFile(path)
   if (!workflow) return
   const destination = statePath(workflow)
@@ -264,12 +271,16 @@ async function migrateLegacyWorkflowFile(path: string): Promise<void> {
     const existing = await readWorkflowFile(destination)
     if (existing && existing.key !== workflow.key) throw new Error('workflow migration target belongs to another issue')
     if (!existing) {
+      assertLegacyStateWriteAllowed(root)
       await mkdir(join(destination, '..'), { recursive: true })
+      assertLegacyStateWriteAllowed(root)
       await link(path, destination)
     }
+    assertLegacyStateWriteAllowed(root)
     await rm(path)
     await migrateWorkflowLogs(workflow)
-  } catch {
+  } catch (reason) {
+    if (isV02GenerationViolation(reason)) throw reason
     // Migration is retryable and must not prevent startup.
   }
 }
@@ -278,10 +289,12 @@ const migrations = new Map<string, Promise<void>>()
 
 async function migrateLegacyState(): Promise<void> {
   const root = stateDir()
+  assertLegacyStateWriteAllowed(root)
   const existing = migrations.get(root)
   if (existing) return existing
   const migration = (async () => {
     try {
+      assertLegacyStateWriteAllowed(root)
       for (const entry of await readdir(root, { withFileTypes: true })) {
         if (entry.isFile() && entry.name.endsWith('.json')) {
           await migrateLegacyWorkflowFile(join(root, entry.name))
@@ -289,14 +302,18 @@ async function migrateLegacyState(): Promise<void> {
       }
       const archive = join(root, 'archive')
       try {
+        assertLegacyStateWriteAllowed(root)
         for (const entry of await readdir(archive, { withFileTypes: true })) {
           if (entry.isFile() && entry.name.endsWith('.json')) await migrateLegacyWorkflowFile(join(archive, entry.name))
         }
+        assertLegacyStateWriteAllowed(root)
         await rm(archive, { recursive: false }).catch(() => undefined)
-      } catch {
+      } catch (reason) {
+        if (isV02GenerationViolation(reason)) throw reason
         // No legacy archive directory.
       }
-    } catch {
+    } catch (reason) {
+      if (isV02GenerationViolation(reason)) throw reason
       // Missing state root or a transient read failure is non-fatal.
     }
   })()
@@ -362,7 +379,8 @@ export async function startTaskLog(
 ): Promise<void> {
   try {
     await createTaskLog(stateDir(), workflow, kind, taskId)
-  } catch {
+  } catch (reason) {
+    if (isV02GenerationViolation(reason)) throw reason
     // Log persistence remains best-effort.
   }
 }
@@ -377,7 +395,8 @@ export async function appendTaskLog(
 ): Promise<void> {
   try {
     await appendTaskLogRecord(stateDir(), workflow, kind, taskId, sequence, line, options)
-  } catch {
+  } catch (reason) {
+    if (isV02GenerationViolation(reason)) throw reason
     // Log persistence remains best-effort.
   }
 }
@@ -413,9 +432,12 @@ export async function appendLog(key: string, kind: 'dev' | 'review', line: strin
       }
     }
     const legacyPath = join(stateDir(), storageKey, `${kind}.log`)
+    assertLegacyStateWriteAllowed(stateDir())
     await mkdir(join(legacyPath, '..'), { recursive: true })
+    assertLegacyStateWriteAllowed(stateDir())
     await appendFile(legacyPath, `${line}\n`, 'utf8')
-  } catch {
+  } catch (reason) {
+    if (isV02GenerationViolation(reason)) throw reason
     // log persistence is best-effort
   }
 }

--- a/src/infra/task-log-store.ts
+++ b/src/infra/task-log-store.ts
@@ -2,6 +2,7 @@ import { appendFile, link, mkdir, readFile, readdir, rm, rmdir, writeFile } from
 import { dirname, join } from 'node:path'
 import { decodeLiveLogLine, encodeLiveLogEvent, type LiveLogEvent } from './live-output.ts'
 import { taskLogPath, type WorkflowStorageIdentity } from './state-layout.ts'
+import { assertLegacyStateWriteAllowed } from './v02-generation-fence.ts'
 
 export type TaskLogKind = 'dev' | 'review'
 export type TaskExitStatus = 'done' | 'failed' | 'stopped' | 'timed_out'
@@ -118,6 +119,7 @@ export async function startTaskLog(
   kind: TaskLogKind,
   taskId: string,
 ): Promise<void> {
+  assertLegacyStateWriteAllowed(root)
   const path = taskLogPath(root, workflow, kind, taskId)
   await enqueue(path, async () => {
     await mkdir(dirname(path), { recursive: true })
@@ -138,6 +140,7 @@ export async function appendTaskLog(
   encodedLine: string,
   options: AppendTaskLogOptions = {},
 ): Promise<void> {
+  assertLegacyStateWriteAllowed(root)
   const path = taskLogPath(root, workflow, kind, taskId)
   const record = taskRecord(taskId, sequence, encodedLine, options)
   await enqueue(path, async () => {
@@ -212,6 +215,7 @@ export async function appendTaskLogNext(
   encodedLine: string,
   options: AppendTaskLogOptions = {},
 ): Promise<void> {
+  assertLegacyStateWriteAllowed(root)
   const path = taskLogPath(root, workflow, kind, taskId)
   await enqueue(path, async () => {
     await mkdir(dirname(path), { recursive: true })
@@ -241,6 +245,7 @@ export async function migrateLegacyLog(
   legacyPath: string,
   timestamp: string,
 ): Promise<void> {
+  assertLegacyStateWriteAllowed(root)
   const destination = taskLogPath(root, workflow, kind, taskId)
   const raw = await readFile(legacyPath, 'utf8')
   const lines = raw.split('\n')

--- a/src/infra/task-log-store.ts
+++ b/src/infra/task-log-store.ts
@@ -122,8 +122,10 @@ export async function startTaskLog(
   assertLegacyStateWriteAllowed(root)
   const path = taskLogPath(root, workflow, kind, taskId)
   await enqueue(path, async () => {
+    assertLegacyStateWriteAllowed(root)
     await mkdir(dirname(path), { recursive: true })
     try {
+      assertLegacyStateWriteAllowed(root)
       await writeFile(path, '', { encoding: 'utf8', flag: 'wx' })
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
@@ -144,7 +146,9 @@ export async function appendTaskLog(
   const path = taskLogPath(root, workflow, kind, taskId)
   const record = taskRecord(taskId, sequence, encodedLine, options)
   await enqueue(path, async () => {
+    assertLegacyStateWriteAllowed(root)
     await mkdir(dirname(path), { recursive: true })
+    assertLegacyStateWriteAllowed(root)
     await appendFile(path, `${JSON.stringify(record)}\n`, 'utf8')
   })
 }
@@ -218,6 +222,7 @@ export async function appendTaskLogNext(
   assertLegacyStateWriteAllowed(root)
   const path = taskLogPath(root, workflow, kind, taskId)
   await enqueue(path, async () => {
+    assertLegacyStateWriteAllowed(root)
     await mkdir(dirname(path), { recursive: true })
     let sequence = 1
     try {
@@ -233,6 +238,7 @@ export async function appendTaskLogNext(
     } catch {
       // Missing task file is created by appendFile.
     }
+    assertLegacyStateWriteAllowed(root)
     await appendFile(path, `${JSON.stringify(taskRecord(taskId, sequence, encodedLine, options))}\n`, 'utf8')
   })
 }
@@ -252,10 +258,12 @@ export async function migrateLegacyLog(
   if (lines.at(-1) === '') lines.pop()
   const records = lines.map((line, index) => taskRecord(taskId, index + 1, line, { ts: timestamp }))
   const serialized = records.map((record) => JSON.stringify(record)).join('\n') + (records.length ? '\n' : '')
+  assertLegacyStateWriteAllowed(root)
   await mkdir(dirname(destination), { recursive: true })
   try {
     const existing = await readFile(destination, 'utf8')
     if (existing !== serialized) throw new Error('existing task log differs from legacy source')
+    assertLegacyStateWriteAllowed(root)
     await rm(legacyPath)
     await rmdir(join(legacyPath, '..')).catch(() => undefined)
     return
@@ -263,15 +271,19 @@ export async function migrateLegacyLog(
     // Destination is absent or incomplete; complete it through an exclusive link.
   }
   const temporary = `${destination}.migrating`
+  assertLegacyStateWriteAllowed(root)
   await writeFile(temporary, serialized, 'utf8')
   try {
+    assertLegacyStateWriteAllowed(root)
     await link(temporary, destination)
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
     const existing = await readFile(destination, 'utf8')
     if (existing !== (await readFile(temporary, 'utf8'))) throw error
   }
+  assertLegacyStateWriteAllowed(root)
   await rm(temporary, { force: true })
+  assertLegacyStateWriteAllowed(root)
   await rm(legacyPath)
   await rmdir(join(legacyPath, '..')).catch(() => undefined)
 }

--- a/src/infra/v02-generation-fence.ts
+++ b/src/infra/v02-generation-fence.ts
@@ -1,0 +1,102 @@
+/** Process-generation fence shared by legacy task starts and the v0.2 upgrader. */
+import { existsSync, lstatSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import type { V02UpgradeGenerationFence, V02UpgradeOutcome } from './v02-upgrade-execution.ts'
+import type { V02UpgradeHostActivity } from './v02-upgrade.ts'
+
+interface FenceState {
+  mode: 'legacy-open' | 'upgrade-held' | 'v0.2-active'
+  token: symbol | null
+}
+
+const fenceSymbol = Symbol.for('clickvibe.v02-generation-fence')
+const shared = globalThis as typeof globalThis & { [fenceSymbol]?: FenceState }
+const fenceState = shared[fenceSymbol] ?? { mode: 'legacy-open', token: null }
+if (!shared[fenceSymbol]) shared[fenceSymbol] = fenceState
+
+function clickvibeRootForState(stateRoot: string): string {
+  return dirname(stateRoot)
+}
+
+function journalPhase(root: string): string | null {
+  const path = join(root, 'upgrade-v0.2.json')
+  if (!existsSync(path)) return null
+  try {
+    const metadata = lstatSync(path)
+    if (!metadata.isFile() || metadata.isSymbolicLink()) return 'unknown'
+    const value = JSON.parse(readFileSync(path, 'utf8')) as { schemaVersion?: unknown; phase?: unknown }
+    return value.schemaVersion === 1 && typeof value.phase === 'string' ? value.phase : 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}
+
+function hasV02Marker(stateRoot: string): boolean {
+  const path = join(stateRoot, '.clickvibe-state.json')
+  if (!existsSync(path)) return false
+  try {
+    const metadata = lstatSync(path)
+    if (!metadata.isFile() || metadata.isSymbolicLink()) return true
+    const value = JSON.parse(readFileSync(path, 'utf8')) as { schemaVersion?: unknown; generation?: unknown }
+    return value.schemaVersion === 1 && value.generation === 'v0.2'
+  } catch {
+    return true
+  }
+}
+
+/** Reject every legacy writer once an upgrade journal or v0.2 marker owns the state root. */
+export function assertLegacyStateWriteAllowed(stateRoot: string): void {
+  if (fenceState.mode !== 'legacy-open') throw new Error('legacy state write blocked by the v0.2 generation fence')
+  const phase = journalPhase(clickvibeRootForState(stateRoot))
+  if (phase !== null && phase !== 'rolled_back') {
+    throw new Error(`legacy state write blocked by v0.2 recovery journal (${phase})`)
+  }
+  if (hasV02Marker(stateRoot)) throw new Error('legacy state write blocked by active v0.2 state')
+}
+
+/** Synchronous start boundary: no task can slip between fence acquisition and host observation. */
+export function assertLegacyTaskStartAllowed(): void {
+  if (fenceState.mode === 'upgrade-held') throw new Error('legacy task start blocked by the v0.2 generation fence')
+  if (fenceState.mode === 'v0.2-active') throw new Error('legacy task start blocked by the active v0.2 generation')
+  assertLegacyStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
+}
+
+export function createV02GenerationFence(observe: () => Promise<V02UpgradeHostActivity>): V02UpgradeGenerationFence {
+  return {
+    async acquire() {
+      if (fenceState.mode !== 'legacy-open') throw new Error(`cannot acquire generation fence from ${fenceState.mode}`)
+      const token = Symbol('v0.2-upgrade')
+      fenceState.mode = 'upgrade-held'
+      fenceState.token = token
+      try {
+        const activity = await observe()
+        let released = false
+        return {
+          activity,
+          async release(outcome: V02UpgradeOutcome) {
+            if (released) return
+            if (fenceState.token !== token || fenceState.mode !== 'upgrade-held') {
+              throw new Error('v0.2 generation fence ownership changed before release')
+            }
+            fenceState.mode = outcome === 'verified' ? 'v0.2-active' : 'legacy-open'
+            fenceState.token = null
+            released = true
+          },
+        }
+      } catch (reason) {
+        if (fenceState.token === token) {
+          fenceState.mode = 'legacy-open'
+          fenceState.token = null
+        }
+        throw reason
+      }
+    },
+  }
+}
+
+/** Test-only reset for the process-global fence singleton. */
+export function resetV02GenerationFenceForTest(): void {
+  fenceState.mode = 'legacy-open'
+  fenceState.token = null
+}

--- a/src/infra/v02-generation-fence.ts
+++ b/src/infra/v02-generation-fence.ts
@@ -1,9 +1,13 @@
 /** Process-generation fence shared by legacy task starts and the v0.2 upgrader. */
+import { execFile } from 'node:child_process'
 import { existsSync, lstatSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
+import { promisify } from 'node:util'
 import type { V02UpgradeGenerationFence, V02UpgradeOutcome } from './v02-upgrade-execution.ts'
 import type { V02UpgradeHostActivity } from './v02-upgrade.ts'
+
+const execFileAsync = promisify(execFile)
 
 interface FenceState {
   mode: 'legacy-open' | 'upgrade-held' | 'v0.2-active'
@@ -14,6 +18,17 @@ const fenceSymbol = Symbol.for('clickvibe.v02-generation-fence')
 const shared = globalThis as typeof globalThis & { [fenceSymbol]?: FenceState }
 const fenceState = shared[fenceSymbol] ?? { mode: 'legacy-open', token: null }
 if (!shared[fenceSymbol]) shared[fenceSymbol] = fenceState
+
+export class V02GenerationViolationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'V02GenerationViolationError'
+  }
+}
+
+export function isV02GenerationViolation(reason: unknown): reason is V02GenerationViolationError {
+  return reason instanceof V02GenerationViolationError
+}
 
 function clickvibeRootForState(stateRoot: string): string {
   return dirname(stateRoot)
@@ -47,30 +62,103 @@ function hasV02Marker(stateRoot: string): boolean {
 
 /** Reject every legacy writer once an upgrade journal or v0.2 marker owns the state root. */
 export function assertLegacyStateWriteAllowed(stateRoot: string): void {
-  if (fenceState.mode !== 'legacy-open') throw new Error('legacy state write blocked by the v0.2 generation fence')
+  if (fenceState.mode !== 'legacy-open')
+    throw new V02GenerationViolationError('legacy state write blocked by the v0.2 generation fence')
   const phase = journalPhase(clickvibeRootForState(stateRoot))
   if (phase !== null && phase !== 'rolled_back') {
-    throw new Error(`legacy state write blocked by v0.2 recovery journal (${phase})`)
+    throw new V02GenerationViolationError(`legacy state write blocked by v0.2 recovery journal (${phase})`)
   }
-  if (hasV02Marker(stateRoot)) throw new Error('legacy state write blocked by active v0.2 state')
+  if (hasV02Marker(stateRoot)) throw new V02GenerationViolationError('legacy state write blocked by active v0.2 state')
 }
 
 /** Synchronous start boundary: no task can slip between fence acquisition and host observation. */
 export function assertLegacyTaskStartAllowed(): void {
-  if (fenceState.mode === 'upgrade-held') throw new Error('legacy task start blocked by the v0.2 generation fence')
-  if (fenceState.mode === 'v0.2-active') throw new Error('legacy task start blocked by the active v0.2 generation')
+  if (fenceState.mode === 'upgrade-held')
+    throw new V02GenerationViolationError('legacy task start blocked by the v0.2 generation fence')
+  if (fenceState.mode === 'v0.2-active')
+    throw new V02GenerationViolationError('legacy task start blocked by the active v0.2 generation')
   assertLegacyStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
 }
 
-export function createV02GenerationFence(observe: () => Promise<V02UpgradeHostActivity>): V02UpgradeGenerationFence {
+/**
+ * Enumerate independently running legacy plugin processes. The host confirmation
+ * below remains mandatory because an embedding host may hide plugin identity from
+ * argv; this OS observation is a second, independent safety signal.
+ */
+export async function enumerateLegacyClickVibeProcesses(): Promise<string[]> {
+  const result = await execFileAsync('ps', ['-axo', 'pid=,ppid=,command='], { encoding: 'utf8' })
+  const legacy = /(?:clickvibe-v0\.1-plugin|(?:^|[\s/])clickvibe\/(?:lib|src)\/index\.(?:js|ts)(?:\s|$))/i
+  return result.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((line) => {
+      const match = line.match(/^(\d+)\s+(\d+)\s+(.+)$/)
+      if (!match || Number(match[1]) === process.pid) return false
+      return legacy.test(match[3])
+    })
+    .sort()
+}
+
+export interface V02GenerationFenceIntegration {
+  /** Host-owned linearization point that blocks every legacy plugin/task entry. */
+  acquireLegacyEntryBlock(): Promise<void>
+  /** Independent proof that the acquired host block still owns every entry. */
+  confirmLegacyEntryDisabled(): Promise<boolean>
+  /** Reopen legacy entries on abort, or finalize their replacement on success. */
+  settleLegacyEntryBlock(outcome: V02UpgradeOutcome): Promise<void>
+  /** Host-owned live task/job observation after its start entry is closed. */
+  observeHostActivity(): Promise<V02UpgradeHostActivity>
+  /** Injectable only so tests can deterministically exercise the OS observer. */
+  enumerateOldPluginProcesses?: () => Promise<string[]>
+  waitForExitMs?: number
+  pollIntervalMs?: number
+}
+
+function hasActivity(activity: V02UpgradeHostActivity): boolean {
+  return activity.liveTasks.length > 0 || activity.liveJobs.length > 0 || activity.oldPluginProcesses.length > 0
+}
+
+async function waitForQuiescence(options: V02GenerationFenceIntegration): Promise<V02UpgradeHostActivity> {
+  const enumerate = options.enumerateOldPluginProcesses ?? enumerateLegacyClickVibeProcesses
+  const deadline = Date.now() + (options.waitForExitMs ?? 5_000)
+  const interval = options.pollIntervalMs ?? 25
+  let last: V02UpgradeHostActivity = { liveTasks: [], liveJobs: [], oldPluginProcesses: [] }
+  while (true) {
+    const [host, processes] = await Promise.all([options.observeHostActivity(), enumerate()])
+    last = {
+      liveTasks: [...new Set(host.liveTasks)].sort(),
+      liveJobs: [...new Set(host.liveJobs)].sort(),
+      oldPluginProcesses: [...new Set([...host.oldPluginProcesses, ...processes])].sort(),
+    }
+    if (!hasActivity(last)) return last
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `generation fence cannot prove quiescence; live tasks=${last.liveTasks.length}, live jobs=${last.liveJobs.length}, old ClickVibe processes=${last.oldPluginProcesses.length} still active`,
+      )
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, interval))
+  }
+}
+
+export function createV02GenerationFence(options: V02GenerationFenceIntegration): V02UpgradeGenerationFence {
   return {
     async acquire() {
       if (fenceState.mode !== 'legacy-open') throw new Error(`cannot acquire generation fence from ${fenceState.mode}`)
       const token = Symbol('v0.2-upgrade')
       fenceState.mode = 'upgrade-held'
       fenceState.token = token
+      let hostBlockAcquired = false
       try {
-        const activity = await observe()
+        await options.acquireLegacyEntryBlock()
+        hostBlockAcquired = true
+        if (!(await options.confirmLegacyEntryDisabled())) {
+          throw new Error('host cannot disable every legacy entry; close the host and use the offline upgrade entry')
+        }
+        const activity = await waitForQuiescence(options)
+        if (!(await options.confirmLegacyEntryDisabled())) {
+          throw new Error('legacy entry reopened during fence acquisition; use the offline upgrade entry')
+        }
         let released = false
         return {
           activity,
@@ -79,12 +167,23 @@ export function createV02GenerationFence(observe: () => Promise<V02UpgradeHostAc
             if (fenceState.token !== token || fenceState.mode !== 'upgrade-held') {
               throw new Error('v0.2 generation fence ownership changed before release')
             }
+            await options.settleLegacyEntryBlock(outcome)
             fenceState.mode = outcome === 'verified' ? 'v0.2-active' : 'legacy-open'
             fenceState.token = null
             released = true
           },
         }
       } catch (reason) {
+        if (hostBlockAcquired) {
+          try {
+            await options.settleLegacyEntryBlock('failed')
+          } catch (settleReason) {
+            throw new AggregateError(
+              [reason, settleReason],
+              'generation fence acquisition and host-block release failed',
+            )
+          }
+        }
         if (fenceState.token === token) {
           fenceState.mode = 'legacy-open'
           fenceState.token = null

--- a/src/infra/v02-generation-fence.ts
+++ b/src/infra/v02-generation-fence.ts
@@ -26,6 +26,24 @@ export class V02GenerationViolationError extends Error {
   }
 }
 
+const approvedFences = new WeakSet<V02UpgradeGenerationFence>()
+const disabledOnlineFences = new WeakSet<V02UpgradeGenerationFence>()
+
+function approveFence(fence: V02UpgradeGenerationFence): V02UpgradeGenerationFence {
+  approvedFences.add(fence)
+  return fence
+}
+
+/** Reject caller-built no-op fences before the upgrader creates its lock candidate. */
+export function assertApprovedV02GenerationFence(fence: V02UpgradeGenerationFence): void {
+  if (!approvedFences.has(fence)) {
+    throw new Error('v0.2 apply requires a generation fence from an approved generation fence factory')
+  }
+  if (disabledOnlineFences.has(fence)) {
+    throw new Error('online v0.2 apply is disabled until DSH host integration registers a real generation capability')
+  }
+}
+
 export function isV02GenerationViolation(reason: unknown): reason is V02GenerationViolationError {
   return reason instanceof V02GenerationViolationError
 }
@@ -100,16 +118,12 @@ export async function enumerateLegacyClickVibeProcesses(): Promise<string[]> {
     .sort()
 }
 
-export interface V02GenerationFenceIntegration {
-  /** Host-owned linearization point that blocks every legacy plugin/task entry. */
-  acquireLegacyEntryBlock(): Promise<void>
-  /** Independent proof that the acquired host block still owns every entry. */
-  confirmLegacyEntryDisabled(): Promise<boolean>
-  /** Reopen legacy entries on abort, or finalize their replacement on success. */
-  settleLegacyEntryBlock(outcome: V02UpgradeOutcome): Promise<void>
-  /** Host-owned live task/job observation after its start entry is closed. */
-  observeHostActivity(): Promise<V02UpgradeHostActivity>
-  /** Injectable only so tests can deterministically exercise the OS observer. */
+export const V02_OFFLINE_HOST_DECLARATION = 'host-stopped-and-restart-disabled' as const
+
+export interface V02OfflineGenerationFenceOptions {
+  /** Explicit operator assertion that the embedding DSH host is stopped and cannot restart during apply. */
+  declaration: typeof V02_OFFLINE_HOST_DECLARATION
+  /** Secondary observation for standalone legacy processes whose argv exposes ClickVibe. */
   enumerateOldPluginProcesses?: () => Promise<string[]>
   waitForExitMs?: number
   pollIntervalMs?: number
@@ -119,17 +133,17 @@ function hasActivity(activity: V02UpgradeHostActivity): boolean {
   return activity.liveTasks.length > 0 || activity.liveJobs.length > 0 || activity.oldPluginProcesses.length > 0
 }
 
-async function waitForQuiescence(options: V02GenerationFenceIntegration): Promise<V02UpgradeHostActivity> {
+async function waitForOfflineQuiescence(options: V02OfflineGenerationFenceOptions): Promise<V02UpgradeHostActivity> {
   const enumerate = options.enumerateOldPluginProcesses ?? enumerateLegacyClickVibeProcesses
   const deadline = Date.now() + (options.waitForExitMs ?? 5_000)
   const interval = options.pollIntervalMs ?? 25
   let last: V02UpgradeHostActivity = { liveTasks: [], liveJobs: [], oldPluginProcesses: [] }
   while (true) {
-    const [host, processes] = await Promise.all([options.observeHostActivity(), enumerate()])
+    const processes = await enumerate()
     last = {
-      liveTasks: [...new Set(host.liveTasks)].sort(),
-      liveJobs: [...new Set(host.liveJobs)].sort(),
-      oldPluginProcesses: [...new Set([...host.oldPluginProcesses, ...processes])].sort(),
+      liveTasks: [],
+      liveJobs: [],
+      oldPluginProcesses: [...new Set(processes)].sort(),
     }
     if (!hasActivity(last)) return last
     if (Date.now() >= deadline) {
@@ -141,24 +155,34 @@ async function waitForQuiescence(options: V02GenerationFenceIntegration): Promis
   }
 }
 
-export function createV02GenerationFence(options: V02GenerationFenceIntegration): V02UpgradeGenerationFence {
-  return {
+/** Online apply has no product factory until the DSH host owns a real entry-block capability. */
+export function createOnlineV02GenerationFence(): V02UpgradeGenerationFence {
+  const fence = approveFence({
+    async acquire() {
+      throw new Error('online v0.2 apply is disabled until DSH host integration registers a real generation capability')
+    },
+  })
+  disabledOnlineFences.add(fence)
+  return fence
+}
+
+/**
+ * Offline apply is the only executable Slice 2 path. The declaration covers the
+ * in-process-plugin shape that cannot be proven from argv; OS enumeration remains
+ * a secondary guard for independently running legacy binaries.
+ */
+export function createOfflineV02GenerationFence(options: V02OfflineGenerationFenceOptions): V02UpgradeGenerationFence {
+  if (options.declaration !== V02_OFFLINE_HOST_DECLARATION) {
+    throw new Error('offline v0.2 apply requires an explicit declaration that the DSH host is stopped')
+  }
+  return approveFence({
     async acquire() {
       if (fenceState.mode !== 'legacy-open') throw new Error(`cannot acquire generation fence from ${fenceState.mode}`)
       const token = Symbol('v0.2-upgrade')
       fenceState.mode = 'upgrade-held'
       fenceState.token = token
-      let hostBlockAcquired = false
       try {
-        await options.acquireLegacyEntryBlock()
-        hostBlockAcquired = true
-        if (!(await options.confirmLegacyEntryDisabled())) {
-          throw new Error('host cannot disable every legacy entry; close the host and use the offline upgrade entry')
-        }
-        const activity = await waitForQuiescence(options)
-        if (!(await options.confirmLegacyEntryDisabled())) {
-          throw new Error('legacy entry reopened during fence acquisition; use the offline upgrade entry')
-        }
+        const activity = await waitForOfflineQuiescence(options)
         let released = false
         return {
           activity,
@@ -167,23 +191,12 @@ export function createV02GenerationFence(options: V02GenerationFenceIntegration)
             if (fenceState.token !== token || fenceState.mode !== 'upgrade-held') {
               throw new Error('v0.2 generation fence ownership changed before release')
             }
-            await options.settleLegacyEntryBlock(outcome)
             fenceState.mode = outcome === 'verified' ? 'v0.2-active' : 'legacy-open'
             fenceState.token = null
             released = true
           },
         }
       } catch (reason) {
-        if (hostBlockAcquired) {
-          try {
-            await options.settleLegacyEntryBlock('failed')
-          } catch (settleReason) {
-            throw new AggregateError(
-              [reason, settleReason],
-              'generation fence acquisition and host-block release failed',
-            )
-          }
-        }
         if (fenceState.token === token) {
           fenceState.mode = 'legacy-open'
           fenceState.token = null
@@ -191,7 +204,7 @@ export function createV02GenerationFence(options: V02GenerationFenceIntegration)
         throw reason
       }
     },
-  }
+  })
 }
 
 /** Test-only reset for the process-global fence singleton. */

--- a/src/infra/v02-generation-fence.ts
+++ b/src/infra/v02-generation-fence.ts
@@ -148,7 +148,7 @@ async function waitForOfflineQuiescence(options: V02OfflineGenerationFenceOption
     if (!hasActivity(last)) return last
     if (Date.now() >= deadline) {
       throw new Error(
-        `generation fence cannot prove quiescence; live tasks=${last.liveTasks.length}, live jobs=${last.liveJobs.length}, old ClickVibe processes=${last.oldPluginProcesses.length} still active`,
+        `generation fence cannot prove offline quiescence; old ClickVibe processes=${last.oldPluginProcesses.length} still active`,
       )
     }
     await new Promise<void>((resolve) => setTimeout(resolve, interval))

--- a/src/infra/v02-upgrade-durable.ts
+++ b/src/infra/v02-upgrade-durable.ts
@@ -1,0 +1,100 @@
+/** Durable filesystem primitives for the v0.2 upgrade transaction. */
+import { randomUUID } from 'node:crypto'
+import { link, lstat, mkdir, open, readFile, rename, rm } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+export type V02UpgradeCheckpoint = (name: string) => Promise<void> | void
+
+async function checkpoint(callback: V02UpgradeCheckpoint | undefined, name: string): Promise<void> {
+  await callback?.(name)
+}
+
+export async function syncDirectory(path: string, callback?: V02UpgradeCheckpoint): Promise<void> {
+  await checkpoint(callback, `before-directory-fsync:${path}`)
+  const handle = await open(path, 'r')
+  try {
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+  await checkpoint(callback, `after-directory-fsync:${path}`)
+}
+
+export async function ensureDurableDirectory(path: string, callback?: V02UpgradeCheckpoint): Promise<void> {
+  try {
+    await mkdir(path, { mode: 0o700 })
+    await syncDirectory(dirname(path), callback)
+  } catch (reason) {
+    if ((reason as NodeJS.ErrnoException).code !== 'EEXIST') throw reason
+  }
+  const metadata = await lstat(path)
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) throw new Error(`expected real directory: ${path}`)
+}
+
+async function prepareTemporary(destination: string, value: string | Buffer, callback?: V02UpgradeCheckpoint) {
+  const temporary = `${destination}.tmp-${process.pid}-${randomUUID()}`
+  await checkpoint(callback, `before-file-write:${destination}`)
+  const handle = await open(temporary, 'wx', 0o600)
+  try {
+    await handle.writeFile(value)
+    await checkpoint(callback, `after-file-write:${destination}`)
+    await checkpoint(callback, `before-file-fsync:${destination}`)
+    await handle.sync()
+    await checkpoint(callback, `after-file-fsync:${destination}`)
+  } catch (reason) {
+    await handle.close().catch(() => undefined)
+    await rm(temporary, { force: true }).catch(() => undefined)
+    throw reason
+  }
+  await handle.close()
+  return temporary
+}
+
+export async function durableWriteExclusive(
+  destination: string,
+  value: string | Buffer,
+  callback?: V02UpgradeCheckpoint,
+): Promise<void> {
+  const temporary = await prepareTemporary(destination, value, callback)
+  try {
+    await checkpoint(callback, `before-publish:${destination}`)
+    await link(temporary, destination)
+    await checkpoint(callback, `after-publish:${destination}`)
+    await syncDirectory(dirname(destination), callback)
+  } finally {
+    await rm(temporary, { force: true })
+  }
+}
+
+export async function durableWriteReplace(
+  destination: string,
+  value: string | Buffer,
+  callback?: V02UpgradeCheckpoint,
+): Promise<void> {
+  const temporary = await prepareTemporary(destination, value, callback)
+  try {
+    await checkpoint(callback, `before-replace:${destination}`)
+    await rename(temporary, destination)
+    await checkpoint(callback, `after-replace:${destination}`)
+    await syncDirectory(dirname(destination), callback)
+  } catch (reason) {
+    await rm(temporary, { force: true }).catch(() => undefined)
+    throw reason
+  }
+}
+
+export async function durableRename(
+  source: string,
+  destination: string,
+  callback?: V02UpgradeCheckpoint,
+): Promise<void> {
+  await checkpoint(callback, `before-rename:${source}->${destination}`)
+  await rename(source, destination)
+  await checkpoint(callback, `after-rename:${source}->${destination}`)
+  await syncDirectory(dirname(destination), callback)
+  if (dirname(source) !== dirname(destination)) await syncDirectory(dirname(source), callback)
+}
+
+export async function readExactFile(path: string): Promise<Buffer> {
+  return readFile(path)
+}

--- a/src/infra/v02-upgrade-execution.ts
+++ b/src/infra/v02-upgrade-execution.ts
@@ -1,6 +1,6 @@
 /** Authorized execution of the explicit v0.1 -> v0.2 upgrade transaction. */
 import { createHash } from 'node:crypto'
-import { lstat, readFile, stat } from 'node:fs/promises'
+import { readFile, stat } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { parse as parseYaml } from 'yaml'
 import { parseClickVibeConfigV1 } from './project-binding.ts'
@@ -15,6 +15,7 @@ import {
 import { acquireV02UpgradeLock, type V02UpgradeLockOwner } from './v02-upgrade-lock.ts'
 import {
   previewV02Upgrade,
+  inventoryV02StateDirectory,
   v02UpgradePlanFingerprint,
   type V02UpgradeHostActivity,
   type V02UpgradePlan,
@@ -223,8 +224,17 @@ export async function verifyV02UpgradeCutover(journal: V02UpgradeJournal): Promi
     throw new Error('config backup no longer matches the legacy config')
   }
   if (journal.initialState === 'present') {
-    const backup = await lstat(plan.paths.stateBackup)
-    if (!backup.isDirectory() || backup.isSymbolicLink()) throw new Error('legacy state backup is not a real directory')
+    const backup = await inventoryV02StateDirectory(plan.paths.stateBackup)
+    if (
+      backup.status !== 'present' ||
+      backup.sha256 !== plan.legacyState.sha256 ||
+      backup.fileCount !== plan.legacyState.fileCount ||
+      backup.byteCount !== plan.legacyState.byteCount ||
+      backup.device !== plan.legacyState.device ||
+      backup.inode !== plan.legacyState.inode
+    ) {
+      throw new Error('legacy state backup no longer matches the authorized legacy state')
+    }
   } else if (await exists(plan.paths.stateBackup)) {
     throw new Error('legacy state backup was fabricated although the source was initially absent')
   }
@@ -254,6 +264,7 @@ export async function applyV02Upgrade(options: ApplyV02UpgradeOptions): Promise<
   const lock = await acquireV02UpgradeLock(options.plan.paths.lock, options.fingerprint, options.checkpoint)
   let fence: Awaited<ReturnType<V02UpgradeGenerationFence['acquire']>> | undefined
   let journal: V02UpgradeJournal | undefined
+  let journalPublished = false
   let outcome: V02UpgradeOutcome = 'failed'
   let result: V02UpgradeApplyResult
   try {
@@ -265,17 +276,20 @@ export async function applyV02Upgrade(options: ApplyV02UpgradeOptions): Promise<
     } else {
       journal = initialJournal(options.plan, options.fingerprint, lock.owner)
       await publishJournal(journal, options.plan.expectedJournal === 'absent', options.checkpoint)
+      journalPublished = true
       await prepareAssets(journal, options.checkpoint)
       await cutOver(journal, options.checkpoint)
       await verifyV02UpgradeCutover(journal)
       journal.phase = 'verified'
+      await options.checkpoint?.('before-terminal-journal:verified')
       await publishJournal(journal, false, options.checkpoint)
+      await options.checkpoint?.('after-terminal-journal:verified')
       outcome = 'verified'
       result = { status: 'verified', journal }
     }
   } catch (reason) {
     const message = errorMessage(reason)
-    if (journal) {
+    if (journal && journalPublished) {
       journal.phase = 'failed'
       journal.errors.push({ at: new Date().toISOString(), action: 'apply', message })
       try {

--- a/src/infra/v02-upgrade-execution.ts
+++ b/src/infra/v02-upgrade-execution.ts
@@ -13,6 +13,7 @@ import {
   type V02UpgradeCheckpoint,
 } from './v02-upgrade-durable.ts'
 import { acquireV02UpgradeLock, type V02UpgradeLockOwner } from './v02-upgrade-lock.ts'
+import { assertApprovedV02GenerationFence } from './v02-generation-fence.ts'
 import {
   previewV02Upgrade,
   inventoryV02StateDirectory,
@@ -261,6 +262,7 @@ export async function applyV02Upgrade(options: ApplyV02UpgradeOptions): Promise<
   const expectedFingerprint = v02UpgradePlanFingerprint(options.plan)
   if (options.fingerprint !== expectedFingerprint)
     throw new Error('authorization fingerprint does not match the supplied plan')
+  assertApprovedV02GenerationFence(options.fence)
   const lock = await acquireV02UpgradeLock(options.plan.paths.lock, options.fingerprint, options.checkpoint)
   let fence: Awaited<ReturnType<V02UpgradeGenerationFence['acquire']>> | undefined
   let journal: V02UpgradeJournal | undefined

--- a/src/infra/v02-upgrade-execution.ts
+++ b/src/infra/v02-upgrade-execution.ts
@@ -1,0 +1,303 @@
+/** Authorized execution of the explicit v0.1 -> v0.2 upgrade transaction. */
+import { createHash } from 'node:crypto'
+import { lstat, readFile, stat } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { parse as parseYaml } from 'yaml'
+import { parseClickVibeConfigV1 } from './project-binding.ts'
+import { ensurePlannedRepositoryId, readRepositoryId } from './repository-identity.ts'
+import {
+  durableRename,
+  durableWriteExclusive,
+  durableWriteReplace,
+  ensureDurableDirectory,
+  type V02UpgradeCheckpoint,
+} from './v02-upgrade-durable.ts'
+import { acquireV02UpgradeLock, type V02UpgradeLockOwner } from './v02-upgrade-lock.ts'
+import {
+  previewV02Upgrade,
+  v02UpgradePlanFingerprint,
+  type V02UpgradeHostActivity,
+  type V02UpgradePlan,
+  type V02UpgradePreview,
+} from './v02-upgrade.ts'
+
+export type V02UpgradeOutcome = 'verified' | 'facts-changed' | 'failed' | 'rolled-back'
+
+export interface V02UpgradeGenerationFence {
+  acquire(planFingerprint: string): Promise<{
+    activity: V02UpgradeHostActivity
+    release(outcome: V02UpgradeOutcome): Promise<void>
+  }>
+}
+
+export interface V02UpgradeJournal {
+  schemaVersion: 1
+  phase: 'preparing' | 'prepared' | 'cutting-over' | 'verified' | 'failed' | 'rolled_back'
+  planFingerprint: string
+  plan: V02UpgradePlan
+  lockOwner: V02UpgradeLockOwner
+  initialState: 'present' | 'absent'
+  actions: {
+    configBackup: 'pending' | 'verified'
+    repositoryIds: 'pending' | 'verified'
+    stagedConfig: 'pending' | 'verified'
+    stagedState: 'pending' | 'verified'
+    stateBackup: 'pending' | 'intent' | 'verified' | 'initially-absent'
+    stateActivation: 'pending' | 'intent' | 'verified'
+    configActivation: 'pending' | 'intent' | 'verified'
+  }
+  errors: Array<{ at: string; action: string; message: string }>
+  updatedAt: string
+}
+
+export type V02UpgradeApplyResult =
+  | { status: 'verified'; journal: V02UpgradeJournal }
+  | { status: 'facts-changed'; preview: V02UpgradePreview }
+  | { status: 'failed'; error: string; journal?: V02UpgradeJournal }
+
+export interface ApplyV02UpgradeOptions {
+  plan: V02UpgradePlan
+  fingerprint: string
+  fence: V02UpgradeGenerationFence
+  checkpoint?: V02UpgradeCheckpoint
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function errorMessage(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason)
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch (reason) {
+    if ((reason as NodeJS.ErrnoException).code === 'ENOENT') return false
+    throw reason
+  }
+}
+
+function choicesFromPlan(plan: V02UpgradePlan) {
+  const primaryRemotes: Record<string, string> = {}
+  const proposedRepositoryIds: Record<string, string> = {}
+  for (const worktree of plan.worktrees) {
+    const binding = plan.bindings.find((item) => item.repository.localPath === worktree.repositoryPath)
+    if (!binding) throw new Error(`authorized plan has no binding for ${worktree.repoKey}`)
+    primaryRemotes[worktree.repoKey] = binding.repository.primaryRemote
+    proposedRepositoryIds[worktree.repoKey] = binding.repository.repositoryId
+  }
+  const exclusions = Object.fromEntries(plan.exclusions.map((item) => [item.repoKey, item.reason]))
+  return { primaryRemotes, proposedRepositoryIds, exclusions }
+}
+
+async function observeAuthorizedFacts(
+  plan: V02UpgradePlan,
+  hostActivity: V02UpgradeHostActivity,
+): Promise<V02UpgradePreview> {
+  const choices = choicesFromPlan(plan)
+  return previewV02Upgrade({
+    home: dirname(plan.paths.root),
+    baselineSha: plan.baselineSha,
+    now: plan.createdAt,
+    nonce: plan.nonce,
+    proposedRepositoryIds: choices.proposedRepositoryIds,
+    choices: { primaryRemotes: choices.primaryRemotes, exclusions: choices.exclusions },
+    hostActivity,
+  })
+}
+
+function initialJournal(plan: V02UpgradePlan, fingerprint: string, lockOwner: V02UpgradeLockOwner): V02UpgradeJournal {
+  if (plan.legacyState.status === 'error') throw new Error('cannot execute a plan with unreadable legacy state')
+  return {
+    schemaVersion: 1,
+    phase: 'preparing',
+    planFingerprint: fingerprint,
+    plan,
+    lockOwner,
+    initialState: plan.legacyState.status,
+    actions: {
+      configBackup: 'pending',
+      repositoryIds: 'pending',
+      stagedConfig: 'pending',
+      stagedState: 'pending',
+      stateBackup: 'pending',
+      stateActivation: 'pending',
+      configActivation: 'pending',
+    },
+    errors: [],
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+async function publishJournal(
+  journal: V02UpgradeJournal,
+  exclusive: boolean,
+  callback?: V02UpgradeCheckpoint,
+): Promise<void> {
+  journal.updatedAt = new Date().toISOString()
+  const raw = `${JSON.stringify(journal, null, 2)}\n`
+  if (exclusive) await durableWriteExclusive(journal.plan.paths.journal, raw, callback)
+  else await durableWriteReplace(journal.plan.paths.journal, raw, callback)
+}
+
+async function prepareAssets(journal: V02UpgradeJournal, callback?: V02UpgradeCheckpoint): Promise<void> {
+  const { plan } = journal
+  const configBytes = await readFile(plan.paths.activeConfig)
+  if (configBytes.length !== plan.legacyConfig.bytes || sha256(configBytes) !== plan.legacyConfig.sha256) {
+    throw new Error('legacy config changed after authorization')
+  }
+  await durableWriteExclusive(plan.paths.configBackup, configBytes, callback)
+  if (sha256(await readFile(plan.paths.configBackup)) !== plan.legacyConfig.sha256) {
+    throw new Error('config backup read-back verification failed')
+  }
+  journal.actions.configBackup = 'verified'
+  await publishJournal(journal, false, callback)
+
+  for (const binding of plan.bindings) {
+    await ensurePlannedRepositoryId(binding.repository.localPath, binding.repository.repositoryId)
+  }
+  journal.actions.repositoryIds = 'verified'
+  await publishJournal(journal, false, callback)
+
+  await durableWriteExclusive(plan.paths.stagedConfig, plan.targetConfig.yaml, callback)
+  const stagedConfig = await readFile(plan.paths.stagedConfig, 'utf8')
+  parseClickVibeConfigV1(parseYaml(stagedConfig))
+  if (sha256(stagedConfig) !== plan.targetConfig.sha256) throw new Error('staged config read-back verification failed')
+  journal.actions.stagedConfig = 'verified'
+  await publishJournal(journal, false, callback)
+
+  await ensureDurableDirectory(plan.paths.stagedState, callback)
+  const marker = {
+    schemaVersion: 1,
+    generation: 'v0.2',
+    planFingerprint: journal.planFingerprint,
+    createdAt: plan.createdAt,
+  }
+  await durableWriteExclusive(
+    join(plan.paths.stagedState, '.clickvibe-state.json'),
+    `${JSON.stringify(marker)}\n`,
+    callback,
+  )
+  journal.actions.stagedState = 'verified'
+  journal.phase = 'prepared'
+  await publishJournal(journal, false, callback)
+}
+
+async function cutOver(journal: V02UpgradeJournal, callback?: V02UpgradeCheckpoint): Promise<void> {
+  const { plan } = journal
+  journal.phase = 'cutting-over'
+  if (journal.initialState === 'present') {
+    journal.actions.stateBackup = 'intent'
+    await publishJournal(journal, false, callback)
+    await durableRename(plan.paths.activeState, plan.paths.stateBackup, callback)
+    journal.actions.stateBackup = 'verified'
+    await publishJournal(journal, false, callback)
+  } else {
+    journal.actions.stateBackup = 'initially-absent'
+    await publishJournal(journal, false, callback)
+  }
+
+  journal.actions.stateActivation = 'intent'
+  await publishJournal(journal, false, callback)
+  await durableRename(plan.paths.stagedState, plan.paths.activeState, callback)
+  journal.actions.stateActivation = 'verified'
+  await publishJournal(journal, false, callback)
+
+  journal.actions.configActivation = 'intent'
+  await publishJournal(journal, false, callback)
+  await durableRename(plan.paths.stagedConfig, plan.paths.activeConfig, callback)
+  journal.actions.configActivation = 'verified'
+  await publishJournal(journal, false, callback)
+}
+
+export async function verifyV02UpgradeCutover(journal: V02UpgradeJournal): Promise<void> {
+  const { plan } = journal
+  const activeConfig = await readFile(plan.paths.activeConfig, 'utf8')
+  parseClickVibeConfigV1(parseYaml(activeConfig))
+  if (sha256(activeConfig) !== plan.targetConfig.sha256)
+    throw new Error('active config does not match the authorized plan')
+  if (sha256(await readFile(plan.paths.configBackup)) !== plan.legacyConfig.sha256) {
+    throw new Error('config backup no longer matches the legacy config')
+  }
+  if (journal.initialState === 'present') {
+    const backup = await lstat(plan.paths.stateBackup)
+    if (!backup.isDirectory() || backup.isSymbolicLink()) throw new Error('legacy state backup is not a real directory')
+  } else if (await exists(plan.paths.stateBackup)) {
+    throw new Error('legacy state backup was fabricated although the source was initially absent')
+  }
+  const marker = JSON.parse(await readFile(join(plan.paths.activeState, '.clickvibe-state.json'), 'utf8')) as {
+    schemaVersion?: unknown
+    generation?: unknown
+    planFingerprint?: unknown
+  }
+  if (
+    marker.schemaVersion !== 1 ||
+    marker.generation !== 'v0.2' ||
+    marker.planFingerprint !== journal.planFingerprint
+  ) {
+    throw new Error('active state marker does not match the authorized plan')
+  }
+  for (const binding of plan.bindings) {
+    if ((await readRepositoryId(binding.repository.localPath)) !== binding.repository.repositoryId) {
+      throw new Error(`repositoryId read-back mismatch for ${binding.repository.localPath}`)
+    }
+  }
+}
+
+export async function applyV02Upgrade(options: ApplyV02UpgradeOptions): Promise<V02UpgradeApplyResult> {
+  const expectedFingerprint = v02UpgradePlanFingerprint(options.plan)
+  if (options.fingerprint !== expectedFingerprint)
+    throw new Error('authorization fingerprint does not match the supplied plan')
+  const lock = await acquireV02UpgradeLock(options.plan.paths.lock, options.fingerprint, options.checkpoint)
+  let fence: Awaited<ReturnType<V02UpgradeGenerationFence['acquire']>> | undefined
+  let journal: V02UpgradeJournal | undefined
+  let outcome: V02UpgradeOutcome = 'failed'
+  let result: V02UpgradeApplyResult
+  try {
+    fence = await options.fence.acquire(options.fingerprint)
+    const observed = await observeAuthorizedFacts(options.plan, fence.activity)
+    if (observed.status !== 'previewed' || observed.fingerprint !== options.fingerprint) {
+      outcome = 'facts-changed'
+      result = { status: 'facts-changed', preview: observed }
+    } else {
+      journal = initialJournal(options.plan, options.fingerprint, lock.owner)
+      await publishJournal(journal, options.plan.expectedJournal === 'absent', options.checkpoint)
+      await prepareAssets(journal, options.checkpoint)
+      await cutOver(journal, options.checkpoint)
+      await verifyV02UpgradeCutover(journal)
+      journal.phase = 'verified'
+      await publishJournal(journal, false, options.checkpoint)
+      outcome = 'verified'
+      result = { status: 'verified', journal }
+    }
+  } catch (reason) {
+    const message = errorMessage(reason)
+    if (journal) {
+      journal.phase = 'failed'
+      journal.errors.push({ at: new Date().toISOString(), action: 'apply', message })
+      try {
+        await publishJournal(journal, false, options.checkpoint)
+      } catch (journalReason) {
+        result = {
+          status: 'failed',
+          error: `${message}; journal update failed: ${errorMessage(journalReason)}`,
+          journal,
+        }
+        const failures: unknown[] = []
+        if (fence) await fence.release(outcome).catch((releaseReason) => failures.push(releaseReason))
+        await lock.release().catch((releaseReason) => failures.push(releaseReason))
+        if (failures.length > 0) throw new AggregateError(failures, 'failed to release v0.2 upgrade ownership')
+        return result
+      }
+    }
+    result = { status: 'failed', error: message, ...(journal ? { journal } : {}) }
+  }
+  const failures: unknown[] = []
+  if (fence) await fence.release(outcome).catch((reason) => failures.push(reason))
+  await lock.release().catch((reason) => failures.push(reason))
+  if (failures.length > 0) throw new AggregateError(failures, 'failed to release v0.2 upgrade ownership')
+  return result
+}

--- a/src/infra/v02-upgrade-inventory.ts
+++ b/src/infra/v02-upgrade-inventory.ts
@@ -54,14 +54,13 @@ async function hasJournalLessUpgradeEvidence(
   paths: V02UpgradePlan['paths'],
   assets: V02UpgradeRecoveryAsset[],
 ): Promise<boolean> {
-  if (
-    assets.some((asset) =>
-      /^(?:config-v0\.1-backup-|config-v0\.2-staging-|state-v0\.1-backup-|state-v0\.2-staging-)/.test(
-        basename(asset.path),
-      ),
-    )
+  const nonce = '[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}'
+  const stamp = '\\d{8}T\\d{9}Z'
+  const artifact = new RegExp(
+    `^(?:config-v0\\.1-backup-${stamp}-${nonce}\\.yaml|config-v0\\.2-staging-${nonce}\\.yaml|state-v0\\.1-backup-${stamp}-${nonce}|state-v0\\.2-staging-${nonce})$`,
+    'i',
   )
-    return true
+  if (assets.some((asset) => artifact.test(basename(asset.path)))) return true
   try {
     const parsed = parseDocument(await readFile(paths.activeConfig, 'utf8')).toJS() as {
       schemaVersion?: unknown

--- a/src/infra/v02-upgrade-inventory.ts
+++ b/src/infra/v02-upgrade-inventory.ts
@@ -1,0 +1,125 @@
+/** Read-only discovery of existing v0.2 upgrade and recovery evidence. */
+import { createHash } from 'node:crypto'
+import type { Dirent } from 'node:fs'
+import { lstat, readFile, readdir } from 'node:fs/promises'
+import { basename, join } from 'node:path'
+import { parseDocument } from 'yaml'
+import type { V02UpgradePlan, V02UpgradePreview, V02UpgradeRecoveryAsset } from './v02-upgrade.ts'
+
+function sha256(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function errorMessage(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason)
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
+async function recoveryAssets(root: string): Promise<V02UpgradeRecoveryAsset[]> {
+  const assets: V02UpgradeRecoveryAsset[] = []
+  let entries: Dirent[]
+  try {
+    entries = await readdir(root, { withFileTypes: true })
+  } catch (reason) {
+    if ((reason as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw reason
+  }
+  for (const entry of entries) {
+    if (!/^(config|state|upgrade-v0\.2)/.test(entry.name)) continue
+    const path = join(root, entry.name)
+    const metadata = await lstat(path)
+    const kind = entry.isSymbolicLink()
+      ? 'symlink'
+      : entry.isFile()
+        ? 'file'
+        : entry.isDirectory()
+          ? 'directory'
+          : 'other'
+    const bytes = entry.isFile() ? await readFile(path) : null
+    assets.push({
+      path,
+      kind,
+      bytes: bytes?.length ?? metadata.size,
+      ...(bytes ? { sha256: sha256(bytes) } : {}),
+      modifiedAt: metadata.mtime.toISOString(),
+    })
+  }
+  return assets.sort((a, b) => compareText(a.path, b.path))
+}
+
+async function hasJournalLessUpgradeEvidence(
+  paths: V02UpgradePlan['paths'],
+  assets: V02UpgradeRecoveryAsset[],
+): Promise<boolean> {
+  if (
+    assets.some((asset) =>
+      /^(?:config-v0\.1-backup-|config-v0\.2-staging-|state-v0\.1-backup-|state-v0\.2-staging-)/.test(
+        basename(asset.path),
+      ),
+    )
+  )
+    return true
+  try {
+    const parsed = parseDocument(await readFile(paths.activeConfig, 'utf8')).toJS() as {
+      schemaVersion?: unknown
+    } | null
+    if (parsed?.schemaVersion === 1) return true
+  } catch {
+    // Config validation remains the ordinary preview's responsibility.
+  }
+  try {
+    const marker = JSON.parse(await readFile(join(paths.activeState, '.clickvibe-state.json'), 'utf8')) as {
+      generation?: unknown
+    }
+    return marker.generation === 'v0.2'
+  } catch {
+    return false
+  }
+}
+
+export async function inspectV02UpgradeRecovery(paths: V02UpgradePlan['paths']): Promise<V02UpgradePreview | null> {
+  let raw: string
+  try {
+    raw = await readFile(paths.journal, 'utf8')
+  } catch (reason) {
+    if ((reason as NodeJS.ErrnoException).code === 'ENOENT') {
+      const assets = await recoveryAssets(paths.root)
+      if (!(await hasJournalLessUpgradeEvidence(paths, assets))) return null
+      return {
+        status: 'recovery',
+        recovery: { journal: { status: 'missing', error: 'upgrade journal is missing' }, assets },
+      }
+    }
+    return {
+      status: 'recovery',
+      recovery: {
+        journal: { status: 'corrupt', error: errorMessage(reason) },
+        assets: await recoveryAssets(paths.root),
+      },
+    }
+  }
+  try {
+    const value = JSON.parse(raw) as { schemaVersion?: unknown }
+    return {
+      status: 'recovery',
+      recovery: {
+        journal:
+          value.schemaVersion === 1
+            ? { status: 'complete', value, sha256: sha256(raw) }
+            : { status: 'unknown-schema', value, sha256: sha256(raw) },
+        assets: await recoveryAssets(paths.root),
+      },
+    }
+  } catch (reason) {
+    return {
+      status: 'recovery',
+      recovery: {
+        journal: { status: 'corrupt', error: errorMessage(reason) },
+        assets: await recoveryAssets(paths.root),
+      },
+    }
+  }
+}

--- a/src/infra/v02-upgrade-lock.ts
+++ b/src/infra/v02-upgrade-lock.ts
@@ -22,11 +22,19 @@ export interface V02UpgradeLock {
   release(): Promise<void>
 }
 
-async function processStart(pid: number): Promise<string | null> {
+interface ProcessIdentity {
+  start: string
+  state: string
+}
+
+async function processIdentity(pid: number): Promise<ProcessIdentity | null> {
   try {
-    const result = await execFileAsync('ps', ['-p', String(pid), '-o', 'lstart='], { encoding: 'utf8' })
-    const value = result.stdout.trim()
-    return value || null
+    const result = await execFileAsync('ps', ['-p', String(pid), '-o', 'lstart=', '-o', 'stat='], {
+      encoding: 'utf8',
+      env: { ...process.env, LANG: 'C', LC_ALL: 'C', TZ: 'UTC' },
+    })
+    const match = result.stdout.trim().match(/^(.*\d{4})\s+(\S+)$/)
+    return match ? { start: match[1], state: match[2] } : null
   } catch {
     return null
   }
@@ -55,10 +63,10 @@ async function ownerIsStale(owner: V02UpgradeLockOwner): Promise<boolean> {
     if ((reason as NodeJS.ErrnoException).code === 'ESRCH') return true
     return false
   }
-  // A live PID is never safe to steal from. `ps lstart` is locale/TZ-sensitive,
-  // and a mismatch can mean formatting drift rather than proven PID reuse.
-  // Conservatively wait for ESRCH instead of creating two lock owners.
-  return false
+  const identity = await processIdentity(owner.pid)
+  if (!identity) return false
+  if (identity.state.startsWith('Z')) return true
+  return identity.start !== owner.processStart
 }
 
 async function reclaimStaleLock(
@@ -89,13 +97,13 @@ export async function acquireV02UpgradeLock(
   planFingerprint: string,
   callback?: V02UpgradeCheckpoint,
 ): Promise<V02UpgradeLock> {
-  const currentStart = await processStart(process.pid)
-  if (!currentStart) throw new Error('cannot determine current process start identity')
+  const currentIdentity = await processIdentity(process.pid)
+  if (!currentIdentity) throw new Error('cannot determine current process start identity')
   const owner: V02UpgradeLockOwner = {
     schemaVersion: 1,
     token: randomUUID(),
     pid: process.pid,
-    processStart: currentStart,
+    processStart: currentIdentity.start,
     acquiredAt: new Date().toISOString(),
     planFingerprint,
   }

--- a/src/infra/v02-upgrade-lock.ts
+++ b/src/infra/v02-upgrade-lock.ts
@@ -55,8 +55,10 @@ async function ownerIsStale(owner: V02UpgradeLockOwner): Promise<boolean> {
     if ((reason as NodeJS.ErrnoException).code === 'ESRCH') return true
     return false
   }
-  const observedStart = await processStart(owner.pid)
-  return observedStart !== null && observedStart !== owner.processStart
+  // A live PID is never safe to steal from. `ps lstart` is locale/TZ-sensitive,
+  // and a mismatch can mean formatting drift rather than proven PID reuse.
+  // Conservatively wait for ESRCH instead of creating two lock owners.
+  return false
 }
 
 async function reclaimStaleLock(

--- a/src/infra/v02-upgrade-lock.ts
+++ b/src/infra/v02-upgrade-lock.ts
@@ -1,0 +1,132 @@
+/** Cross-process upgrade lock with conservative stale-owner recovery. */
+import { execFile } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { link, lstat, readFile, rm, unlink } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { promisify } from 'node:util'
+import { durableWriteExclusive, syncDirectory, type V02UpgradeCheckpoint } from './v02-upgrade-durable.ts'
+
+const execFileAsync = promisify(execFile)
+
+export interface V02UpgradeLockOwner {
+  schemaVersion: 1
+  token: string
+  pid: number
+  processStart: string
+  acquiredAt: string
+  planFingerprint: string
+}
+
+export interface V02UpgradeLock {
+  owner: V02UpgradeLockOwner
+  release(): Promise<void>
+}
+
+async function processStart(pid: number): Promise<string | null> {
+  try {
+    const result = await execFileAsync('ps', ['-p', String(pid), '-o', 'lstart='], { encoding: 'utf8' })
+    const value = result.stdout.trim()
+    return value || null
+  } catch {
+    return null
+  }
+}
+
+async function readOwner(path: string): Promise<V02UpgradeLockOwner> {
+  const metadata = await lstat(path)
+  if (!metadata.isFile() || metadata.isSymbolicLink()) throw new Error(`upgrade lock is not a regular file: ${path}`)
+  const value = JSON.parse(await readFile(path, 'utf8')) as V02UpgradeLockOwner
+  if (
+    value.schemaVersion !== 1 ||
+    typeof value.token !== 'string' ||
+    !Number.isSafeInteger(value.pid) ||
+    typeof value.processStart !== 'string' ||
+    typeof value.planFingerprint !== 'string'
+  ) {
+    throw new Error(`upgrade lock has an invalid owner record: ${path}`)
+  }
+  return value
+}
+
+async function ownerIsStale(owner: V02UpgradeLockOwner): Promise<boolean> {
+  try {
+    process.kill(owner.pid, 0)
+  } catch (reason) {
+    if ((reason as NodeJS.ErrnoException).code === 'ESRCH') return true
+    return false
+  }
+  const observedStart = await processStart(owner.pid)
+  return observedStart !== null && observedStart !== owner.processStart
+}
+
+async function reclaimStaleLock(
+  path: string,
+  owner: V02UpgradeLockOwner,
+  callback?: V02UpgradeCheckpoint,
+): Promise<boolean> {
+  const claim = `${path}.stale-${process.pid}-${randomUUID()}`
+  try {
+    await link(path, claim)
+    const [locked, claimed] = await Promise.all([lstat(path), lstat(claim)])
+    if (locked.dev !== claimed.dev || locked.ino !== claimed.ino) return false
+    const current = await readOwner(claim)
+    if (current.token !== owner.token || !(await ownerIsStale(current))) return false
+    await unlink(path)
+    await syncDirectory(dirname(path), callback)
+    return true
+  } catch (reason) {
+    if ((reason as NodeJS.ErrnoException).code === 'ENOENT') return true
+    throw reason
+  } finally {
+    await rm(claim, { force: true }).catch(() => undefined)
+  }
+}
+
+export async function acquireV02UpgradeLock(
+  path: string,
+  planFingerprint: string,
+  callback?: V02UpgradeCheckpoint,
+): Promise<V02UpgradeLock> {
+  const currentStart = await processStart(process.pid)
+  if (!currentStart) throw new Error('cannot determine current process start identity')
+  const owner: V02UpgradeLockOwner = {
+    schemaVersion: 1,
+    token: randomUUID(),
+    pid: process.pid,
+    processStart: currentStart,
+    acquiredAt: new Date().toISOString(),
+    planFingerprint,
+  }
+  const candidate = `${path}.candidate-${process.pid}-${owner.token}`
+  await durableWriteExclusive(candidate, `${JSON.stringify(owner)}\n`, callback)
+  try {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        await link(candidate, path)
+        await syncDirectory(dirname(path), callback)
+        let released = false
+        return {
+          owner,
+          async release() {
+            if (released) return
+            const current = await readOwner(path)
+            if (current.token !== owner.token) throw new Error('upgrade lock ownership changed before release')
+            await unlink(path)
+            await syncDirectory(dirname(path), callback)
+            released = true
+          },
+        }
+      } catch (reason) {
+        if ((reason as NodeJS.ErrnoException).code !== 'EEXIST') throw reason
+        const existing = await readOwner(path)
+        if (!(await ownerIsStale(existing))) {
+          throw new Error(`upgrade already locked by pid ${existing.pid} (${existing.acquiredAt})`)
+        }
+        if (!(await reclaimStaleLock(path, existing, callback))) continue
+      }
+    }
+    throw new Error('upgrade lock changed repeatedly while acquiring it')
+  } finally {
+    await rm(candidate, { force: true }).catch(() => undefined)
+  }
+}

--- a/src/infra/v02-upgrade-lock.ts
+++ b/src/infra/v02-upgrade-lock.ts
@@ -9,13 +9,19 @@ import { durableWriteExclusive, syncDirectory, type V02UpgradeCheckpoint } from 
 const execFileAsync = promisify(execFile)
 
 export interface V02UpgradeLockOwner {
-  schemaVersion: 1
+  schemaVersion: 2
   token: string
   pid: number
   processStart: string
   acquiredAt: string
   planFingerprint: string
 }
+
+interface LegacyV02UpgradeLockOwner extends Omit<V02UpgradeLockOwner, 'schemaVersion'> {
+  schemaVersion: 1
+}
+
+type ReadV02UpgradeLockOwner = V02UpgradeLockOwner | LegacyV02UpgradeLockOwner
 
 export interface V02UpgradeLock {
   owner: V02UpgradeLockOwner
@@ -40,12 +46,12 @@ async function processIdentity(pid: number): Promise<ProcessIdentity | null> {
   }
 }
 
-async function readOwner(path: string): Promise<V02UpgradeLockOwner> {
+async function readOwner(path: string): Promise<ReadV02UpgradeLockOwner> {
   const metadata = await lstat(path)
   if (!metadata.isFile() || metadata.isSymbolicLink()) throw new Error(`upgrade lock is not a regular file: ${path}`)
-  const value = JSON.parse(await readFile(path, 'utf8')) as V02UpgradeLockOwner
+  const value = JSON.parse(await readFile(path, 'utf8')) as ReadV02UpgradeLockOwner
   if (
-    value.schemaVersion !== 1 ||
+    (value.schemaVersion !== 1 && value.schemaVersion !== 2) ||
     typeof value.token !== 'string' ||
     !Number.isSafeInteger(value.pid) ||
     typeof value.processStart !== 'string' ||
@@ -56,13 +62,16 @@ async function readOwner(path: string): Promise<V02UpgradeLockOwner> {
   return value
 }
 
-async function ownerIsStale(owner: V02UpgradeLockOwner): Promise<boolean> {
+async function ownerIsStale(owner: ReadV02UpgradeLockOwner): Promise<boolean> {
   try {
     process.kill(owner.pid, 0)
   } catch (reason) {
     if ((reason as NodeJS.ErrnoException).code === 'ESRCH') return true
     return false
   }
+  // v1 stored a locale/timezone-dependent ps string. A live v1 PID is therefore
+  // ambiguous and must remain owned; only v2 has a comparable UTC identity.
+  if (owner.schemaVersion === 1) return false
   const identity = await processIdentity(owner.pid)
   if (!identity) return false
   if (identity.state.startsWith('Z')) return true
@@ -71,7 +80,7 @@ async function ownerIsStale(owner: V02UpgradeLockOwner): Promise<boolean> {
 
 async function reclaimStaleLock(
   path: string,
-  owner: V02UpgradeLockOwner,
+  owner: ReadV02UpgradeLockOwner,
   callback?: V02UpgradeCheckpoint,
 ): Promise<boolean> {
   const claim = `${path}.stale-${process.pid}-${randomUUID()}`
@@ -100,7 +109,7 @@ export async function acquireV02UpgradeLock(
   const currentIdentity = await processIdentity(process.pid)
   if (!currentIdentity) throw new Error('cannot determine current process start identity')
   const owner: V02UpgradeLockOwner = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     token: randomUUID(),
     pid: process.pid,
     processStart: currentIdentity.start,

--- a/src/infra/v02-upgrade-recovery.ts
+++ b/src/infra/v02-upgrade-recovery.ts
@@ -1,0 +1,399 @@
+/** Read-only recovery planning plus explicitly authorized resume/rollback. */
+import { createHash } from 'node:crypto'
+import { lstat, readFile, readdir } from 'node:fs/promises'
+import { dirname, join, relative, resolve } from 'node:path'
+import { parse as parseYaml } from 'yaml'
+import { parseClickVibeConfigV1 } from './project-binding.ts'
+import { ensurePlannedRepositoryId } from './repository-identity.ts'
+import {
+  durableRename,
+  durableWriteExclusive,
+  durableWriteReplace,
+  ensureDurableDirectory,
+} from './v02-upgrade-durable.ts'
+import {
+  type V02UpgradeGenerationFence,
+  type V02UpgradeJournal,
+  verifyV02UpgradeCutover,
+} from './v02-upgrade-execution.ts'
+import { acquireV02UpgradeLock } from './v02-upgrade-lock.ts'
+import { v02UpgradePlanFingerprint } from './v02-upgrade.ts'
+
+interface RecoveryAsset {
+  path: string
+  status: 'absent' | 'file' | 'directory' | 'symlink' | 'other'
+  device: number | null
+  inode: number | null
+  modifiedAt: string | null
+  bytes: number
+  sha256: string
+  generation?: string
+}
+
+export interface V02UpgradeRecoveryPlan {
+  upgradeVersion: 'clickvibe-v02-recovery-1'
+  createdAt: string
+  journal: { path: string; bytes: number; sha256: string; value: V02UpgradeJournal }
+  assets: RecoveryAsset[]
+}
+
+export type V02UpgradeRecoveryPreview =
+  | { status: 'recovery-previewed'; fingerprint: string; plan: V02UpgradeRecoveryPlan }
+  | { status: 'recovery-blocked'; error: string; assets: RecoveryAsset[] }
+
+interface RecoveryOptions {
+  plan: V02UpgradeRecoveryPlan
+  fingerprint: string
+  fence: V02UpgradeGenerationFence
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function errorMessage(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason)
+}
+
+function canonical(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonical)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, canonical(entry)]),
+    )
+  }
+  return value
+}
+
+function recoveryFingerprint(plan: V02UpgradeRecoveryPlan): string {
+  return sha256(JSON.stringify(canonical(plan)))
+}
+
+async function directoryDigest(root: string): Promise<{ bytes: number; sha256: string }> {
+  const entries: Array<{ path: string; bytes: number; sha256: string }> = []
+  async function visit(directory: string): Promise<void> {
+    for (const entry of (await readdir(directory, { withFileTypes: true })).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    )) {
+      const path = join(directory, entry.name)
+      if (entry.isSymbolicLink()) throw new Error(`recovery directory contains symlink: ${relative(root, path)}`)
+      if (entry.isDirectory()) await visit(path)
+      else if (entry.isFile()) {
+        const value = await readFile(path)
+        entries.push({ path: relative(root, path), bytes: value.length, sha256: sha256(value) })
+      } else throw new Error(`recovery directory contains unsupported entry: ${relative(root, path)}`)
+    }
+  }
+  await visit(root)
+  return { bytes: entries.reduce((total, entry) => total + entry.bytes, 0), sha256: sha256(JSON.stringify(entries)) }
+}
+
+async function observeAsset(path: string): Promise<RecoveryAsset> {
+  try {
+    const metadata = await lstat(path)
+    if (metadata.isSymbolicLink()) {
+      return {
+        path,
+        status: 'symlink',
+        device: metadata.dev,
+        inode: metadata.ino,
+        modifiedAt: metadata.mtime.toISOString(),
+        bytes: metadata.size,
+        sha256: '',
+      }
+    }
+    if (metadata.isFile()) {
+      const value = await readFile(path)
+      return {
+        path,
+        status: 'file',
+        device: metadata.dev,
+        inode: metadata.ino,
+        modifiedAt: metadata.mtime.toISOString(),
+        bytes: value.length,
+        sha256: sha256(value),
+      }
+    }
+    if (metadata.isDirectory()) {
+      const digest = await directoryDigest(path)
+      let generation: string | undefined
+      try {
+        const marker = JSON.parse(await readFile(join(path, '.clickvibe-state.json'), 'utf8')) as {
+          generation?: unknown
+        }
+        if (typeof marker.generation === 'string') generation = marker.generation
+      } catch {
+        // A legacy state directory has no generation marker.
+      }
+      return {
+        path,
+        status: 'directory',
+        device: metadata.dev,
+        inode: metadata.ino,
+        modifiedAt: metadata.mtime.toISOString(),
+        ...digest,
+        ...(generation ? { generation } : {}),
+      }
+    }
+    return {
+      path,
+      status: 'other',
+      device: metadata.dev,
+      inode: metadata.ino,
+      modifiedAt: metadata.mtime.toISOString(),
+      bytes: metadata.size,
+      sha256: '',
+    }
+  } catch (reason) {
+    if ((reason as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { path, status: 'absent', device: null, inode: null, modifiedAt: null, bytes: 0, sha256: sha256('absent') }
+    }
+    throw reason
+  }
+}
+
+function recoveryPaths(journal: V02UpgradeJournal): string[] {
+  const paths = journal.plan.paths
+  return [
+    paths.activeConfig,
+    paths.configBackup,
+    paths.stagedConfig,
+    paths.activeState,
+    paths.stateBackup,
+    paths.stagedState,
+  ]
+}
+
+async function candidateAssets(root: string): Promise<RecoveryAsset[]> {
+  try {
+    const names = (await readdir(root))
+      .filter((name) => /^(?:config|state|upgrade-v0\.2)/.test(name))
+      .sort((left, right) => left.localeCompare(right))
+    return Promise.all(names.map((name) => observeAsset(join(root, name))))
+  } catch (reason) {
+    if ((reason as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw reason
+  }
+}
+
+function parseJournal(raw: string): V02UpgradeJournal {
+  const value = JSON.parse(raw) as V02UpgradeJournal
+  if (value.schemaVersion !== 1 || !value.plan || typeof value.planFingerprint !== 'string') {
+    throw new Error('upgrade journal schema is unknown')
+  }
+  if (v02UpgradePlanFingerprint(value.plan) !== value.planFingerprint)
+    throw new Error('upgrade journal plan fingerprint is invalid')
+  return value
+}
+
+export async function previewV02UpgradeRecovery(options: {
+  home: string
+  now?: string
+}): Promise<V02UpgradeRecoveryPreview> {
+  const root = join(resolve(options.home), '.clickvibe')
+  const path = join(root, 'upgrade-v0.2.json')
+  let raw: string
+  try {
+    raw = await readFile(path, 'utf8')
+  } catch (reason) {
+    return { status: 'recovery-blocked', error: errorMessage(reason), assets: [] }
+  }
+  let journal: V02UpgradeJournal
+  try {
+    journal = parseJournal(raw)
+  } catch (reason) {
+    return { status: 'recovery-blocked', error: errorMessage(reason), assets: await candidateAssets(root) }
+  }
+  const assets = await Promise.all(recoveryPaths(journal).map(observeAsset))
+  const plan: V02UpgradeRecoveryPlan = {
+    upgradeVersion: 'clickvibe-v02-recovery-1',
+    createdAt: options.now ?? new Date().toISOString(),
+    journal: { path, bytes: Buffer.byteLength(raw), sha256: sha256(raw), value: journal },
+    assets,
+  }
+  return { status: 'recovery-previewed', fingerprint: recoveryFingerprint(plan), plan }
+}
+
+async function reobserve(plan: V02UpgradeRecoveryPlan): Promise<V02UpgradeRecoveryPreview> {
+  return previewV02UpgradeRecovery({ home: dirname(dirname(plan.journal.path)), now: plan.createdAt })
+}
+
+async function publishJournal(journal: V02UpgradeJournal): Promise<void> {
+  journal.updatedAt = new Date().toISOString()
+  await durableWriteReplace(journal.plan.paths.journal, `${JSON.stringify(journal, null, 2)}\n`)
+}
+
+async function fileHash(path: string): Promise<string | null> {
+  try {
+    return sha256(await readFile(path))
+  } catch (reason) {
+    if ((reason as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw reason
+  }
+}
+
+async function stateKind(path: string, journal: V02UpgradeJournal): Promise<'absent' | 'legacy' | 'v0.2' | 'unknown'> {
+  const asset = await observeAsset(path)
+  if (asset.status === 'absent') return 'absent'
+  if (asset.status !== 'directory') return 'unknown'
+  if (asset.generation === 'v0.2') {
+    try {
+      const marker = JSON.parse(await readFile(join(path, '.clickvibe-state.json'), 'utf8')) as {
+        planFingerprint?: unknown
+      }
+      return marker.planFingerprint === journal.planFingerprint ? 'v0.2' : 'unknown'
+    } catch {
+      return 'unknown'
+    }
+  }
+  return asset.sha256 === journal.plan.legacyState.sha256 ? 'legacy' : 'unknown'
+}
+
+async function ensurePrepared(journal: V02UpgradeJournal): Promise<void> {
+  const { plan } = journal
+  const activeConfigHash = await fileHash(plan.paths.activeConfig)
+  const backupHash = await fileHash(plan.paths.configBackup)
+  if (backupHash === null) {
+    if (activeConfigHash !== plan.legacyConfig.sha256) throw new Error('cannot reconstruct missing config backup')
+    await durableWriteExclusive(plan.paths.configBackup, await readFile(plan.paths.activeConfig))
+  } else if (backupHash !== plan.legacyConfig.sha256)
+    throw new Error('config backup does not match the authorized legacy bytes')
+  journal.actions.configBackup = 'verified'
+  for (const binding of plan.bindings)
+    await ensurePlannedRepositoryId(binding.repository.localPath, binding.repository.repositoryId)
+  journal.actions.repositoryIds = 'verified'
+
+  if (activeConfigHash !== plan.targetConfig.sha256) {
+    const stagedHash = await fileHash(plan.paths.stagedConfig)
+    if (stagedHash === null) await durableWriteExclusive(plan.paths.stagedConfig, plan.targetConfig.yaml)
+    else if (stagedHash !== plan.targetConfig.sha256)
+      throw new Error('staged config does not match the authorized target')
+    parseClickVibeConfigV1(parseYaml(await readFile(plan.paths.stagedConfig, 'utf8')))
+  }
+  journal.actions.stagedConfig = 'verified'
+
+  if ((await stateKind(plan.paths.activeState, journal)) !== 'v0.2') {
+    const staged = await stateKind(plan.paths.stagedState, journal)
+    if (staged === 'absent') {
+      await ensureDurableDirectory(plan.paths.stagedState)
+      await durableWriteExclusive(
+        join(plan.paths.stagedState, '.clickvibe-state.json'),
+        `${JSON.stringify({ schemaVersion: 1, generation: 'v0.2', planFingerprint: journal.planFingerprint, createdAt: plan.createdAt })}\n`,
+      )
+    } else if (staged !== 'v0.2') throw new Error('staged state is not the authorized v0.2 generation')
+  }
+  journal.actions.stagedState = 'verified'
+  journal.phase = 'prepared'
+  await publishJournal(journal)
+}
+
+async function resumeCutover(journal: V02UpgradeJournal): Promise<void> {
+  const { plan } = journal
+  const activeState = await stateKind(plan.paths.activeState, journal)
+  const backupState = await stateKind(plan.paths.stateBackup, journal)
+  if (journal.initialState === 'present') {
+    if (activeState === 'legacy' && backupState === 'absent') {
+      journal.actions.stateBackup = 'intent'
+      await publishJournal(journal)
+      await durableRename(plan.paths.activeState, plan.paths.stateBackup)
+      journal.actions.stateBackup = 'verified'
+    } else if (!(['absent', 'v0.2'] as const).includes(activeState as 'absent' | 'v0.2') || backupState !== 'legacy') {
+      throw new Error(`cannot resume state cutover from active=${activeState}, backup=${backupState}`)
+    }
+  } else journal.actions.stateBackup = 'initially-absent'
+  if ((await stateKind(plan.paths.activeState, journal)) === 'absent') {
+    journal.actions.stateActivation = 'intent'
+    await publishJournal(journal)
+    await durableRename(plan.paths.stagedState, plan.paths.activeState)
+  }
+  if ((await stateKind(plan.paths.activeState, journal)) !== 'v0.2') throw new Error('v0.2 state activation failed')
+  journal.actions.stateActivation = 'verified'
+  await publishJournal(journal)
+
+  const activeConfigHash = await fileHash(plan.paths.activeConfig)
+  if (activeConfigHash === plan.legacyConfig.sha256) {
+    journal.actions.configActivation = 'intent'
+    await publishJournal(journal)
+    await durableRename(plan.paths.stagedConfig, plan.paths.activeConfig)
+  } else if (activeConfigHash !== plan.targetConfig.sha256)
+    throw new Error('active config is neither authorized generation')
+  journal.actions.configActivation = 'verified'
+  await verifyV02UpgradeCutover(journal)
+  journal.phase = 'verified'
+  await publishJournal(journal)
+}
+
+async function withRecoveryOwnership<T extends { status: string }>(
+  options: RecoveryOptions,
+  execute: (journal: V02UpgradeJournal) => Promise<T>,
+): Promise<T | { status: 'facts-changed' } | { status: 'failed'; error: string }> {
+  if (recoveryFingerprint(options.plan) !== options.fingerprint)
+    throw new Error('recovery authorization fingerprint is invalid')
+  const lock = await acquireV02UpgradeLock(options.plan.journal.value.plan.paths.lock, options.fingerprint)
+  let fence: Awaited<ReturnType<V02UpgradeGenerationFence['acquire']>> | undefined
+  let outcome: 'verified' | 'facts-changed' | 'failed' | 'rolled-back' = 'failed'
+  try {
+    fence = await options.fence.acquire(options.fingerprint)
+    const observed = await reobserve(options.plan)
+    if (
+      fence.activity.liveTasks.length > 0 ||
+      fence.activity.liveJobs.length > 0 ||
+      fence.activity.oldPluginProcesses.length > 0 ||
+      observed.status !== 'recovery-previewed' ||
+      observed.fingerprint !== options.fingerprint
+    ) {
+      outcome = 'facts-changed'
+      return { status: 'facts-changed' }
+    }
+    const result = await execute(structuredClone(options.plan.journal.value))
+    outcome = result.status === 'verified' ? 'verified' : 'rolled-back'
+    return result
+  } catch (reason) {
+    return { status: 'failed', error: errorMessage(reason) }
+  } finally {
+    if (fence) await fence.release(outcome)
+    await lock.release()
+  }
+}
+
+export function resumeV02Upgrade(options: RecoveryOptions) {
+  return withRecoveryOwnership(options, async (journal) => {
+    await ensurePrepared(journal)
+    await resumeCutover(journal)
+    return { status: 'verified' as const, journal }
+  })
+}
+
+export function rollbackV02Upgrade(options: RecoveryOptions) {
+  return withRecoveryOwnership(options, async (journal) => {
+    const { plan } = journal
+    const active = await stateKind(plan.paths.activeState, journal)
+    if (journal.initialState === 'present') {
+      if (active === 'v0.2') {
+        if ((await stateKind(plan.paths.stagedState, journal)) !== 'absent')
+          throw new Error('cannot quarantine v0.2 state over existing staging')
+        await durableRename(plan.paths.activeState, plan.paths.stagedState)
+      } else if (active !== 'absent' && active !== 'legacy')
+        throw new Error(`cannot rollback unknown active state (${active})`)
+      if ((await stateKind(plan.paths.activeState, journal)) === 'absent') {
+        if ((await stateKind(plan.paths.stateBackup, journal)) !== 'legacy')
+          throw new Error('legacy cold backup is unavailable')
+        await durableRename(plan.paths.stateBackup, plan.paths.activeState)
+      }
+    } else if (active === 'v0.2') {
+      if ((await stateKind(plan.paths.stagedState, journal)) !== 'absent')
+        throw new Error('cannot quarantine v0.2 state over existing staging')
+      await durableRename(plan.paths.activeState, plan.paths.stagedState)
+    } else if (active !== 'absent') throw new Error(`cannot restore initially absent state from ${active}`)
+    if ((await fileHash(plan.paths.configBackup)) !== plan.legacyConfig.sha256)
+      throw new Error('legacy config backup is unavailable')
+    await durableWriteReplace(plan.paths.activeConfig, await readFile(plan.paths.configBackup))
+    if ((await fileHash(plan.paths.activeConfig)) !== plan.legacyConfig.sha256)
+      throw new Error('legacy config restore failed')
+    journal.phase = 'rolled_back'
+    await publishJournal(journal)
+    return { status: 'rolled-back' as const, journal }
+  })
+}

--- a/src/infra/v02-upgrade-recovery.ts
+++ b/src/infra/v02-upgrade-recovery.ts
@@ -18,6 +18,7 @@ import {
   verifyV02UpgradeCutover,
 } from './v02-upgrade-execution.ts'
 import { acquireV02UpgradeLock } from './v02-upgrade-lock.ts'
+import { assertApprovedV02GenerationFence } from './v02-generation-fence.ts'
 import { v02UpgradePlanFingerprint } from './v02-upgrade.ts'
 
 interface RecoveryAsset {
@@ -361,6 +362,7 @@ async function withRecoveryOwnership<T extends { status: string }>(
 ): Promise<T | { status: 'facts-changed' } | { status: 'failed'; error: string }> {
   if (recoveryFingerprint(options.plan) !== options.fingerprint)
     throw new Error('recovery authorization fingerprint is invalid')
+  assertApprovedV02GenerationFence(options.fence)
   const lock = await acquireV02UpgradeLock(
     options.plan.journal.value.plan.paths.lock,
     options.fingerprint,

--- a/src/infra/v02-upgrade-recovery.ts
+++ b/src/infra/v02-upgrade-recovery.ts
@@ -370,6 +370,7 @@ async function withRecoveryOwnership<T extends { status: string }>(
   )
   let fence: Awaited<ReturnType<V02UpgradeGenerationFence['acquire']>> | undefined
   let outcome: 'verified' | 'facts-changed' | 'failed' | 'rolled-back' = 'failed'
+  let result: T | { status: 'facts-changed' } | { status: 'failed'; error: string }
   try {
     fence = await options.fence.acquire(options.fingerprint)
     const observed = await reobserve(options.plan)
@@ -381,17 +382,19 @@ async function withRecoveryOwnership<T extends { status: string }>(
       observed.fingerprint !== options.fingerprint
     ) {
       outcome = 'facts-changed'
-      return { status: 'facts-changed' }
+      result = { status: 'facts-changed' }
+    } else {
+      result = await execute(structuredClone(options.plan.journal.value))
+      outcome = result.status === 'verified' ? 'verified' : 'rolled-back'
     }
-    const result = await execute(structuredClone(options.plan.journal.value))
-    outcome = result.status === 'verified' ? 'verified' : 'rolled-back'
-    return result
   } catch (reason) {
-    return { status: 'failed', error: errorMessage(reason) }
-  } finally {
-    if (fence) await fence.release(outcome)
-    await lock.release()
+    result = { status: 'failed', error: errorMessage(reason) }
   }
+  const failures: unknown[] = []
+  if (fence) await fence.release(outcome).catch((reason) => failures.push(reason))
+  await lock.release().catch((reason) => failures.push(reason))
+  if (failures.length > 0) throw new AggregateError(failures, 'failed to release v0.2 recovery ownership')
+  return result
 }
 
 export function resumeV02Upgrade(options: RecoveryOptions) {

--- a/src/infra/v02-upgrade-recovery.ts
+++ b/src/infra/v02-upgrade-recovery.ts
@@ -10,6 +10,7 @@ import {
   durableWriteExclusive,
   durableWriteReplace,
   ensureDurableDirectory,
+  type V02UpgradeCheckpoint,
 } from './v02-upgrade-durable.ts'
 import {
   type V02UpgradeGenerationFence,
@@ -39,12 +40,19 @@ export interface V02UpgradeRecoveryPlan {
 
 export type V02UpgradeRecoveryPreview =
   | { status: 'recovery-previewed'; fingerprint: string; plan: V02UpgradeRecoveryPlan }
-  | { status: 'recovery-blocked'; error: string; assets: RecoveryAsset[] }
+  | {
+      status: 'recovery-blocked'
+      error: string
+      journal: { path: string; status: 'missing' | 'corrupt' | 'unknown-schema'; sha256?: string }
+      decision: 'manual-recovery-required'
+      assets: RecoveryAsset[]
+    }
 
 interface RecoveryOptions {
   plan: V02UpgradeRecoveryPlan
   fingerprint: string
   fence: V02UpgradeGenerationFence
+  checkpoint?: V02UpgradeCheckpoint
 }
 
 function sha256(value: string | Buffer): string {
@@ -55,12 +63,16 @@ function errorMessage(reason: unknown): string {
   return reason instanceof Error ? reason.message : String(reason)
 }
 
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
 function canonical(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(canonical)
   if (value && typeof value === 'object') {
     return Object.fromEntries(
       Object.entries(value as Record<string, unknown>)
-        .sort(([left], [right]) => left.localeCompare(right))
+        .sort(([left], [right]) => compareText(left, right))
         .map(([key, entry]) => [key, canonical(entry)]),
     )
   }
@@ -75,7 +87,7 @@ async function directoryDigest(root: string): Promise<{ bytes: number; sha256: s
   const entries: Array<{ path: string; bytes: number; sha256: string }> = []
   async function visit(directory: string): Promise<void> {
     for (const entry of (await readdir(directory, { withFileTypes: true })).sort((a, b) =>
-      a.name.localeCompare(b.name),
+      compareText(a.name, b.name),
     )) {
       const path = join(directory, entry.name)
       if (entry.isSymbolicLink()) throw new Error(`recovery directory contains symlink: ${relative(root, path)}`)
@@ -168,9 +180,7 @@ function recoveryPaths(journal: V02UpgradeJournal): string[] {
 
 async function candidateAssets(root: string): Promise<RecoveryAsset[]> {
   try {
-    const names = (await readdir(root))
-      .filter((name) => /^(?:config|state|upgrade-v0\.2)/.test(name))
-      .sort((left, right) => left.localeCompare(right))
+    const names = (await readdir(root)).filter((name) => /^(?:config|state|upgrade-v0\.2)/.test(name)).sort(compareText)
     return Promise.all(names.map((name) => observeAsset(join(root, name))))
   } catch (reason) {
     if ((reason as NodeJS.ErrnoException).code === 'ENOENT') return []
@@ -198,13 +208,30 @@ export async function previewV02UpgradeRecovery(options: {
   try {
     raw = await readFile(path, 'utf8')
   } catch (reason) {
-    return { status: 'recovery-blocked', error: errorMessage(reason), assets: [] }
+    const status = (reason as NodeJS.ErrnoException).code === 'ENOENT' ? 'missing' : 'corrupt'
+    return {
+      status: 'recovery-blocked',
+      error: errorMessage(reason),
+      journal: { path, status },
+      decision: 'manual-recovery-required',
+      assets: await candidateAssets(root),
+    }
   }
   let journal: V02UpgradeJournal
   try {
     journal = parseJournal(raw)
   } catch (reason) {
-    return { status: 'recovery-blocked', error: errorMessage(reason), assets: await candidateAssets(root) }
+    return {
+      status: 'recovery-blocked',
+      error: errorMessage(reason),
+      journal: {
+        path,
+        status: errorMessage(reason).includes('schema is unknown') ? 'unknown-schema' : 'corrupt',
+        sha256: sha256(raw),
+      },
+      decision: 'manual-recovery-required',
+      assets: await candidateAssets(root),
+    }
   }
   const assets = await Promise.all(recoveryPaths(journal).map(observeAsset))
   const plan: V02UpgradeRecoveryPlan = {
@@ -220,9 +247,9 @@ async function reobserve(plan: V02UpgradeRecoveryPlan): Promise<V02UpgradeRecove
   return previewV02UpgradeRecovery({ home: dirname(dirname(plan.journal.path)), now: plan.createdAt })
 }
 
-async function publishJournal(journal: V02UpgradeJournal): Promise<void> {
+async function publishJournal(journal: V02UpgradeJournal, checkpoint?: V02UpgradeCheckpoint): Promise<void> {
   journal.updatedAt = new Date().toISOString()
-  await durableWriteReplace(journal.plan.paths.journal, `${JSON.stringify(journal, null, 2)}\n`)
+  await durableWriteReplace(journal.plan.paths.journal, `${JSON.stringify(journal, null, 2)}\n`, checkpoint)
 }
 
 async function fileHash(path: string): Promise<string | null> {
@@ -251,13 +278,13 @@ async function stateKind(path: string, journal: V02UpgradeJournal): Promise<'abs
   return asset.sha256 === journal.plan.legacyState.sha256 ? 'legacy' : 'unknown'
 }
 
-async function ensurePrepared(journal: V02UpgradeJournal): Promise<void> {
+async function ensurePrepared(journal: V02UpgradeJournal, checkpoint?: V02UpgradeCheckpoint): Promise<void> {
   const { plan } = journal
   const activeConfigHash = await fileHash(plan.paths.activeConfig)
   const backupHash = await fileHash(plan.paths.configBackup)
   if (backupHash === null) {
     if (activeConfigHash !== plan.legacyConfig.sha256) throw new Error('cannot reconstruct missing config backup')
-    await durableWriteExclusive(plan.paths.configBackup, await readFile(plan.paths.activeConfig))
+    await durableWriteExclusive(plan.paths.configBackup, await readFile(plan.paths.activeConfig), checkpoint)
   } else if (backupHash !== plan.legacyConfig.sha256)
     throw new Error('config backup does not match the authorized legacy bytes')
   journal.actions.configBackup = 'verified'
@@ -267,7 +294,7 @@ async function ensurePrepared(journal: V02UpgradeJournal): Promise<void> {
 
   if (activeConfigHash !== plan.targetConfig.sha256) {
     const stagedHash = await fileHash(plan.paths.stagedConfig)
-    if (stagedHash === null) await durableWriteExclusive(plan.paths.stagedConfig, plan.targetConfig.yaml)
+    if (stagedHash === null) await durableWriteExclusive(plan.paths.stagedConfig, plan.targetConfig.yaml, checkpoint)
     else if (stagedHash !== plan.targetConfig.sha256)
       throw new Error('staged config does not match the authorized target')
     parseClickVibeConfigV1(parseYaml(await readFile(plan.paths.stagedConfig, 'utf8')))
@@ -277,27 +304,28 @@ async function ensurePrepared(journal: V02UpgradeJournal): Promise<void> {
   if ((await stateKind(plan.paths.activeState, journal)) !== 'v0.2') {
     const staged = await stateKind(plan.paths.stagedState, journal)
     if (staged === 'absent') {
-      await ensureDurableDirectory(plan.paths.stagedState)
+      await ensureDurableDirectory(plan.paths.stagedState, checkpoint)
       await durableWriteExclusive(
         join(plan.paths.stagedState, '.clickvibe-state.json'),
         `${JSON.stringify({ schemaVersion: 1, generation: 'v0.2', planFingerprint: journal.planFingerprint, createdAt: plan.createdAt })}\n`,
+        checkpoint,
       )
     } else if (staged !== 'v0.2') throw new Error('staged state is not the authorized v0.2 generation')
   }
   journal.actions.stagedState = 'verified'
   journal.phase = 'prepared'
-  await publishJournal(journal)
+  await publishJournal(journal, checkpoint)
 }
 
-async function resumeCutover(journal: V02UpgradeJournal): Promise<void> {
+async function resumeCutover(journal: V02UpgradeJournal, checkpoint?: V02UpgradeCheckpoint): Promise<void> {
   const { plan } = journal
   const activeState = await stateKind(plan.paths.activeState, journal)
   const backupState = await stateKind(plan.paths.stateBackup, journal)
   if (journal.initialState === 'present') {
     if (activeState === 'legacy' && backupState === 'absent') {
       journal.actions.stateBackup = 'intent'
-      await publishJournal(journal)
-      await durableRename(plan.paths.activeState, plan.paths.stateBackup)
+      await publishJournal(journal, checkpoint)
+      await durableRename(plan.paths.activeState, plan.paths.stateBackup, checkpoint)
       journal.actions.stateBackup = 'verified'
     } else if (!(['absent', 'v0.2'] as const).includes(activeState as 'absent' | 'v0.2') || backupState !== 'legacy') {
       throw new Error(`cannot resume state cutover from active=${activeState}, backup=${backupState}`)
@@ -305,24 +333,26 @@ async function resumeCutover(journal: V02UpgradeJournal): Promise<void> {
   } else journal.actions.stateBackup = 'initially-absent'
   if ((await stateKind(plan.paths.activeState, journal)) === 'absent') {
     journal.actions.stateActivation = 'intent'
-    await publishJournal(journal)
-    await durableRename(plan.paths.stagedState, plan.paths.activeState)
+    await publishJournal(journal, checkpoint)
+    await durableRename(plan.paths.stagedState, plan.paths.activeState, checkpoint)
   }
   if ((await stateKind(plan.paths.activeState, journal)) !== 'v0.2') throw new Error('v0.2 state activation failed')
   journal.actions.stateActivation = 'verified'
-  await publishJournal(journal)
+  await publishJournal(journal, checkpoint)
 
   const activeConfigHash = await fileHash(plan.paths.activeConfig)
   if (activeConfigHash === plan.legacyConfig.sha256) {
     journal.actions.configActivation = 'intent'
-    await publishJournal(journal)
-    await durableRename(plan.paths.stagedConfig, plan.paths.activeConfig)
+    await publishJournal(journal, checkpoint)
+    await durableRename(plan.paths.stagedConfig, plan.paths.activeConfig, checkpoint)
   } else if (activeConfigHash !== plan.targetConfig.sha256)
     throw new Error('active config is neither authorized generation')
   journal.actions.configActivation = 'verified'
   await verifyV02UpgradeCutover(journal)
   journal.phase = 'verified'
-  await publishJournal(journal)
+  await checkpoint?.('before-terminal-journal:verified')
+  await publishJournal(journal, checkpoint)
+  await checkpoint?.('after-terminal-journal:verified')
 }
 
 async function withRecoveryOwnership<T extends { status: string }>(
@@ -331,7 +361,11 @@ async function withRecoveryOwnership<T extends { status: string }>(
 ): Promise<T | { status: 'facts-changed' } | { status: 'failed'; error: string }> {
   if (recoveryFingerprint(options.plan) !== options.fingerprint)
     throw new Error('recovery authorization fingerprint is invalid')
-  const lock = await acquireV02UpgradeLock(options.plan.journal.value.plan.paths.lock, options.fingerprint)
+  const lock = await acquireV02UpgradeLock(
+    options.plan.journal.value.plan.paths.lock,
+    options.fingerprint,
+    options.checkpoint,
+  )
   let fence: Awaited<ReturnType<V02UpgradeGenerationFence['acquire']>> | undefined
   let outcome: 'verified' | 'facts-changed' | 'failed' | 'rolled-back' = 'failed'
   try {
@@ -360,8 +394,15 @@ async function withRecoveryOwnership<T extends { status: string }>(
 
 export function resumeV02Upgrade(options: RecoveryOptions) {
   return withRecoveryOwnership(options, async (journal) => {
-    await ensurePrepared(journal)
-    await resumeCutover(journal)
+    if (journal.phase === 'rolled_back') {
+      throw new Error('cannot resume rolled_back journal; start a new upgrade preview and authorization')
+    }
+    if (journal.phase === 'verified') throw new Error('cannot resume verified terminal journal')
+    if (!['preparing', 'prepared', 'cutting-over', 'failed'].includes(journal.phase)) {
+      throw new Error(`cannot resume journal from phase ${journal.phase}`)
+    }
+    await ensurePrepared(journal, options.checkpoint)
+    await resumeCutover(journal, options.checkpoint)
     return { status: 'verified' as const, journal }
   })
 }
@@ -374,26 +415,28 @@ export function rollbackV02Upgrade(options: RecoveryOptions) {
       if (active === 'v0.2') {
         if ((await stateKind(plan.paths.stagedState, journal)) !== 'absent')
           throw new Error('cannot quarantine v0.2 state over existing staging')
-        await durableRename(plan.paths.activeState, plan.paths.stagedState)
+        await durableRename(plan.paths.activeState, plan.paths.stagedState, options.checkpoint)
       } else if (active !== 'absent' && active !== 'legacy')
         throw new Error(`cannot rollback unknown active state (${active})`)
       if ((await stateKind(plan.paths.activeState, journal)) === 'absent') {
         if ((await stateKind(plan.paths.stateBackup, journal)) !== 'legacy')
           throw new Error('legacy cold backup is unavailable')
-        await durableRename(plan.paths.stateBackup, plan.paths.activeState)
+        await durableRename(plan.paths.stateBackup, plan.paths.activeState, options.checkpoint)
       }
     } else if (active === 'v0.2') {
       if ((await stateKind(plan.paths.stagedState, journal)) !== 'absent')
         throw new Error('cannot quarantine v0.2 state over existing staging')
-      await durableRename(plan.paths.activeState, plan.paths.stagedState)
+      await durableRename(plan.paths.activeState, plan.paths.stagedState, options.checkpoint)
     } else if (active !== 'absent') throw new Error(`cannot restore initially absent state from ${active}`)
     if ((await fileHash(plan.paths.configBackup)) !== plan.legacyConfig.sha256)
       throw new Error('legacy config backup is unavailable')
-    await durableWriteReplace(plan.paths.activeConfig, await readFile(plan.paths.configBackup))
+    await durableWriteReplace(plan.paths.activeConfig, await readFile(plan.paths.configBackup), options.checkpoint)
     if ((await fileHash(plan.paths.activeConfig)) !== plan.legacyConfig.sha256)
       throw new Error('legacy config restore failed')
     journal.phase = 'rolled_back'
-    await publishJournal(journal)
+    await options.checkpoint?.('before-terminal-journal:rolled_back')
+    await publishJournal(journal, options.checkpoint)
+    await options.checkpoint?.('after-terminal-journal:rolled_back')
     return { status: 'rolled-back' as const, journal }
   })
 }

--- a/src/infra/v02-upgrade.ts
+++ b/src/infra/v02-upgrade.ts
@@ -329,6 +329,9 @@ async function inspectBinding(
 export async function previewV02Upgrade(options: PreviewV02UpgradeOptions): Promise<V02UpgradePreview> {
   const now = options.now ?? new Date().toISOString()
   const nonce = options.nonce ?? randomUUID()
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(nonce)) {
+    throw new Error('v0.2 upgrade nonce must be a UUIDv4')
+  }
   const paths = upgradePaths(resolve(options.home), now, nonce)
   const recovery = await inspectV02UpgradeRecovery(paths)
   let expectedJournal: V02UpgradePlan['expectedJournal'] = 'absent'

--- a/src/infra/v02-upgrade.ts
+++ b/src/infra/v02-upgrade.ts
@@ -1,0 +1,489 @@
+/** Explicit v0.1 -> v0.2 local config/state upgrade observation and execution. */
+import { execFile } from 'node:child_process'
+import { createHash, randomUUID } from 'node:crypto'
+import { lstat, readFile, readdir, realpath } from 'node:fs/promises'
+import { basename, dirname, join, relative, resolve } from 'node:path'
+import { promisify } from 'node:util'
+import { parseDocument, stringify as stringifyYaml } from 'yaml'
+import type { ClickVibeConfigV1, ProjectBinding } from './contracts.ts'
+import { createProjectBinding, parseClickVibeConfigV1 } from './project-binding.ts'
+import { inspectRepositoryIdentityLocation, readRepositoryId } from './repository-identity.ts'
+
+const execFileAsync = promisify(execFile)
+const UPGRADE_VERSION = 'clickvibe-v02-upgrade-1'
+
+export interface V02UpgradeChoices {
+  primaryRemotes: Record<string, string>
+  exclusions: Record<string, string>
+}
+
+export interface V02UpgradeHostActivity {
+  liveTasks: string[]
+  liveJobs: string[]
+  oldPluginProcesses: string[]
+}
+
+export interface V02UpgradeBindingPlan extends ProjectBinding {
+  realCommonDir: string
+  repositoryIdExisted: boolean
+  remoteUrl: string
+}
+
+export interface V02UpgradeStateInventory {
+  status: 'present' | 'absent' | 'error'
+  realPath: string | null
+  device: number | null
+  inode: number | null
+  fileCount: number
+  byteCount: number
+  sha256: string
+  entries: Array<{ path: string; bytes: number; sha256: string }>
+  error?: string
+}
+
+export interface V02UpgradePlan {
+  upgradeVersion: typeof UPGRADE_VERSION
+  baselineSha: string
+  createdAt: string
+  nonce: string
+  expectedJournal: 'absent' | { phase: 'rolled_back'; sha256: string }
+  paths: {
+    root: string
+    activeConfig: string
+    configBackup: string
+    stagedConfig: string
+    activeState: string
+    stateBackup: string
+    stagedState: string
+    journal: string
+    lock: string
+  }
+  legacyConfig: { status: 'present'; bytes: number; sha256: string }
+  legacyState: V02UpgradeStateInventory
+  bindings: V02UpgradeBindingPlan[]
+  exclusions: Array<{ repoKey: string; localPath: string; reason: string; error: string; sha256: string }>
+  worktrees: Array<{ repoKey: string; repositoryPath: string; porcelain: string }>
+  hostActivity: V02UpgradeHostActivity
+  targetConfig: { yaml: string; sha256: string }
+}
+
+export interface V02UpgradeBlockedItem {
+  scope: 'config' | 'state' | 'repository' | 'host'
+  key: string
+  error: string
+}
+
+export interface V02UpgradeRecoveryAsset {
+  path: string
+  kind: 'file' | 'directory' | 'symlink' | 'other'
+  bytes: number
+  sha256?: string
+  modifiedAt: string
+}
+
+export type V02UpgradePreview =
+  | { status: 'previewed'; fingerprint: string; plan: V02UpgradePlan }
+  | { status: 'blocked'; blocked: V02UpgradeBlockedItem[] }
+  | {
+      status: 'recovery'
+      recovery: {
+        journal: {
+          status: 'complete' | 'corrupt' | 'unknown-schema'
+          value?: unknown
+          sha256?: string
+          error?: string
+        }
+        assets: V02UpgradeRecoveryAsset[]
+      }
+    }
+
+export interface PreviewV02UpgradeOptions {
+  home: string
+  baselineSha: string
+  now?: string
+  nonce?: string
+  proposedRepositoryIds?: Record<string, string>
+  choices: V02UpgradeChoices
+  hostActivity: V02UpgradeHostActivity
+}
+
+interface LegacyConfig {
+  repos: Record<string, string>
+  worktreeRoot: string
+  fetchTtlSeconds?: number
+  diagnosticsMaxBytes?: number
+}
+
+function errorMessage(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason)
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function canonicalValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalValue)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, canonicalValue(entry)]),
+    )
+  }
+  return value
+}
+
+export function v02UpgradePlanFingerprint(plan: V02UpgradePlan): string {
+  return sha256(JSON.stringify(canonicalValue(plan)))
+}
+
+function expandHome(path: string, home: string): string {
+  if (path === '~') return home
+  if (path.startsWith('~/')) return join(home, path.slice(2))
+  return path
+}
+
+function parsePositiveInteger(value: unknown, field: string): number | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${field} must be a positive integer`)
+  }
+  return value
+}
+
+function parseLegacyConfig(raw: string, home: string): LegacyConfig {
+  const document = parseDocument(raw)
+  if (document.errors.length > 0) throw new Error(`config.yaml cannot be parsed: ${document.errors[0].message}`)
+  const value = document.toJS() as unknown
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('legacy config must be an object')
+  const input = value as Record<string, unknown>
+  const unknown = Object.keys(input).filter(
+    (key) => !['repos', 'worktreeRoot', 'fetchTtlSeconds', 'diagnosticsMaxBytes'].includes(key),
+  )
+  if (unknown.length > 0) throw new Error(`legacy config contains unknown field(s): ${unknown.join(', ')}`)
+  if (input.repos !== undefined && (!input.repos || typeof input.repos !== 'object' || Array.isArray(input.repos))) {
+    throw new Error('legacy config repos must be an owner/repository to path mapping')
+  }
+  const repos: Record<string, string> = {}
+  for (const [repoKey, path] of Object.entries((input.repos ?? {}) as Record<string, unknown>).sort(([a], [b]) =>
+    a.localeCompare(b),
+  )) {
+    if (!/^[^/\s]+\/[^/\s]+$/.test(repoKey) || typeof path !== 'string' || path.length === 0) {
+      throw new Error(`legacy config repos.${repoKey} is invalid`)
+    }
+    repos[repoKey] = resolve(expandHome(path, home))
+  }
+  const worktreeRootValue = input.worktreeRoot ?? join(home, '.clickvibe', 'worktrees')
+  if (typeof worktreeRootValue !== 'string' || worktreeRootValue.length === 0) {
+    throw new Error('legacy config worktreeRoot must be a non-empty string')
+  }
+  const fetchTtlSeconds = parsePositiveInteger(input.fetchTtlSeconds, 'fetchTtlSeconds')
+  if (fetchTtlSeconds !== undefined && (fetchTtlSeconds < 30 || fetchTtlSeconds > 60)) {
+    throw new Error('fetchTtlSeconds must be between 30 and 60')
+  }
+  const diagnosticsMaxBytes = parsePositiveInteger(input.diagnosticsMaxBytes, 'diagnosticsMaxBytes')
+  return {
+    repos,
+    worktreeRoot: resolve(expandHome(worktreeRootValue, home)),
+    ...(fetchTtlSeconds === undefined ? {} : { fetchTtlSeconds }),
+    ...(diagnosticsMaxBytes === undefined ? {} : { diagnosticsMaxBytes }),
+  }
+}
+
+async function git(repositoryPath: string, ...args: string[]): Promise<string> {
+  const result = await execFileAsync('git', ['-C', repositoryPath, ...args], { encoding: 'utf8' })
+  return result.stdout.trim()
+}
+
+async function inventoryState(path: string): Promise<V02UpgradeStateInventory> {
+  try {
+    const root = await lstat(path)
+    if (root.isSymbolicLink() || !root.isDirectory()) throw new Error('active state must be a real directory')
+    const entries: V02UpgradeStateInventory['entries'] = []
+    async function visit(directory: string): Promise<void> {
+      for (const entry of (await readdir(directory, { withFileTypes: true })).sort((a, b) =>
+        a.name.localeCompare(b.name),
+      )) {
+        const child = join(directory, entry.name)
+        if (entry.isSymbolicLink()) throw new Error(`state contains symlink: ${relative(path, child)}`)
+        if (entry.isDirectory()) await visit(child)
+        else if (entry.isFile()) {
+          const bytes = await readFile(child)
+          entries.push({ path: relative(path, child), bytes: bytes.length, sha256: sha256(bytes) })
+        } else throw new Error(`state contains unsupported entry: ${relative(path, child)}`)
+      }
+    }
+    await visit(path)
+    const sorted = entries.sort((a, b) => a.path.localeCompare(b.path))
+    return {
+      status: 'present',
+      realPath: await realpath(path),
+      device: root.dev,
+      inode: root.ino,
+      fileCount: sorted.length,
+      byteCount: sorted.reduce((total, entry) => total + entry.bytes, 0),
+      sha256: sha256(JSON.stringify(sorted)),
+      entries: sorted,
+    }
+  } catch (reason) {
+    if ((reason as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {
+        status: 'absent',
+        realPath: null,
+        device: null,
+        inode: null,
+        fileCount: 0,
+        byteCount: 0,
+        sha256: sha256('absent'),
+        entries: [],
+      }
+    }
+    return {
+      status: 'error',
+      realPath: null,
+      device: null,
+      inode: null,
+      fileCount: 0,
+      byteCount: 0,
+      sha256: sha256(`error:${errorMessage(reason)}`),
+      entries: [],
+      error: errorMessage(reason),
+    }
+  }
+}
+
+function pathStamp(now: string): string {
+  return now.replace(/[-:.]/g, '')
+}
+
+function upgradePaths(home: string, now: string, nonce: string): V02UpgradePlan['paths'] {
+  const root = join(home, '.clickvibe')
+  const stamp = pathStamp(now)
+  return {
+    root,
+    activeConfig: join(root, 'config.yaml'),
+    configBackup: join(root, `config-v0.1-backup-${stamp}-${nonce}.yaml`),
+    stagedConfig: join(root, `config-v0.2-staging-${nonce}.yaml`),
+    activeState: join(root, 'state'),
+    stateBackup: join(root, `state-v0.1-backup-${stamp}-${nonce}`),
+    stagedState: join(root, `state-v0.2-staging-${nonce}`),
+    journal: join(root, 'upgrade-v0.2.json'),
+    lock: join(root, 'upgrade-v0.2.lock'),
+  }
+}
+
+async function recoveryAssets(root: string): Promise<V02UpgradeRecoveryAsset[]> {
+  const assets: V02UpgradeRecoveryAsset[] = []
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    if (!/^(config|state|upgrade-v0\.2)/.test(entry.name)) continue
+    const path = join(root, entry.name)
+    const metadata = await lstat(path)
+    const kind = entry.isSymbolicLink()
+      ? 'symlink'
+      : entry.isFile()
+        ? 'file'
+        : entry.isDirectory()
+          ? 'directory'
+          : 'other'
+    const bytes = entry.isFile() ? await readFile(path) : null
+    assets.push({
+      path,
+      kind,
+      bytes: bytes?.length ?? metadata.size,
+      ...(bytes ? { sha256: sha256(bytes) } : {}),
+      modifiedAt: metadata.mtime.toISOString(),
+    })
+  }
+  return assets.sort((a, b) => a.path.localeCompare(b.path))
+}
+
+async function inspectRecovery(paths: V02UpgradePlan['paths']): Promise<V02UpgradePreview | null> {
+  let raw: string
+  try {
+    raw = await readFile(paths.journal, 'utf8')
+  } catch (reason) {
+    if ((reason as NodeJS.ErrnoException).code === 'ENOENT') return null
+    return {
+      status: 'recovery',
+      recovery: {
+        journal: { status: 'corrupt', error: errorMessage(reason) },
+        assets: await recoveryAssets(paths.root),
+      },
+    }
+  }
+  try {
+    const value = JSON.parse(raw) as { schemaVersion?: unknown }
+    return {
+      status: 'recovery',
+      recovery: {
+        journal:
+          value.schemaVersion === 1
+            ? { status: 'complete', value, sha256: sha256(raw) }
+            : { status: 'unknown-schema', value, sha256: sha256(raw) },
+        assets: await recoveryAssets(paths.root),
+      },
+    }
+  } catch (reason) {
+    return {
+      status: 'recovery',
+      recovery: {
+        journal: { status: 'corrupt', error: errorMessage(reason) },
+        assets: await recoveryAssets(paths.root),
+      },
+    }
+  }
+}
+
+async function inspectBinding(
+  repoKey: string,
+  localPath: string,
+  primaryRemote: string | undefined,
+  proposedRepositoryId: string | undefined,
+): Promise<{ binding: V02UpgradeBindingPlan; worktree: V02UpgradePlan['worktrees'][number] }> {
+  const location = await inspectRepositoryIdentityLocation(localPath)
+  let repositoryId: string
+  let repositoryIdExisted = true
+  try {
+    repositoryId = await readRepositoryId(localPath)
+  } catch (reason) {
+    if (
+      (reason as NodeJS.ErrnoException).code !== 'ENOENT' &&
+      !/(?:ENOENT|repositoryId is missing:)/.test(errorMessage(reason))
+    )
+      throw reason
+    repositoryId = proposedRepositoryId ?? `repo_${randomUUID()}`
+    repositoryIdExisted = false
+  }
+  const remotes = (await git(localPath, 'remote'))
+    .split('\n')
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .sort()
+  const selected = primaryRemote ?? (remotes.length === 1 ? remotes[0] : undefined)
+  if (!selected) throw new Error(`primary remote must be selected from: ${remotes.join(', ') || '(none)'}`)
+  if (!remotes.includes(selected)) throw new Error(`primary remote ${selected} does not exist`)
+  const [owner, repository] = repoKey.split('/')
+  const binding = createProjectBinding({
+    container: { provider: 'github', instance: 'github.com', id: `${owner.toLowerCase()}/${repository.toLowerCase()}` },
+    repository: { repositoryId, localPath: location.localPath, primaryRemote: selected },
+  })
+  return {
+    binding: {
+      ...binding,
+      realCommonDir: location.commonDir,
+      repositoryIdExisted,
+      remoteUrl: await git(localPath, 'remote', 'get-url', selected),
+    },
+    worktree: {
+      repoKey,
+      repositoryPath: location.localPath,
+      porcelain: await git(localPath, 'worktree', 'list', '--porcelain'),
+    },
+  }
+}
+
+export async function previewV02Upgrade(options: PreviewV02UpgradeOptions): Promise<V02UpgradePreview> {
+  const now = options.now ?? new Date().toISOString()
+  const nonce = options.nonce ?? randomUUID()
+  const paths = upgradePaths(resolve(options.home), now, nonce)
+  const recovery = await inspectRecovery(paths)
+  let expectedJournal: V02UpgradePlan['expectedJournal'] = 'absent'
+  if (recovery) {
+    if (recovery.status !== 'recovery') return recovery
+    const recoveredJournal = recovery.recovery.journal
+    const value = recoveredJournal.status === 'complete' ? (recoveredJournal.value as { phase?: unknown }) : null
+    if (value?.phase !== 'rolled_back' || !recoveredJournal.sha256) return recovery
+    expectedJournal = { phase: 'rolled_back', sha256: recoveredJournal.sha256 }
+  }
+  const blocked: V02UpgradeBlockedItem[] = []
+  let rawConfig: string
+  let legacyConfig: LegacyConfig
+  try {
+    const configMetadata = await lstat(paths.activeConfig)
+    if (!configMetadata.isFile() || configMetadata.isSymbolicLink()) {
+      throw new Error('legacy config must be a real regular file')
+    }
+    rawConfig = await readFile(paths.activeConfig, 'utf8')
+    legacyConfig = parseLegacyConfig(rawConfig, options.home)
+  } catch (reason) {
+    return { status: 'blocked', blocked: [{ scope: 'config', key: paths.activeConfig, error: errorMessage(reason) }] }
+  }
+  const state = await inventoryState(paths.activeState)
+  if (state.status === 'error')
+    blocked.push({ scope: 'state', key: paths.activeState, error: state.error ?? 'unknown state error' })
+  for (const task of options.hostActivity.liveTasks)
+    blocked.push({ scope: 'host', key: task, error: 'live ClickVibe task' })
+  for (const job of options.hostActivity.liveJobs)
+    blocked.push({ scope: 'host', key: job, error: 'live ClickVibe host job' })
+  for (const process of options.hostActivity.oldPluginProcesses) {
+    blocked.push({ scope: 'host', key: process, error: 'old ClickVibe plugin process is still active' })
+  }
+
+  const bindings: V02UpgradeBindingPlan[] = []
+  const exclusions: V02UpgradePlan['exclusions'] = []
+  const worktrees: V02UpgradePlan['worktrees'] = []
+  for (const [repoKey, localPath] of Object.entries(legacyConfig.repos)) {
+    try {
+      const observed = await inspectBinding(
+        repoKey,
+        localPath,
+        options.choices.primaryRemotes[repoKey],
+        options.proposedRepositoryIds?.[repoKey],
+      )
+      if (options.choices.exclusions[repoKey]) {
+        blocked.push({ scope: 'repository', key: repoKey, error: 'a valid repository cannot be silently excluded' })
+        continue
+      }
+      bindings.push(observed.binding)
+      worktrees.push(observed.worktree)
+    } catch (reason) {
+      const error = errorMessage(reason)
+      const exclusionReason = options.choices.exclusions[repoKey]?.trim()
+      if (exclusionReason) {
+        exclusions.push({
+          repoKey,
+          localPath,
+          reason: exclusionReason,
+          error,
+          sha256: sha256(JSON.stringify([repoKey, localPath, error, exclusionReason])),
+        })
+      } else blocked.push({ scope: 'repository', key: repoKey, error })
+    }
+  }
+  if (blocked.length > 0) return { status: 'blocked', blocked }
+
+  let targetConfig: ClickVibeConfigV1
+  try {
+    targetConfig = parseClickVibeConfigV1({
+      schemaVersion: 1,
+      worktreeRoot: legacyConfig.worktreeRoot,
+      ...(legacyConfig.fetchTtlSeconds === undefined ? {} : { fetchTtlSeconds: legacyConfig.fetchTtlSeconds }),
+      ...(legacyConfig.diagnosticsMaxBytes === undefined
+        ? {}
+        : { diagnosticsMaxBytes: legacyConfig.diagnosticsMaxBytes }),
+      projectBindings: bindings.map(
+        ({ realCommonDir: _common, repositoryIdExisted: _existed, remoteUrl: _url, ...binding }) => binding,
+      ),
+    })
+  } catch (reason) {
+    return { status: 'blocked', blocked: [{ scope: 'config', key: 'targetConfig', error: errorMessage(reason) }] }
+  }
+  const targetYaml = stringifyYaml(targetConfig, { lineWidth: 0 })
+  const plan: V02UpgradePlan = {
+    upgradeVersion: UPGRADE_VERSION,
+    baselineSha: options.baselineSha,
+    createdAt: now,
+    nonce,
+    expectedJournal,
+    paths,
+    legacyConfig: { status: 'present', bytes: Buffer.byteLength(rawConfig), sha256: sha256(rawConfig) },
+    legacyState: state,
+    bindings: bindings.sort((a, b) => a.container.id.localeCompare(b.container.id)),
+    exclusions: exclusions.sort((a, b) => a.repoKey.localeCompare(b.repoKey)),
+    worktrees: worktrees.sort((a, b) => a.repoKey.localeCompare(b.repoKey)),
+    hostActivity: options.hostActivity,
+    targetConfig: { yaml: targetYaml, sha256: sha256(targetYaml) },
+  }
+  return { status: 'previewed', fingerprint: v02UpgradePlanFingerprint(plan), plan }
+}

--- a/src/infra/v02-upgrade.ts
+++ b/src/infra/v02-upgrade.ts
@@ -2,12 +2,13 @@
 import { execFile } from 'node:child_process'
 import { createHash, randomUUID } from 'node:crypto'
 import { lstat, readFile, readdir, realpath } from 'node:fs/promises'
-import { basename, dirname, join, relative, resolve } from 'node:path'
+import { dirname, join, relative, resolve } from 'node:path'
 import { promisify } from 'node:util'
 import { parseDocument, stringify as stringifyYaml } from 'yaml'
 import type { ClickVibeConfigV1, ProjectBinding } from './contracts.ts'
 import { createProjectBinding, parseClickVibeConfigV1 } from './project-binding.ts'
 import { inspectRepositoryIdentityLocation, readRepositoryId } from './repository-identity.ts'
+import { inspectV02UpgradeRecovery } from './v02-upgrade-inventory.ts'
 
 const execFileAsync = promisify(execFile)
 const UPGRADE_VERSION = 'clickvibe-v02-upgrade-1'
@@ -88,7 +89,7 @@ export type V02UpgradePreview =
       status: 'recovery'
       recovery: {
         journal: {
-          status: 'complete' | 'corrupt' | 'unknown-schema'
+          status: 'complete' | 'corrupt' | 'unknown-schema' | 'missing'
           value?: unknown
           sha256?: string
           error?: string
@@ -122,12 +123,16 @@ function sha256(value: string | Buffer): string {
   return createHash('sha256').update(value).digest('hex')
 }
 
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
 function canonicalValue(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(canonicalValue)
   if (value && typeof value === 'object') {
     return Object.fromEntries(
       Object.entries(value as Record<string, unknown>)
-        .sort(([left], [right]) => left.localeCompare(right))
+        .sort(([left], [right]) => compareText(left, right))
         .map(([key, entry]) => [key, canonicalValue(entry)]),
     )
   }
@@ -167,12 +172,12 @@ function parseLegacyConfig(raw: string, home: string): LegacyConfig {
   }
   const repos: Record<string, string> = {}
   for (const [repoKey, path] of Object.entries((input.repos ?? {}) as Record<string, unknown>).sort(([a], [b]) =>
-    a.localeCompare(b),
+    compareText(a, b),
   )) {
     if (!/^[^/\s]+\/[^/\s]+$/.test(repoKey) || typeof path !== 'string' || path.length === 0) {
       throw new Error(`legacy config repos.${repoKey} is invalid`)
     }
-    repos[repoKey] = resolve(expandHome(path, home))
+    repos[repoKey] = resolve(home, expandHome(path, home))
   }
   const worktreeRootValue = input.worktreeRoot ?? join(home, '.clickvibe', 'worktrees')
   if (typeof worktreeRootValue !== 'string' || worktreeRootValue.length === 0) {
@@ -196,14 +201,14 @@ async function git(repositoryPath: string, ...args: string[]): Promise<string> {
   return result.stdout.trim()
 }
 
-async function inventoryState(path: string): Promise<V02UpgradeStateInventory> {
+export async function inventoryV02StateDirectory(path: string): Promise<V02UpgradeStateInventory> {
   try {
     const root = await lstat(path)
     if (root.isSymbolicLink() || !root.isDirectory()) throw new Error('active state must be a real directory')
     const entries: V02UpgradeStateInventory['entries'] = []
     async function visit(directory: string): Promise<void> {
       for (const entry of (await readdir(directory, { withFileTypes: true })).sort((a, b) =>
-        a.name.localeCompare(b.name),
+        compareText(a.name, b.name),
       )) {
         const child = join(directory, entry.name)
         if (entry.isSymbolicLink()) throw new Error(`state contains symlink: ${relative(path, child)}`)
@@ -215,7 +220,7 @@ async function inventoryState(path: string): Promise<V02UpgradeStateInventory> {
       }
     }
     await visit(path)
-    const sorted = entries.sort((a, b) => a.path.localeCompare(b.path))
+    const sorted = entries.sort((a, b) => compareText(a.path, b.path))
     return {
       status: 'present',
       realPath: await realpath(path),
@@ -273,68 +278,6 @@ function upgradePaths(home: string, now: string, nonce: string): V02UpgradePlan[
   }
 }
 
-async function recoveryAssets(root: string): Promise<V02UpgradeRecoveryAsset[]> {
-  const assets: V02UpgradeRecoveryAsset[] = []
-  for (const entry of await readdir(root, { withFileTypes: true })) {
-    if (!/^(config|state|upgrade-v0\.2)/.test(entry.name)) continue
-    const path = join(root, entry.name)
-    const metadata = await lstat(path)
-    const kind = entry.isSymbolicLink()
-      ? 'symlink'
-      : entry.isFile()
-        ? 'file'
-        : entry.isDirectory()
-          ? 'directory'
-          : 'other'
-    const bytes = entry.isFile() ? await readFile(path) : null
-    assets.push({
-      path,
-      kind,
-      bytes: bytes?.length ?? metadata.size,
-      ...(bytes ? { sha256: sha256(bytes) } : {}),
-      modifiedAt: metadata.mtime.toISOString(),
-    })
-  }
-  return assets.sort((a, b) => a.path.localeCompare(b.path))
-}
-
-async function inspectRecovery(paths: V02UpgradePlan['paths']): Promise<V02UpgradePreview | null> {
-  let raw: string
-  try {
-    raw = await readFile(paths.journal, 'utf8')
-  } catch (reason) {
-    if ((reason as NodeJS.ErrnoException).code === 'ENOENT') return null
-    return {
-      status: 'recovery',
-      recovery: {
-        journal: { status: 'corrupt', error: errorMessage(reason) },
-        assets: await recoveryAssets(paths.root),
-      },
-    }
-  }
-  try {
-    const value = JSON.parse(raw) as { schemaVersion?: unknown }
-    return {
-      status: 'recovery',
-      recovery: {
-        journal:
-          value.schemaVersion === 1
-            ? { status: 'complete', value, sha256: sha256(raw) }
-            : { status: 'unknown-schema', value, sha256: sha256(raw) },
-        assets: await recoveryAssets(paths.root),
-      },
-    }
-  } catch (reason) {
-    return {
-      status: 'recovery',
-      recovery: {
-        journal: { status: 'corrupt', error: errorMessage(reason) },
-        assets: await recoveryAssets(paths.root),
-      },
-    }
-  }
-}
-
 async function inspectBinding(
   repoKey: string,
   localPath: string,
@@ -387,7 +330,7 @@ export async function previewV02Upgrade(options: PreviewV02UpgradeOptions): Prom
   const now = options.now ?? new Date().toISOString()
   const nonce = options.nonce ?? randomUUID()
   const paths = upgradePaths(resolve(options.home), now, nonce)
-  const recovery = await inspectRecovery(paths)
+  const recovery = await inspectV02UpgradeRecovery(paths)
   let expectedJournal: V02UpgradePlan['expectedJournal'] = 'absent'
   if (recovery) {
     if (recovery.status !== 'recovery') return recovery
@@ -409,7 +352,7 @@ export async function previewV02Upgrade(options: PreviewV02UpgradeOptions): Prom
   } catch (reason) {
     return { status: 'blocked', blocked: [{ scope: 'config', key: paths.activeConfig, error: errorMessage(reason) }] }
   }
-  const state = await inventoryState(paths.activeState)
+  const state = await inventoryV02StateDirectory(paths.activeState)
   if (state.status === 'error')
     blocked.push({ scope: 'state', key: paths.activeState, error: state.error ?? 'unknown state error' })
   for (const task of options.hostActivity.liveTasks)
@@ -479,9 +422,9 @@ export async function previewV02Upgrade(options: PreviewV02UpgradeOptions): Prom
     paths,
     legacyConfig: { status: 'present', bytes: Buffer.byteLength(rawConfig), sha256: sha256(rawConfig) },
     legacyState: state,
-    bindings: bindings.sort((a, b) => a.container.id.localeCompare(b.container.id)),
-    exclusions: exclusions.sort((a, b) => a.repoKey.localeCompare(b.repoKey)),
-    worktrees: worktrees.sort((a, b) => a.repoKey.localeCompare(b.repoKey)),
+    bindings: bindings.sort((a, b) => compareText(a.container.id, b.container.id)),
+    exclusions: exclusions.sort((a, b) => compareText(a.repoKey, b.repoKey)),
+    worktrees: worktrees.sort((a, b) => compareText(a.repoKey, b.repoKey)),
     hostActivity: options.hostActivity,
     targetConfig: { yaml: targetYaml, sha256: sha256(targetYaml) },
   }

--- a/src/infra/workflow-persistence.ts
+++ b/src/infra/workflow-persistence.ts
@@ -6,6 +6,7 @@ import { isDeepStrictEqual } from 'node:util'
 import type { IssueWorkflow } from './state.ts'
 import { workflowPath, type WorkflowStorageIdentity } from './state-layout.ts'
 import { applyWorkflowMetadataPatch, TASK_STATE_FIELDS, type WorkflowMetadataPatch } from './workflow-metadata.ts'
+import { assertLegacyStateWriteAllowed } from './v02-generation-fence.ts'
 
 export type { WorkflowMetadataPatch } from './workflow-metadata.ts'
 
@@ -115,6 +116,7 @@ const workflowCommandQueues = new Map<string, Promise<void>>()
  */
 function enqueueWorkflowCommand<T>(workflow: WorkflowStorageIdentity, execute: () => Promise<T>): Promise<T> {
   const key = workflowStatePath(workflow)
+  assertLegacyStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
   const previous = workflowCommandQueues.get(key) ?? Promise.resolve()
   const operation = previous.catch(() => undefined).then(execute)
   const tail = operation.then(
@@ -221,6 +223,7 @@ async function readCurrent(path: string): Promise<IssueWorkflow | null> {
 }
 
 async function atomicWrite(path: string, workflow: IssueWorkflow): Promise<void> {
+  assertLegacyStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
   await mkdir(dirname(path), { recursive: true })
   const temporary = `${path}.${process.pid}.${randomBytes(8).toString('hex')}.tmp`
   try {

--- a/src/infra/workflow-persistence.ts
+++ b/src/infra/workflow-persistence.ts
@@ -118,7 +118,12 @@ function enqueueWorkflowCommand<T>(workflow: WorkflowStorageIdentity, execute: (
   const key = workflowStatePath(workflow)
   assertLegacyStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
   const previous = workflowCommandQueues.get(key) ?? Promise.resolve()
-  const operation = previous.catch(() => undefined).then(execute)
+  const operation = previous
+    .catch(() => undefined)
+    .then(async () => {
+      assertLegacyStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
+      return execute()
+    })
   const tail = operation.then(
     () => undefined,
     () => undefined,
@@ -227,7 +232,9 @@ async function atomicWrite(path: string, workflow: IssueWorkflow): Promise<void>
   await mkdir(dirname(path), { recursive: true })
   const temporary = `${path}.${process.pid}.${randomBytes(8).toString('hex')}.tmp`
   try {
+    assertLegacyStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
     await writeFile(temporary, JSON.stringify(workflow, null, 2), { encoding: 'utf8', mode: 0o600 })
+    assertLegacyStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
     await rename(temporary, path)
   } finally {
     await rm(temporary, { force: true }).catch(() => undefined)

--- a/tests/v02-generation-fence.test.ts
+++ b/tests/v02-generation-fence.test.ts
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict'
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { spawn } from 'node:child_process'
+import { once } from 'node:events'
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
@@ -7,12 +9,33 @@ import {
   assertLegacyStateWriteAllowed,
   assertLegacyTaskStartAllowed,
   createV02GenerationFence,
+  enumerateLegacyClickVibeProcesses,
   resetV02GenerationFenceForTest,
 } from '../src/infra/v02-generation-fence.ts'
 
+const idleActivity = { liveTasks: [] as string[], liveJobs: [] as string[], oldPluginProcesses: [] as string[] }
+
+function integratedFence(
+  overrides: {
+    legacyEntryDisabled?: boolean
+    observeHostActivity?: () => Promise<typeof idleActivity>
+    enumerateOldPluginProcesses?: () => Promise<string[]>
+  } = {},
+) {
+  return createV02GenerationFence({
+    acquireLegacyEntryBlock: async () => {},
+    confirmLegacyEntryDisabled: async () => overrides.legacyEntryDisabled ?? true,
+    settleLegacyEntryBlock: async () => {},
+    observeHostActivity: overrides.observeHostActivity ?? (async () => idleActivity),
+    enumerateOldPluginProcesses: overrides.enumerateOldPluginProcesses ?? (async () => []),
+    waitForExitMs: 20,
+    pollIntervalMs: 1,
+  })
+}
+
 test('generation fence linearizes new legacy starts and remains closed after verified cutover', async () => {
   resetV02GenerationFenceForTest()
-  const fence = createV02GenerationFence(async () => ({ liveTasks: [], liveJobs: [], oldPluginProcesses: [] }))
+  const fence = integratedFence()
   const held = await fence.acquire('sha256:plan')
   assert.throws(() => assertLegacyTaskStartAllowed(), /generation fence/)
   await held.release('verified')
@@ -41,12 +64,72 @@ test('legacy state writers fail closed for active v0.2 state and unfinished or c
 test('facts-changed and failed-before-journal release reopen the in-process start gate', async () => {
   for (const outcome of ['facts-changed', 'failed'] as const) {
     resetV02GenerationFenceForTest()
-    const held = await createV02GenerationFence(async () => ({
-      liveTasks: [],
-      liveJobs: [],
-      oldPluginProcesses: [],
-    })).acquire('sha256:plan')
+    const held = await integratedFence().acquire('sha256:plan')
     await held.release(outcome)
     assert.doesNotThrow(() => assertLegacyTaskStartAllowed())
+  }
+})
+
+test('online fence refuses when the host cannot prove the legacy entry is disabled', async () => {
+  resetV02GenerationFenceForTest()
+  await assert.rejects(integratedFence({ legacyEntryDisabled: false }).acquire('sha256:plan'), /offline upgrade/)
+  assert.doesNotThrow(() => assertLegacyTaskStartAllowed())
+})
+
+test('process enumeration finds a real legacy ClickVibe process and fence waits fail closed', async () => {
+  resetV02GenerationFenceForTest()
+  const child = spawn(
+    process.execPath,
+    ['-e', "console.log('READY'); setInterval(() => {}, 1000)", 'clickvibe-v0.1-plugin'],
+    { stdio: ['ignore', 'pipe', 'pipe'] },
+  )
+  try {
+    await once(child.stdout, 'data')
+    const observed = await enumerateLegacyClickVibeProcesses()
+    assert.equal(
+      observed.some((entry) => entry.includes(String(child.pid))),
+      true,
+      JSON.stringify(observed),
+    )
+    await assert.rejects(
+      integratedFence({ enumerateOldPluginProcesses: enumerateLegacyClickVibeProcesses }).acquire('sha256:plan'),
+      /old ClickVibe processes.*still active/,
+    )
+  } finally {
+    child.kill()
+    if (child.exitCode === null) await once(child, 'exit')
+    resetV02GenerationFenceForTest()
+  }
+})
+
+test('legacy startup migration cannot scan or move files after a v0.2 marker takes ownership', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'clickvibe-v02-legacy-migration-'))
+  const root = join(home, '.clickvibe')
+  const state = join(root, 'state')
+  const legacy = join(state, 'legacy.json')
+  const moduleUrl = new URL('../src/infra/state.ts', import.meta.url).href
+  try {
+    await mkdir(state, { recursive: true })
+    await writeFile(legacy, '{}\n')
+    await writeFile(join(state, '.clickvibe-state.json'), '{"schemaVersion":1,"generation":"v0.2"}\n')
+    const script = `
+      import { loadAllWorkflows } from ${JSON.stringify(moduleUrl)};
+      try { await loadAllWorkflows(); console.log('ALLOWED') }
+      catch (error) { console.log('BLOCKED:' + error.message) }
+    `
+    const child = spawn(process.execPath, ['--input-type=module', '-e', script], {
+      env: { ...process.env, HOME: home },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let output = ''
+    child.stdout.on('data', (chunk) => {
+      output += chunk.toString('utf8')
+    })
+    const [code] = (await once(child, 'exit')) as [number]
+    assert.equal(code, 0)
+    assert.match(output, /BLOCKED:.*v0\.2 state/)
+    assert.equal(await readFile(legacy, 'utf8'), '{}\n')
+  } finally {
+    await rm(home, { recursive: true, force: true })
   }
 })

--- a/tests/v02-generation-fence.test.ts
+++ b/tests/v02-generation-fence.test.ts
@@ -8,26 +8,34 @@ import test from 'node:test'
 import {
   assertLegacyStateWriteAllowed,
   assertLegacyTaskStartAllowed,
-  createV02GenerationFence,
+  createOfflineV02GenerationFence,
+  createOnlineV02GenerationFence,
   enumerateLegacyClickVibeProcesses,
   resetV02GenerationFenceForTest,
+  V02_OFFLINE_HOST_DECLARATION,
 } from '../src/infra/v02-generation-fence.ts'
 
-const idleActivity = { liveTasks: [] as string[], liveJobs: [] as string[], oldPluginProcesses: [] as string[] }
+test('online upgrade stays disabled until the host registers a real generation capability', async () => {
+  resetV02GenerationFenceForTest()
+  await assert.rejects(createOnlineV02GenerationFence().acquire('sha256:plan'), /online.*disabled.*host integration/i)
+  assert.doesNotThrow(() => assertLegacyTaskStartAllowed())
+})
 
-function integratedFence(
-  overrides: {
-    legacyEntryDisabled?: boolean
-    observeHostActivity?: () => Promise<typeof idleActivity>
-    enumerateOldPluginProcesses?: () => Promise<string[]>
-  } = {},
-) {
-  return createV02GenerationFence({
-    acquireLegacyEntryBlock: async () => {},
-    confirmLegacyEntryDisabled: async () => overrides.legacyEntryDisabled ?? true,
-    settleLegacyEntryBlock: async () => {},
-    observeHostActivity: overrides.observeHostActivity ?? (async () => idleActivity),
-    enumerateOldPluginProcesses: overrides.enumerateOldPluginProcesses ?? (async () => []),
+test('offline upgrade requires an explicit host-stopped declaration', async () => {
+  assert.throws(
+    () =>
+      createOfflineV02GenerationFence({
+        declaration: 'not-confirmed' as never,
+        enumerateOldPluginProcesses: async () => [],
+      }),
+    /explicit.*host.*stopped/i,
+  )
+})
+
+function offlineFence(enumerateOldPluginProcesses: () => Promise<string[]> = async () => []) {
+  return createOfflineV02GenerationFence({
+    declaration: V02_OFFLINE_HOST_DECLARATION,
+    enumerateOldPluginProcesses,
     waitForExitMs: 20,
     pollIntervalMs: 1,
   })
@@ -35,7 +43,7 @@ function integratedFence(
 
 test('generation fence linearizes new legacy starts and remains closed after verified cutover', async () => {
   resetV02GenerationFenceForTest()
-  const fence = integratedFence()
+  const fence = offlineFence()
   const held = await fence.acquire('sha256:plan')
   assert.throws(() => assertLegacyTaskStartAllowed(), /generation fence/)
   await held.release('verified')
@@ -64,16 +72,10 @@ test('legacy state writers fail closed for active v0.2 state and unfinished or c
 test('facts-changed and failed-before-journal release reopen the in-process start gate', async () => {
   for (const outcome of ['facts-changed', 'failed'] as const) {
     resetV02GenerationFenceForTest()
-    const held = await integratedFence().acquire('sha256:plan')
+    const held = await offlineFence().acquire('sha256:plan')
     await held.release(outcome)
     assert.doesNotThrow(() => assertLegacyTaskStartAllowed())
   }
-})
-
-test('online fence refuses when the host cannot prove the legacy entry is disabled', async () => {
-  resetV02GenerationFenceForTest()
-  await assert.rejects(integratedFence({ legacyEntryDisabled: false }).acquire('sha256:plan'), /offline upgrade/)
-  assert.doesNotThrow(() => assertLegacyTaskStartAllowed())
 })
 
 test('process enumeration finds a real legacy ClickVibe process and fence waits fail closed', async () => {
@@ -92,7 +94,7 @@ test('process enumeration finds a real legacy ClickVibe process and fence waits 
       JSON.stringify(observed),
     )
     await assert.rejects(
-      integratedFence({ enumerateOldPluginProcesses: enumerateLegacyClickVibeProcesses }).acquire('sha256:plan'),
+      offlineFence(enumerateLegacyClickVibeProcesses).acquire('sha256:plan'),
       /old ClickVibe processes.*still active/,
     )
   } finally {

--- a/tests/v02-generation-fence.test.ts
+++ b/tests/v02-generation-fence.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import {
+  assertLegacyStateWriteAllowed,
+  assertLegacyTaskStartAllowed,
+  createV02GenerationFence,
+  resetV02GenerationFenceForTest,
+} from '../src/infra/v02-generation-fence.ts'
+
+test('generation fence linearizes new legacy starts and remains closed after verified cutover', async () => {
+  resetV02GenerationFenceForTest()
+  const fence = createV02GenerationFence(async () => ({ liveTasks: [], liveJobs: [], oldPluginProcesses: [] }))
+  const held = await fence.acquire('sha256:plan')
+  assert.throws(() => assertLegacyTaskStartAllowed(), /generation fence/)
+  await held.release('verified')
+  assert.throws(() => assertLegacyTaskStartAllowed(), /v0\.2 generation/)
+  resetV02GenerationFenceForTest()
+})
+
+test('legacy state writers fail closed for active v0.2 state and unfinished or corrupt journals', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'clickvibe-v02-generation-'))
+  const root = join(home, '.clickvibe')
+  const state = join(root, 'state')
+  try {
+    await mkdir(state, { recursive: true })
+    assert.doesNotThrow(() => assertLegacyStateWriteAllowed(state))
+    await writeFile(join(root, 'upgrade-v0.2.json'), '{broken')
+    assert.throws(() => assertLegacyStateWriteAllowed(state), /recovery journal/)
+    await writeFile(join(root, 'upgrade-v0.2.json'), JSON.stringify({ schemaVersion: 1, phase: 'rolled_back' }))
+    assert.doesNotThrow(() => assertLegacyStateWriteAllowed(state))
+    await writeFile(join(state, '.clickvibe-state.json'), JSON.stringify({ schemaVersion: 1, generation: 'v0.2' }))
+    assert.throws(() => assertLegacyStateWriteAllowed(state), /v0\.2 state/)
+  } finally {
+    await rm(home, { recursive: true, force: true })
+  }
+})
+
+test('facts-changed and failed-before-journal release reopen the in-process start gate', async () => {
+  for (const outcome of ['facts-changed', 'failed'] as const) {
+    resetV02GenerationFenceForTest()
+    const held = await createV02GenerationFence(async () => ({
+      liveTasks: [],
+      liveJobs: [],
+      oldPluginProcesses: [],
+    })).acquire('sha256:plan')
+    await held.release(outcome)
+    assert.doesNotThrow(() => assertLegacyTaskStartAllowed())
+  }
+})

--- a/tests/v02-generation-fence.test.ts
+++ b/tests/v02-generation-fence.test.ts
@@ -93,10 +93,11 @@ test('process enumeration finds a real legacy ClickVibe process and fence waits 
       true,
       JSON.stringify(observed),
     )
-    await assert.rejects(
-      offlineFence(enumerateLegacyClickVibeProcesses).acquire('sha256:plan'),
-      /old ClickVibe processes.*still active/,
-    )
+    await assert.rejects(offlineFence(enumerateLegacyClickVibeProcesses).acquire('sha256:plan'), (reason: unknown) => {
+      assert.match(String(reason), /old ClickVibe processes.*still active/)
+      assert.doesNotMatch(String(reason), /live tasks|live jobs/)
+      return true
+    })
   } finally {
     child.kill()
     if (child.exitCode === null) await once(child, 'exit')

--- a/tests/v02-upgrade-apply.test.ts
+++ b/tests/v02-upgrade-apply.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { execFile } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, readdir, rm, stat, unlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { promisify } from 'node:util'
@@ -220,6 +220,9 @@ test('runtime rejects every independently damaged member of the verified v0.2 pa
     await mutateJournal((journal) => {
       journal.schemaVersion = 2
     }, /verified upgrade journal/)
+    await unlink(journalPath)
+    await assert.rejects(loadConfigFromHome(item.home), /ENOENT|upgrade-v0\.2\.json/)
+    await restore()
     const tamperedJournal = JSON.parse(originalJournal)
     tamperedJournal.planFingerprint = 'tampered'
     const tamperedMarker = JSON.parse(originalMarker)
@@ -246,6 +249,10 @@ test('runtime rejects every independently damaged member of the verified v0.2 pa
     await writeFile(item.preview.plan.paths.configBackup, 'damaged backup')
     await assert.rejects(verifyV02UpgradeCutover(result.journal), /config backup/)
     await writeFile(item.preview.plan.paths.configBackup, item.config)
+    const stragglerPath = join(item.preview.plan.paths.stateBackup, 'late-v0.1-write.json')
+    await writeFile(stragglerPath, '{"late":true}\n')
+    await assert.rejects(verifyV02UpgradeCutover(result.journal), /state backup.*authorized legacy state/)
+    await rm(stragglerPath)
     const badMarker = JSON.parse(originalMarker)
     badMarker.generation = 'v9'
     await writeFile(markerPath, JSON.stringify(badMarker))
@@ -272,6 +279,55 @@ test('runtime rejects every independently damaged member of the verified v0.2 pa
     await writeFile(journalPath, JSON.stringify(unsupportedJournal))
     await writeFile(markerPath, JSON.stringify(unsupportedMarker))
     await assert.rejects(loadConfigFromHome(item.home), /unsupported active ProjectBinding provider/)
+  } finally {
+    await rm(item.home, { recursive: true, force: true })
+  }
+})
+
+test('a journal publication collision never overwrites the competing owner evidence', async () => {
+  const item = await fixture('journal-collision')
+  const foreign = '{"owner":"other-upgrader"}\n'
+  try {
+    let injected = false
+    const result = await applyV02Upgrade({
+      plan: item.preview.plan,
+      fingerprint: item.preview.fingerprint,
+      fence: recordingFence().fence,
+      async checkpoint(current) {
+        if (!injected && current === `before-file-write:${item.preview.plan.paths.journal}`) {
+          injected = true
+          await writeFile(item.preview.plan.paths.journal, foreign)
+        }
+      },
+    })
+    assert.equal(result.status, 'failed')
+    assert.equal(await readFile(item.preview.plan.paths.journal, 'utf8'), foreign)
+  } finally {
+    await rm(item.home, { recursive: true, force: true })
+  }
+})
+
+test('a late legacy write into the renamed cold backup prevents verified cutover', async () => {
+  const item = await fixture('late-backup-write')
+  try {
+    let injected = false
+    const result = await applyV02Upgrade({
+      plan: item.preview.plan,
+      fingerprint: item.preview.fingerprint,
+      fence: recordingFence().fence,
+      async checkpoint(current) {
+        if (
+          !injected &&
+          current === `after-rename:${item.preview.plan.paths.activeState}->${item.preview.plan.paths.stateBackup}`
+        ) {
+          injected = true
+          await writeFile(join(item.preview.plan.paths.stateBackup, 'late-v0.1-write.json'), '{"late":true}\n')
+        }
+      },
+    })
+    assert.equal(result.status, 'failed')
+    if (result.status === 'failed') assert.match(result.error, /state backup.*authorized legacy state/)
+    assert.equal(JSON.parse(await readFile(item.preview.plan.paths.journal, 'utf8')).phase, 'failed')
   } finally {
     await rm(item.home, { recursive: true, force: true })
   }

--- a/tests/v02-upgrade-apply.test.ts
+++ b/tests/v02-upgrade-apply.test.ts
@@ -1,0 +1,345 @@
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { promisify } from 'node:util'
+import test from 'node:test'
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
+import { createProjectBinding, parseClickVibeConfigV1 } from '../src/infra/project-binding.ts'
+import { readRepositoryId } from '../src/infra/repository-identity.ts'
+import { loadConfigFromHome } from '../src/infra/runtime.ts'
+import {
+  applyV02Upgrade,
+  type V02UpgradeGenerationFence,
+  verifyV02UpgradeCutover,
+} from '../src/infra/v02-upgrade-execution.ts'
+import { previewV02Upgrade, type V02UpgradePlan, v02UpgradePlanFingerprint } from '../src/infra/v02-upgrade.ts'
+
+const execFileAsync = promisify(execFile)
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const result = await execFileAsync('git', ['-C', cwd, ...args], { encoding: 'utf8' })
+  return result.stdout.trim()
+}
+
+async function fixture(name: string, statePresent = true) {
+  const home = await mkdtemp(join(tmpdir(), `clickvibe-v02-apply-${name}-`))
+  const repository = join(home, 'repo')
+  const root = join(home, '.clickvibe')
+  await git(dirname(repository), 'init', repository)
+  await git(repository, 'config', 'user.name', 'clickvibe-test')
+  await git(repository, 'config', 'user.email', 'clickvibe-test@example.invalid')
+  await git(repository, 'commit', '--allow-empty', '-m', 'base')
+  await git(repository, 'remote', 'add', 'origin', 'https://github.com/o/r.git')
+  await mkdir(root, { recursive: true })
+  const config = `repos:\n  o/r: ${repository}\nfetchTtlSeconds: 45\n`
+  await writeFile(join(root, 'config.yaml'), config, { mode: 0o600 })
+  if (statePresent) {
+    await mkdir(join(root, 'state', 'o', 'r', 'issue-9'), { recursive: true })
+    await writeFile(join(root, 'state', 'o', 'r', 'issue-9', 'workflow.json'), '{"legacy":true}\n')
+  }
+  const preview = await previewV02Upgrade({
+    home,
+    baselineSha: '553a926405919bd3efc677fbd9bf0388f7c6a26d',
+    now: '2026-08-27T16:30:00.000Z',
+    nonce: name,
+    proposedRepositoryIds: { 'o/r': 'repo_22222222-2222-4222-8222-222222222222' },
+    choices: { primaryRemotes: { 'o/r': 'origin' }, exclusions: {} },
+    hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
+  })
+  assert.equal(preview.status, 'previewed', JSON.stringify(preview))
+  return { home, repository, root, config, preview }
+}
+
+function recordingFence(
+  activity = { liveTasks: [] as string[], liveJobs: [] as string[], oldPluginProcesses: [] as string[] },
+) {
+  const events: string[] = []
+  const fence: V02UpgradeGenerationFence = {
+    async acquire() {
+      events.push('acquire')
+      return {
+        activity,
+        async release(outcome) {
+          events.push(`release:${outcome}`)
+        },
+      }
+    },
+  }
+  return { fence, events }
+}
+
+async function assertNoPreparedAssets(plan: V02UpgradePlan): Promise<void> {
+  for (const path of [
+    plan.paths.journal,
+    plan.paths.configBackup,
+    plan.paths.stagedConfig,
+    plan.paths.stateBackup,
+    plan.paths.stagedState,
+  ]) {
+    await assert.rejects(stat(path), { code: 'ENOENT' })
+  }
+  await assert.rejects(readRepositoryId(plan.bindings[0].repository.localPath), /missing/)
+}
+
+test('authorized apply durably cold-backs up legacy assets and verifies the v0.2 pair', async () => {
+  const item = await fixture('success')
+  const { fence, events } = recordingFence()
+  const beforeHead = await git(item.repository, 'rev-parse', 'HEAD')
+  const beforeStatus = await git(item.repository, 'status', '--porcelain=v1', '--untracked-files=all')
+  try {
+    const result = await applyV02Upgrade({
+      plan: item.preview.plan,
+      fingerprint: item.preview.fingerprint,
+      fence,
+    })
+    assert.equal(result.status, 'verified', JSON.stringify(result))
+    assert.deepEqual(events, ['acquire', 'release:verified'])
+    assert.equal(await readFile(item.preview.plan.paths.configBackup, 'utf8'), item.config)
+    assert.equal(
+      await readFile(join(item.preview.plan.paths.stateBackup, 'o', 'r', 'issue-9', 'workflow.json'), 'utf8'),
+      '{"legacy":true}\n',
+    )
+    const marker = JSON.parse(
+      await readFile(join(item.preview.plan.paths.activeState, '.clickvibe-state.json'), 'utf8'),
+    )
+    assert.equal(marker.schemaVersion, 1)
+    assert.equal(marker.planFingerprint, item.preview.fingerprint)
+    const activeConfig = parseClickVibeConfigV1(parseYaml(await readFile(item.preview.plan.paths.activeConfig, 'utf8')))
+    assert.equal(activeConfig.projectBindings.length, 1)
+    assert.equal(await readRepositoryId(item.repository), 'repo_22222222-2222-4222-8222-222222222222')
+    const journal = JSON.parse(await readFile(item.preview.plan.paths.journal, 'utf8'))
+    assert.equal(journal.phase, 'verified')
+    assert.equal(journal.planFingerprint, item.preview.fingerprint)
+    assert.equal(await git(item.repository, 'rev-parse', 'HEAD'), beforeHead)
+    assert.equal(await git(item.repository, 'status', '--porcelain=v1', '--untracked-files=all'), beforeStatus)
+  } finally {
+    await rm(item.home, { recursive: true, force: true })
+  }
+})
+
+test('state initially absent is recorded and never fabricated as a legacy rename', async () => {
+  const item = await fixture('absent', false)
+  const { fence } = recordingFence()
+  try {
+    const result = await applyV02Upgrade({
+      plan: item.preview.plan,
+      fingerprint: item.preview.fingerprint,
+      fence,
+    })
+    assert.equal(result.status, 'verified')
+    await assert.rejects(stat(item.preview.plan.paths.stateBackup), { code: 'ENOENT' })
+    const journal = JSON.parse(await readFile(item.preview.plan.paths.journal, 'utf8'))
+    assert.equal(journal.initialState, 'absent')
+    assert.equal(journal.actions.stateBackup, 'initially-absent')
+  } finally {
+    await rm(item.home, { recursive: true, force: true })
+  }
+})
+
+test('facts changed after authorization invalidates the plan before any prepared asset is written', async () => {
+  const item = await fixture('changed')
+  const { fence, events } = recordingFence()
+  try {
+    await writeFile(item.preview.plan.paths.activeConfig, `${item.config}# changed after preview\n`)
+    const result = await applyV02Upgrade({
+      plan: item.preview.plan,
+      fingerprint: item.preview.fingerprint,
+      fence,
+    })
+    assert.equal(result.status, 'facts-changed')
+    assert.deepEqual(events, ['acquire', 'release:facts-changed'])
+    await assertNoPreparedAssets(item.preview.plan)
+    assert.equal(
+      (await readdir(item.root)).some((name) => name.startsWith('upgrade-v0.2.lock')),
+      false,
+    )
+  } finally {
+    await rm(item.home, { recursive: true, force: true })
+  }
+})
+
+test('verified v0.2 config/state pair becomes the strict runtime repository view', async () => {
+  const item = await fixture('runtime')
+  const { fence } = recordingFence()
+  try {
+    const result = await applyV02Upgrade({
+      plan: item.preview.plan,
+      fingerprint: item.preview.fingerprint,
+      fence,
+    })
+    assert.equal(result.status, 'verified')
+    const config = await loadConfigFromHome(item.home)
+    assert.equal(config.schemaVersion, 1)
+    assert.deepEqual(config.repos, { 'o/r': item.preview.plan.bindings[0].repository.localPath })
+    await writeFile(
+      join(item.preview.plan.paths.activeState, '.clickvibe-state.json'),
+      '{"schemaVersion":1,"generation":"v0.2","planFingerprint":"wrong"}\n',
+    )
+    await assert.rejects(loadConfigFromHome(item.home), /marker.*journal|fingerprint/)
+  } finally {
+    await rm(item.home, { recursive: true, force: true })
+  }
+})
+
+test('runtime rejects every independently damaged member of the verified v0.2 pair', async () => {
+  const item = await fixture('runtime-damage')
+  try {
+    const result = await applyV02Upgrade({
+      plan: item.preview.plan,
+      fingerprint: item.preview.fingerprint,
+      fence: recordingFence().fence,
+    })
+    assert.equal(result.status, 'verified')
+    const journalPath = item.preview.plan.paths.journal
+    const markerPath = join(item.preview.plan.paths.activeState, '.clickvibe-state.json')
+    const originalJournal = await readFile(journalPath, 'utf8')
+    const originalMarker = await readFile(markerPath, 'utf8')
+    const originalConfig = await readFile(item.preview.plan.paths.activeConfig, 'utf8')
+    const restore = async () => {
+      await writeFile(journalPath, originalJournal)
+      await writeFile(markerPath, originalMarker)
+      await writeFile(item.preview.plan.paths.activeConfig, originalConfig)
+    }
+    const mutateJournal = async (
+      mutation: (journal: { phase: string; schemaVersion: number }) => void,
+      expected: RegExp,
+    ) => {
+      const journal = JSON.parse(originalJournal) as { phase: string; schemaVersion: number }
+      mutation(journal)
+      await writeFile(journalPath, JSON.stringify(journal))
+      await assert.rejects(loadConfigFromHome(item.home), expected)
+      await restore()
+    }
+
+    await mutateJournal((journal) => {
+      journal.phase = 'failed'
+    }, /verified upgrade journal/)
+    await mutateJournal((journal) => {
+      journal.schemaVersion = 2
+    }, /verified upgrade journal/)
+    const tamperedJournal = JSON.parse(originalJournal)
+    tamperedJournal.planFingerprint = 'tampered'
+    const tamperedMarker = JSON.parse(originalMarker)
+    tamperedMarker.planFingerprint = 'tampered'
+    await writeFile(journalPath, JSON.stringify(tamperedJournal))
+    await writeFile(markerPath, JSON.stringify(tamperedMarker))
+    await assert.rejects(loadConfigFromHome(item.home), /plan fingerprint is invalid/)
+    await restore()
+
+    const wrongPathJournal = JSON.parse(originalJournal)
+    wrongPathJournal.plan.paths.root = join(item.home, 'other-home')
+    wrongPathJournal.planFingerprint = v02UpgradePlanFingerprint(wrongPathJournal.plan)
+    const wrongPathMarker = JSON.parse(originalMarker)
+    wrongPathMarker.planFingerprint = wrongPathJournal.planFingerprint
+    await writeFile(journalPath, JSON.stringify(wrongPathJournal))
+    await writeFile(markerPath, JSON.stringify(wrongPathMarker))
+    await assert.rejects(loadConfigFromHome(item.home), /paths do not belong/)
+    await restore()
+
+    await writeFile(item.preview.plan.paths.activeConfig, `${originalConfig}# drift\n`)
+    await assert.rejects(loadConfigFromHome(item.home), /config fingerprint/)
+    await restore()
+
+    await writeFile(item.preview.plan.paths.configBackup, 'damaged backup')
+    await assert.rejects(verifyV02UpgradeCutover(result.journal), /config backup/)
+    await writeFile(item.preview.plan.paths.configBackup, item.config)
+    const badMarker = JSON.parse(originalMarker)
+    badMarker.generation = 'v9'
+    await writeFile(markerPath, JSON.stringify(badMarker))
+    await assert.rejects(verifyV02UpgradeCutover(result.journal), /state marker/)
+    await restore()
+
+    const unsupported = parseClickVibeConfigV1(parseYaml(originalConfig))
+    unsupported.projectBindings = [
+      createProjectBinding({
+        container: { provider: 'gitlab', instance: 'gitlab.example', id: 'o/r' },
+        repository: unsupported.projectBindings[0].repository,
+      }),
+    ]
+    const unsupportedRaw = stringifyYaml(unsupported, { lineWidth: 0 })
+    const unsupportedJournal = JSON.parse(originalJournal)
+    unsupportedJournal.plan.targetConfig = {
+      yaml: unsupportedRaw,
+      sha256: createHash('sha256').update(unsupportedRaw).digest('hex'),
+    }
+    unsupportedJournal.planFingerprint = v02UpgradePlanFingerprint(unsupportedJournal.plan)
+    const unsupportedMarker = JSON.parse(originalMarker)
+    unsupportedMarker.planFingerprint = unsupportedJournal.planFingerprint
+    await writeFile(item.preview.plan.paths.activeConfig, unsupportedRaw)
+    await writeFile(journalPath, JSON.stringify(unsupportedJournal))
+    await writeFile(markerPath, JSON.stringify(unsupportedMarker))
+    await assert.rejects(loadConfigFromHome(item.home), /unsupported active ProjectBinding provider/)
+  } finally {
+    await rm(item.home, { recursive: true, force: true })
+  }
+})
+
+test('authorization, plan-shape and durable journal failures release ownership with raw evidence', async () => {
+  const wrong = await fixture('wrong-authorization')
+  try {
+    await assert.rejects(
+      applyV02Upgrade({ plan: wrong.preview.plan, fingerprint: 'wrong', fence: recordingFence().fence }),
+      /authorization fingerprint/,
+    )
+  } finally {
+    await rm(wrong.home, { recursive: true, force: true })
+  }
+
+  const malformed = await fixture('malformed-plan')
+  try {
+    const plan = structuredClone(malformed.preview.plan)
+    plan.bindings = []
+    const observed = recordingFence()
+    const result = await applyV02Upgrade({ plan, fingerprint: v02UpgradePlanFingerprint(plan), fence: observed.fence })
+    assert.equal(result.status, 'failed')
+    assert.match(result.error, /no binding/)
+    assert.deepEqual(observed.events, ['acquire', 'release:failed'])
+  } finally {
+    await rm(malformed.home, { recursive: true, force: true })
+  }
+
+  for (const [name, checkpoint, expected] of [
+    ['raw-string', 'before-publish:BACKUP', /raw checkpoint failure/],
+    ['journal-replace', 'before-replace:JOURNAL', /journal update failed/],
+  ] as const) {
+    const item = await fixture(name)
+    try {
+      const selected = checkpoint
+        .replace('BACKUP', item.preview.plan.paths.configBackup)
+        .replace('JOURNAL', item.preview.plan.paths.journal)
+      const result = await applyV02Upgrade({
+        plan: item.preview.plan,
+        fingerprint: item.preview.fingerprint,
+        fence: recordingFence().fence,
+        checkpoint(current) {
+          if (current !== selected) return
+          if (name === 'raw-string') throw 'raw checkpoint failure'
+          throw new Error('journal replace unavailable')
+        },
+      })
+      assert.equal(result.status, 'failed')
+      assert.match(result.error, expected)
+    } finally {
+      await rm(item.home, { recursive: true, force: true })
+    }
+  }
+})
+
+test('verification rejects a fabricated cold state backup when legacy state was initially absent', async () => {
+  const item = await fixture('fabricated-backup', false)
+  try {
+    const result = await applyV02Upgrade({
+      plan: item.preview.plan,
+      fingerprint: item.preview.fingerprint,
+      fence: recordingFence().fence,
+    })
+    assert.equal(result.status, 'verified')
+    await mkdir(item.preview.plan.paths.stateBackup)
+    await assert.rejects(verifyV02UpgradeCutover(result.journal), /fabricated/)
+  } finally {
+    await rm(item.home, { recursive: true, force: true })
+  }
+})

--- a/tests/v02-upgrade-apply.test.ts
+++ b/tests/v02-upgrade-apply.test.ts
@@ -11,6 +11,12 @@ import { createProjectBinding, parseClickVibeConfigV1 } from '../src/infra/proje
 import { readRepositoryId } from '../src/infra/repository-identity.ts'
 import { loadConfigFromHome } from '../src/infra/runtime.ts'
 import {
+  createOfflineV02GenerationFence,
+  createOnlineV02GenerationFence,
+  resetV02GenerationFenceForTest,
+  V02_OFFLINE_HOST_DECLARATION,
+} from '../src/infra/v02-generation-fence.ts'
+import {
   applyV02Upgrade,
   type V02UpgradeGenerationFence,
   verifyV02UpgradeCutover,
@@ -53,22 +59,12 @@ async function fixture(name: string, statePresent = true) {
   return { home, repository, root, config, preview }
 }
 
-function recordingFence(
-  activity = { liveTasks: [] as string[], liveJobs: [] as string[], oldPluginProcesses: [] as string[] },
-) {
-  const events: string[] = []
-  const fence: V02UpgradeGenerationFence = {
-    async acquire() {
-      events.push('acquire')
-      return {
-        activity,
-        async release(outcome) {
-          events.push(`release:${outcome}`)
-        },
-      }
-    },
-  }
-  return { fence, events }
+function offlineFence() {
+  resetV02GenerationFenceForTest()
+  return createOfflineV02GenerationFence({
+    declaration: V02_OFFLINE_HOST_DECLARATION,
+    enumerateOldPluginProcesses: async () => [],
+  })
 }
 
 async function assertNoPreparedAssets(plan: V02UpgradePlan): Promise<void> {
@@ -84,9 +80,55 @@ async function assertNoPreparedAssets(plan: V02UpgradePlan): Promise<void> {
   await assert.rejects(readRepositoryId(plan.bindings[0].repository.localPath), /missing/)
 }
 
+test('apply rejects an unregistered caller-built fence before the first upgrade write', async () => {
+  const item = await fixture('unregistered-fence')
+  const unregistered: V02UpgradeGenerationFence = {
+    async acquire() {
+      return {
+        activity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
+        async release() {},
+      }
+    },
+  }
+  try {
+    await assert.rejects(
+      applyV02Upgrade({
+        plan: item.preview.plan,
+        fingerprint: item.preview.fingerprint,
+        fence: unregistered,
+      }),
+      /approved generation fence factory/i,
+    )
+    await assertNoPreparedAssets(item.preview.plan)
+  } finally {
+    await rm(item.home, { recursive: true, force: true })
+  }
+})
+
+test('online apply is disabled before host integration and leaves no prepared asset', async () => {
+  const item = await fixture('online-disabled')
+  try {
+    await assert.rejects(
+      applyV02Upgrade({
+        plan: item.preview.plan,
+        fingerprint: item.preview.fingerprint,
+        fence: createOnlineV02GenerationFence(),
+      }),
+      /online.*disabled.*host integration/i,
+    )
+    await assertNoPreparedAssets(item.preview.plan)
+    assert.equal(
+      (await readdir(item.root)).some((name) => name.startsWith('upgrade-v0.2.lock')),
+      false,
+    )
+  } finally {
+    await rm(item.home, { recursive: true, force: true })
+  }
+})
+
 test('authorized apply durably cold-backs up legacy assets and verifies the v0.2 pair', async () => {
   const item = await fixture('success')
-  const { fence, events } = recordingFence()
+  const fence = offlineFence()
   const beforeHead = await git(item.repository, 'rev-parse', 'HEAD')
   const beforeStatus = await git(item.repository, 'status', '--porcelain=v1', '--untracked-files=all')
   try {
@@ -96,7 +138,6 @@ test('authorized apply durably cold-backs up legacy assets and verifies the v0.2
       fence,
     })
     assert.equal(result.status, 'verified', JSON.stringify(result))
-    assert.deepEqual(events, ['acquire', 'release:verified'])
     assert.equal(await readFile(item.preview.plan.paths.configBackup, 'utf8'), item.config)
     assert.equal(
       await readFile(join(item.preview.plan.paths.stateBackup, 'o', 'r', 'issue-9', 'workflow.json'), 'utf8'),
@@ -122,7 +163,7 @@ test('authorized apply durably cold-backs up legacy assets and verifies the v0.2
 
 test('state initially absent is recorded and never fabricated as a legacy rename', async () => {
   const item = await fixture('absent', false)
-  const { fence } = recordingFence()
+  const fence = offlineFence()
   try {
     const result = await applyV02Upgrade({
       plan: item.preview.plan,
@@ -141,7 +182,7 @@ test('state initially absent is recorded and never fabricated as a legacy rename
 
 test('facts changed after authorization invalidates the plan before any prepared asset is written', async () => {
   const item = await fixture('changed')
-  const { fence, events } = recordingFence()
+  const fence = offlineFence()
   try {
     await writeFile(item.preview.plan.paths.activeConfig, `${item.config}# changed after preview\n`)
     const result = await applyV02Upgrade({
@@ -150,7 +191,6 @@ test('facts changed after authorization invalidates the plan before any prepared
       fence,
     })
     assert.equal(result.status, 'facts-changed')
-    assert.deepEqual(events, ['acquire', 'release:facts-changed'])
     await assertNoPreparedAssets(item.preview.plan)
     assert.equal(
       (await readdir(item.root)).some((name) => name.startsWith('upgrade-v0.2.lock')),
@@ -163,7 +203,7 @@ test('facts changed after authorization invalidates the plan before any prepared
 
 test('verified v0.2 config/state pair becomes the strict runtime repository view', async () => {
   const item = await fixture('runtime')
-  const { fence } = recordingFence()
+  const fence = offlineFence()
   try {
     const result = await applyV02Upgrade({
       plan: item.preview.plan,
@@ -190,7 +230,7 @@ test('runtime rejects every independently damaged member of the verified v0.2 pa
     const result = await applyV02Upgrade({
       plan: item.preview.plan,
       fingerprint: item.preview.fingerprint,
-      fence: recordingFence().fence,
+      fence: offlineFence(),
     })
     assert.equal(result.status, 'verified')
     const journalPath = item.preview.plan.paths.journal
@@ -292,7 +332,7 @@ test('a journal publication collision never overwrites the competing owner evide
     const result = await applyV02Upgrade({
       plan: item.preview.plan,
       fingerprint: item.preview.fingerprint,
-      fence: recordingFence().fence,
+      fence: offlineFence(),
       async checkpoint(current) {
         if (!injected && current === `before-file-write:${item.preview.plan.paths.journal}`) {
           injected = true
@@ -314,7 +354,7 @@ test('a late legacy write into the renamed cold backup prevents verified cutover
     const result = await applyV02Upgrade({
       plan: item.preview.plan,
       fingerprint: item.preview.fingerprint,
-      fence: recordingFence().fence,
+      fence: offlineFence(),
       async checkpoint(current) {
         if (
           !injected &&
@@ -337,7 +377,7 @@ test('authorization, plan-shape and durable journal failures release ownership w
   const wrong = await fixture('wrong-authorization')
   try {
     await assert.rejects(
-      applyV02Upgrade({ plan: wrong.preview.plan, fingerprint: 'wrong', fence: recordingFence().fence }),
+      applyV02Upgrade({ plan: wrong.preview.plan, fingerprint: 'wrong', fence: offlineFence() }),
       /authorization fingerprint/,
     )
   } finally {
@@ -348,11 +388,9 @@ test('authorization, plan-shape and durable journal failures release ownership w
   try {
     const plan = structuredClone(malformed.preview.plan)
     plan.bindings = []
-    const observed = recordingFence()
-    const result = await applyV02Upgrade({ plan, fingerprint: v02UpgradePlanFingerprint(plan), fence: observed.fence })
+    const result = await applyV02Upgrade({ plan, fingerprint: v02UpgradePlanFingerprint(plan), fence: offlineFence() })
     assert.equal(result.status, 'failed')
     assert.match(result.error, /no binding/)
-    assert.deepEqual(observed.events, ['acquire', 'release:failed'])
   } finally {
     await rm(malformed.home, { recursive: true, force: true })
   }
@@ -369,7 +407,7 @@ test('authorization, plan-shape and durable journal failures release ownership w
       const result = await applyV02Upgrade({
         plan: item.preview.plan,
         fingerprint: item.preview.fingerprint,
-        fence: recordingFence().fence,
+        fence: offlineFence(),
         checkpoint(current) {
           if (current !== selected) return
           if (name === 'raw-string') throw 'raw checkpoint failure'
@@ -390,7 +428,7 @@ test('verification rejects a fabricated cold state backup when legacy state was 
     const result = await applyV02Upgrade({
       plan: item.preview.plan,
       fingerprint: item.preview.fingerprint,
-      fence: recordingFence().fence,
+      fence: offlineFence(),
     })
     assert.equal(result.status, 'verified')
     await mkdir(item.preview.plan.paths.stateBackup)

--- a/tests/v02-upgrade-apply.test.ts
+++ b/tests/v02-upgrade-apply.test.ts
@@ -25,6 +25,11 @@ import { previewV02Upgrade, type V02UpgradePlan, v02UpgradePlanFingerprint } fro
 
 const execFileAsync = promisify(execFile)
 
+function testNonce(label: string): string {
+  const hex = createHash('sha256').update(label).digest('hex')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-4${hex.slice(13, 16)}-8${hex.slice(17, 20)}-${hex.slice(20, 32)}`
+}
+
 async function git(cwd: string, ...args: string[]): Promise<string> {
   const result = await execFileAsync('git', ['-C', cwd, ...args], { encoding: 'utf8' })
   return result.stdout.trim()
@@ -50,7 +55,7 @@ async function fixture(name: string, statePresent = true) {
     home,
     baselineSha: '553a926405919bd3efc677fbd9bf0388f7c6a26d',
     now: '2026-08-27T16:30:00.000Z',
-    nonce: name,
+    nonce: testNonce(name),
     proposedRepositoryIds: { 'o/r': 'repo_22222222-2222-4222-8222-222222222222' },
     choices: { primaryRemotes: { 'o/r': 'origin' }, exclusions: {} },
     hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },

--- a/tests/v02-upgrade-failures.test.ts
+++ b/tests/v02-upgrade-failures.test.ts
@@ -9,6 +9,24 @@ import { type V02UpgradeGenerationFence } from '../src/infra/v02-upgrade-executi
 import { acquireV02UpgradeLock } from '../src/infra/v02-upgrade-lock.ts'
 import { previewV02UpgradeRecovery, rollbackV02Upgrade } from '../src/infra/v02-upgrade-recovery.ts'
 
+function integratedFence(
+  observeHostActivity: () => Promise<{
+    liveTasks: string[]
+    liveJobs: string[]
+    oldPluginProcesses: string[]
+  }> = async () => ({ liveTasks: [], liveJobs: [], oldPluginProcesses: [] }),
+) {
+  return createV02GenerationFence({
+    acquireLegacyEntryBlock: async () => {},
+    confirmLegacyEntryDisabled: async () => true,
+    settleLegacyEntryBlock: async () => {},
+    observeHostActivity,
+    enumerateOldPluginProcesses: async () => [],
+    waitForExitMs: 20,
+    pollIntervalMs: 1,
+  })
+}
+
 test('durable primitives reject collisions and clean an interrupted temporary publication', async () => {
   const root = await mkdtemp(join(tmpdir(), 'clickvibe-v02-durable-'))
   const firstDirectory = join(root, 'first')
@@ -43,27 +61,16 @@ test('durable primitives reject collisions and clean an interrupted temporary pu
 
 test('generation fence rejects a competing holder and resets if host observation fails', async () => {
   resetV02GenerationFenceForTest()
-  const held = await createV02GenerationFence(async () => ({
-    liveTasks: [],
-    liveJobs: [],
-    oldPluginProcesses: [],
-  })).acquire('first')
-  await assert.rejects(
-    createV02GenerationFence(async () => ({ liveTasks: [], liveJobs: [], oldPluginProcesses: [] })).acquire('second'),
-    /cannot acquire/,
-  )
+  const held = await integratedFence().acquire('first')
+  await assert.rejects(integratedFence().acquire('second'), /cannot acquire/)
   await held.release('facts-changed')
   await assert.rejects(
-    createV02GenerationFence(async () => {
+    integratedFence(async () => {
       throw new Error('host observation unavailable')
     }).acquire('third'),
     /host observation unavailable/,
   )
-  const recovered = await createV02GenerationFence(async () => ({
-    liveTasks: [],
-    liveJobs: [],
-    oldPluginProcesses: [],
-  })).acquire('fourth')
+  const recovered = await integratedFence().acquire('fourth')
   await recovered.release('facts-changed')
   resetV02GenerationFenceForTest()
 })
@@ -74,6 +81,18 @@ test('upgrade lock rejects malformed ownership and conservatively reclaims a pro
   try {
     await writeFile(path, '{}')
     await assert.rejects(acquireV02UpgradeLock(path, 'plan'), /invalid owner record/)
+    await writeFile(
+      path,
+      JSON.stringify({
+        schemaVersion: 1,
+        token: 'live-owner-with-different-locale',
+        pid: process.pid,
+        processStart: 'locale-dependent-mismatch',
+        acquiredAt: '2026-08-27T00:00:00.000Z',
+        planFingerprint: 'old-plan',
+      }),
+    )
+    await assert.rejects(acquireV02UpgradeLock(path, 'plan'), /already locked/)
     await writeFile(
       path,
       JSON.stringify({
@@ -102,6 +121,8 @@ test('corrupt recovery journal inventories every candidate and changed evidence 
     await writeFile(join(root, 'upgrade-v0.2.json'), '{broken')
     const corrupt = await previewV02UpgradeRecovery({ home })
     assert.equal(corrupt.status, 'recovery-blocked')
+    assert.equal(corrupt.journal.status, 'corrupt')
+    assert.equal(corrupt.decision, 'manual-recovery-required')
     assert.deepEqual(
       corrupt.assets.map((asset) => asset.path.split('/').at(-1)),
       ['config-v0.1-backup-evidence.yaml', 'config.yaml', 'state', 'upgrade-v0.2.json'],
@@ -116,6 +137,13 @@ test('corrupt recovery journal inventories every candidate and changed evidence 
     await writeFile(join(root, 'upgrade-v0.2.json'), JSON.stringify(journal))
     const invalid = await previewV02UpgradeRecovery({ home })
     assert.equal(invalid.status, 'recovery-blocked')
+
+    await rm(join(root, 'upgrade-v0.2.json'))
+    const missing = await previewV02UpgradeRecovery({ home })
+    assert.equal(missing.status, 'recovery-blocked')
+    assert.equal(missing.journal.status, 'missing')
+    assert.equal(missing.decision, 'manual-recovery-required')
+    assert.match(missing.assets.map((asset) => asset.path).join('\n'), /config-v0\.1-backup/)
   } finally {
     await rm(home, { recursive: true, force: true })
   }

--- a/tests/v02-upgrade-failures.test.ts
+++ b/tests/v02-upgrade-failures.test.ts
@@ -70,7 +70,7 @@ test('generation fence rejects a competing holder and resets if host observation
   resetV02GenerationFenceForTest()
 })
 
-test('upgrade lock rejects malformed ownership and conservatively reclaims a proven dead owner', async () => {
+test('upgrade lock preserves live legacy owners and reclaims new-format reused PIDs or proven dead owners', async () => {
   const root = await mkdtemp(join(tmpdir(), 'clickvibe-v02-stale-lock-'))
   const path = join(root, 'upgrade-v0.2.lock')
   try {
@@ -80,6 +80,18 @@ test('upgrade lock rejects malformed ownership and conservatively reclaims a pro
       path,
       JSON.stringify({
         schemaVersion: 1,
+        token: 'legacy-live-owner',
+        pid: process.pid,
+        processStart: 'Mon Jan  1 00:00:00 1990',
+        acquiredAt: '2026-08-27T00:00:00.000Z',
+        planFingerprint: 'old-plan',
+      }),
+    )
+    await assert.rejects(acquireV02UpgradeLock(path, 'plan'), /already locked/)
+    await writeFile(
+      path,
+      JSON.stringify({
+        schemaVersion: 2,
         token: 'reused-pid-owner',
         pid: process.pid,
         processStart: 'Mon Jan  1 00:00:00 1990',

--- a/tests/v02-upgrade-failures.test.ts
+++ b/tests/v02-upgrade-failures.test.ts
@@ -3,25 +3,20 @@ import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promis
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
-import { createV02GenerationFence, resetV02GenerationFenceForTest } from '../src/infra/v02-generation-fence.ts'
+import {
+  createOfflineV02GenerationFence,
+  resetV02GenerationFenceForTest,
+  V02_OFFLINE_HOST_DECLARATION,
+} from '../src/infra/v02-generation-fence.ts'
 import { durableRename, durableWriteExclusive, ensureDurableDirectory } from '../src/infra/v02-upgrade-durable.ts'
 import { type V02UpgradeGenerationFence } from '../src/infra/v02-upgrade-execution.ts'
 import { acquireV02UpgradeLock } from '../src/infra/v02-upgrade-lock.ts'
 import { previewV02UpgradeRecovery, rollbackV02Upgrade } from '../src/infra/v02-upgrade-recovery.ts'
 
-function integratedFence(
-  observeHostActivity: () => Promise<{
-    liveTasks: string[]
-    liveJobs: string[]
-    oldPluginProcesses: string[]
-  }> = async () => ({ liveTasks: [], liveJobs: [], oldPluginProcesses: [] }),
-) {
-  return createV02GenerationFence({
-    acquireLegacyEntryBlock: async () => {},
-    confirmLegacyEntryDisabled: async () => true,
-    settleLegacyEntryBlock: async () => {},
-    observeHostActivity,
-    enumerateOldPluginProcesses: async () => [],
+function offlineFence(enumerateOldPluginProcesses: () => Promise<string[]> = async () => []) {
+  return createOfflineV02GenerationFence({
+    declaration: V02_OFFLINE_HOST_DECLARATION,
+    enumerateOldPluginProcesses,
     waitForExitMs: 20,
     pollIntervalMs: 1,
   })
@@ -61,16 +56,16 @@ test('durable primitives reject collisions and clean an interrupted temporary pu
 
 test('generation fence rejects a competing holder and resets if host observation fails', async () => {
   resetV02GenerationFenceForTest()
-  const held = await integratedFence().acquire('first')
-  await assert.rejects(integratedFence().acquire('second'), /cannot acquire/)
+  const held = await offlineFence().acquire('first')
+  await assert.rejects(offlineFence().acquire('second'), /cannot acquire/)
   await held.release('facts-changed')
   await assert.rejects(
-    integratedFence(async () => {
+    offlineFence(async () => {
       throw new Error('host observation unavailable')
     }).acquire('third'),
     /host observation unavailable/,
   )
-  const recovered = await integratedFence().acquire('fourth')
+  const recovered = await offlineFence().acquire('fourth')
   await recovered.release('facts-changed')
   resetV02GenerationFenceForTest()
 })
@@ -85,14 +80,15 @@ test('upgrade lock rejects malformed ownership and conservatively reclaims a pro
       path,
       JSON.stringify({
         schemaVersion: 1,
-        token: 'live-owner-with-different-locale',
+        token: 'reused-pid-owner',
         pid: process.pid,
-        processStart: 'locale-dependent-mismatch',
+        processStart: 'Mon Jan  1 00:00:00 1990',
         acquiredAt: '2026-08-27T00:00:00.000Z',
         planFingerprint: 'old-plan',
       }),
     )
-    await assert.rejects(acquireV02UpgradeLock(path, 'plan'), /already locked/)
+    const reusedPidRecovered = await acquireV02UpgradeLock(path, 'plan')
+    await reusedPidRecovered.release()
     await writeFile(
       path,
       JSON.stringify({
@@ -117,7 +113,10 @@ test('corrupt recovery journal inventories every candidate and changed evidence 
   try {
     await mkdir(join(root, 'state'), { recursive: true })
     await writeFile(join(root, 'config.yaml'), 'repos: {}\n')
-    await writeFile(join(root, 'config-v0.1-backup-evidence.yaml'), 'legacy\n')
+    await writeFile(
+      join(root, 'config-v0.1-backup-20260827T000000000Z-11111111-1111-4111-8111-111111111111.yaml'),
+      'legacy\n',
+    )
     await writeFile(join(root, 'upgrade-v0.2.json'), '{broken')
     const corrupt = await previewV02UpgradeRecovery({ home })
     assert.equal(corrupt.status, 'recovery-blocked')
@@ -125,7 +124,12 @@ test('corrupt recovery journal inventories every candidate and changed evidence 
     assert.equal(corrupt.decision, 'manual-recovery-required')
     assert.deepEqual(
       corrupt.assets.map((asset) => asset.path.split('/').at(-1)),
-      ['config-v0.1-backup-evidence.yaml', 'config.yaml', 'state', 'upgrade-v0.2.json'],
+      [
+        'config-v0.1-backup-20260827T000000000Z-11111111-1111-4111-8111-111111111111.yaml',
+        'config.yaml',
+        'state',
+        'upgrade-v0.2.json',
+      ],
     )
 
     const journal = {

--- a/tests/v02-upgrade-failures.test.ts
+++ b/tests/v02-upgrade-failures.test.ts
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { createV02GenerationFence, resetV02GenerationFenceForTest } from '../src/infra/v02-generation-fence.ts'
+import { durableRename, durableWriteExclusive, ensureDurableDirectory } from '../src/infra/v02-upgrade-durable.ts'
+import { type V02UpgradeGenerationFence } from '../src/infra/v02-upgrade-execution.ts'
+import { acquireV02UpgradeLock } from '../src/infra/v02-upgrade-lock.ts'
+import { previewV02UpgradeRecovery, rollbackV02Upgrade } from '../src/infra/v02-upgrade-recovery.ts'
+
+test('durable primitives reject collisions and clean an interrupted temporary publication', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'clickvibe-v02-durable-'))
+  const firstDirectory = join(root, 'first')
+  const secondDirectory = join(root, 'second')
+  try {
+    await ensureDurableDirectory(firstDirectory)
+    await ensureDurableDirectory(firstDirectory)
+    await ensureDurableDirectory(secondDirectory)
+    const destination = join(firstDirectory, 'value')
+    await durableWriteExclusive(destination, 'complete')
+    await assert.rejects(durableWriteExclusive(destination, 'replacement'), { code: 'EEXIST' })
+    const interrupted = join(firstDirectory, 'interrupted')
+    await assert.rejects(
+      durableWriteExclusive(interrupted, 'partial', (checkpoint) => {
+        if (checkpoint.startsWith('after-file-write:')) throw new Error('injected write interruption')
+      }),
+      /injected write interruption/,
+    )
+    assert.equal(
+      (await readdir(firstDirectory)).some((name) => name.includes('interrupted')),
+      false,
+    )
+    const moved = join(secondDirectory, 'value')
+    await durableRename(destination, moved)
+    assert.equal(await readFile(moved, 'utf8'), 'complete')
+    await writeFile(join(root, 'not-a-directory'), 'x')
+    await assert.rejects(ensureDurableDirectory(join(root, 'not-a-directory')), /expected real directory/)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('generation fence rejects a competing holder and resets if host observation fails', async () => {
+  resetV02GenerationFenceForTest()
+  const held = await createV02GenerationFence(async () => ({
+    liveTasks: [],
+    liveJobs: [],
+    oldPluginProcesses: [],
+  })).acquire('first')
+  await assert.rejects(
+    createV02GenerationFence(async () => ({ liveTasks: [], liveJobs: [], oldPluginProcesses: [] })).acquire('second'),
+    /cannot acquire/,
+  )
+  await held.release('facts-changed')
+  await assert.rejects(
+    createV02GenerationFence(async () => {
+      throw new Error('host observation unavailable')
+    }).acquire('third'),
+    /host observation unavailable/,
+  )
+  const recovered = await createV02GenerationFence(async () => ({
+    liveTasks: [],
+    liveJobs: [],
+    oldPluginProcesses: [],
+  })).acquire('fourth')
+  await recovered.release('facts-changed')
+  resetV02GenerationFenceForTest()
+})
+
+test('upgrade lock rejects malformed ownership and conservatively reclaims a proven dead owner', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'clickvibe-v02-stale-lock-'))
+  const path = join(root, 'upgrade-v0.2.lock')
+  try {
+    await writeFile(path, '{}')
+    await assert.rejects(acquireV02UpgradeLock(path, 'plan'), /invalid owner record/)
+    await writeFile(
+      path,
+      JSON.stringify({
+        schemaVersion: 1,
+        token: 'dead-owner',
+        pid: 2_147_483_647,
+        processStart: 'never',
+        acquiredAt: '2026-08-27T00:00:00.000Z',
+        planFingerprint: 'old-plan',
+      }),
+    )
+    const recovered = await acquireV02UpgradeLock(path, 'new-plan')
+    await recovered.release()
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('corrupt recovery journal inventories every candidate and changed evidence invalidates authorization', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'clickvibe-v02-corrupt-recovery-'))
+  const root = join(home, '.clickvibe')
+  try {
+    await mkdir(join(root, 'state'), { recursive: true })
+    await writeFile(join(root, 'config.yaml'), 'repos: {}\n')
+    await writeFile(join(root, 'config-v0.1-backup-evidence.yaml'), 'legacy\n')
+    await writeFile(join(root, 'upgrade-v0.2.json'), '{broken')
+    const corrupt = await previewV02UpgradeRecovery({ home })
+    assert.equal(corrupt.status, 'recovery-blocked')
+    assert.deepEqual(
+      corrupt.assets.map((asset) => asset.path.split('/').at(-1)),
+      ['config-v0.1-backup-evidence.yaml', 'config.yaml', 'state', 'upgrade-v0.2.json'],
+    )
+
+    const journal = {
+      schemaVersion: 1,
+      phase: 'rolled_back',
+      planFingerprint: 'invalid-until-parsed',
+      plan: {},
+    }
+    await writeFile(join(root, 'upgrade-v0.2.json'), JSON.stringify(journal))
+    const invalid = await previewV02UpgradeRecovery({ home })
+    assert.equal(invalid.status, 'recovery-blocked')
+  } finally {
+    await rm(home, { recursive: true, force: true })
+  }
+})
+
+test('recovery authorization fingerprint is checked before any lock or fence mutation', async () => {
+  let acquired = false
+  const fence: V02UpgradeGenerationFence = {
+    async acquire() {
+      acquired = true
+      throw new Error('must not acquire')
+    },
+  }
+  await assert.rejects(
+    rollbackV02Upgrade({
+      plan: {
+        upgradeVersion: 'clickvibe-v02-recovery-1',
+        createdAt: '2026-08-27T00:00:00.000Z',
+        journal: {
+          path: '/invalid',
+          bytes: 0,
+          sha256: '',
+          value: {} as never,
+        },
+        assets: [],
+      },
+      fingerprint: 'wrong',
+      fence,
+    }),
+    /recovery authorization fingerprint is invalid/,
+  )
+  assert.equal(acquired, false)
+})

--- a/tests/v02-upgrade-lock.test.ts
+++ b/tests/v02-upgrade-lock.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { once } from 'node:events'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { acquireV02UpgradeLock } from '../src/infra/v02-upgrade-lock.ts'
+
+test('a real second Node process cannot acquire the fixed upgrade lock', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'clickvibe-v02-lock-'))
+  const lockPath = join(root, 'upgrade-v0.2.lock')
+  const moduleUrl = new URL('../src/infra/v02-upgrade-lock.ts', import.meta.url).href
+  const script = `
+    import { acquireV02UpgradeLock } from ${JSON.stringify(moduleUrl)};
+    const lock = await acquireV02UpgradeLock(${JSON.stringify(lockPath)}, 'child-plan');
+    console.log('LOCKED');
+    setTimeout(async () => { await lock.release(); process.exit(0) }, 1200);
+  `
+  const child = spawn(process.execPath, ['--input-type=module', '-e', script], { stdio: ['ignore', 'pipe', 'pipe'] })
+  try {
+    let output = ''
+    while (!output.includes('LOCKED')) {
+      const [chunk] = (await once(child.stdout, 'data')) as [Buffer]
+      output += chunk.toString('utf8')
+    }
+    await assert.rejects(acquireV02UpgradeLock(lockPath, 'parent-plan'), /already locked/)
+    const [exitCode] = (await once(child, 'exit')) as [number]
+    assert.equal(exitCode, 0)
+    const parent = await acquireV02UpgradeLock(lockPath, 'parent-plan')
+    await parent.release()
+  } finally {
+    if (child.exitCode === null) child.kill()
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/tests/v02-upgrade-lock.test.ts
+++ b/tests/v02-upgrade-lock.test.ts
@@ -34,3 +34,24 @@ test('a real second Node process cannot acquire the fixed upgrade lock', async (
     await rm(root, { recursive: true, force: true })
   }
 })
+
+test('two simultaneous acquirers produce exactly one owner', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'clickvibe-v02-lock-race-'))
+  const lockPath = join(root, 'upgrade-v0.2.lock')
+  try {
+    const attempts = await Promise.allSettled([
+      acquireV02UpgradeLock(lockPath, 'first-plan'),
+      acquireV02UpgradeLock(lockPath, 'second-plan'),
+    ])
+    const winners = attempts.filter(
+      (result): result is PromiseFulfilledResult<Awaited<ReturnType<typeof acquireV02UpgradeLock>>> =>
+        result.status === 'fulfilled',
+    )
+    const losers = attempts.filter((result) => result.status === 'rejected')
+    assert.equal(winners.length, 1)
+    assert.equal(losers.length, 1)
+    await winners[0].value.release()
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/tests/v02-upgrade-preview.test.ts
+++ b/tests/v02-upgrade-preview.test.ts
@@ -177,7 +177,21 @@ test('an unfinished or corrupt journal takes precedence over a fresh preview', a
     assert.match(preview.recovery.assets.map((asset) => asset.path).join('\n'), /upgrade-v0\.2\.json/)
 
     await unlink(join(clickvibe, 'upgrade-v0.2.json'))
-    await writeFile(join(clickvibe, 'config-v0.1-backup-evidence.yaml'), 'repos: {}\n')
+    await writeFile(join(clickvibe, 'config-v0.1-backup-notes.txt'), 'not an upgrader artifact\n')
+    const notesOnly = await previewV02Upgrade({
+      home,
+      baselineSha: 'baseline',
+      now: '2026-08-27T16:00:00.000Z',
+      nonce: 'missing-journal',
+      choices: { primaryRemotes: {}, exclusions: {} },
+      hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
+    })
+    assert.equal(notesOnly.status, 'previewed')
+
+    await writeFile(
+      join(clickvibe, 'config-v0.1-backup-20260827T160000000Z-11111111-1111-4111-8111-111111111111.yaml'),
+      'repos: {}\n',
+    )
     const missing = await previewV02Upgrade({
       home,
       baselineSha: 'baseline',

--- a/tests/v02-upgrade-preview.test.ts
+++ b/tests/v02-upgrade-preview.test.ts
@@ -1,0 +1,284 @@
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { mkdtemp, mkdir, readFile, readdir, rm, symlink, unlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { promisify } from 'node:util'
+import test from 'node:test'
+import { parse as parseYaml } from 'yaml'
+import { parseClickVibeConfigV1 } from '../src/infra/project-binding.ts'
+import { previewV02Upgrade } from '../src/infra/v02-upgrade.ts'
+
+const execFileAsync = promisify(execFile)
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const result = await execFileAsync('git', ['-C', cwd, ...args], { encoding: 'utf8' })
+  return result.stdout.trim()
+}
+
+async function initRepository(path: string): Promise<void> {
+  await git(dirname(path), 'init', path)
+  await git(path, 'config', 'user.name', 'clickvibe-test')
+  await git(path, 'config', 'user.email', 'clickvibe-test@example.invalid')
+  await git(path, 'commit', '--allow-empty', '-m', 'base')
+  await git(path, 'remote', 'add', 'origin', 'https://github.com/o/r.git')
+}
+
+async function treeDigest(root: string): Promise<string> {
+  const entries: string[] = []
+  async function visit(path: string, relative: string): Promise<void> {
+    for (const entry of (await readdir(path, { withFileTypes: true })).sort((a, b) => a.name.localeCompare(b.name))) {
+      const child = join(path, entry.name)
+      const name = relative === '' ? entry.name : `${relative}/${entry.name}`
+      if (entry.isDirectory()) {
+        entries.push(`d:${name}`)
+        await visit(child, name)
+      } else if (entry.isFile()) {
+        entries.push(
+          `f:${name}:${createHash('sha256')
+            .update(await readFile(child))
+            .digest('hex')}`,
+        )
+      } else {
+        entries.push(`x:${name}`)
+      }
+    }
+  }
+  await visit(root, '')
+  return createHash('sha256').update(entries.join('\n')).digest('hex')
+}
+
+test('v0.2 preview is zero-write and freezes exact config, state, repository and worktree facts', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'clickvibe-v02-preview-'))
+  const repository = join(home, 'repo')
+  const clickvibe = join(home, '.clickvibe')
+  const configPath = join(clickvibe, 'config.yaml')
+  try {
+    await initRepository(repository)
+    await mkdir(join(clickvibe, 'state', 'o', 'r', 'issue-9'), { recursive: true })
+    await writeFile(join(clickvibe, 'state', 'o', 'r', 'issue-9', 'workflow.json'), '{"legacy":true}\n')
+    const legacyConfig = [
+      'repos:',
+      `  o/r: ${repository}`,
+      `worktreeRoot: ${join(home, 'worktrees')}`,
+      'fetchTtlSeconds: 45',
+      'diagnosticsMaxBytes: 10485760',
+      '',
+    ].join('\n')
+    await mkdir(clickvibe, { recursive: true })
+    await writeFile(configPath, legacyConfig, { mode: 0o600 })
+    const before = await treeDigest(home)
+
+    const preview = await previewV02Upgrade({
+      home,
+      baselineSha: '553a926405919bd3efc677fbd9bf0388f7c6a26d',
+      now: '2026-08-27T16:00:00.000Z',
+      nonce: 'preview-a',
+      proposedRepositoryIds: { 'o/r': 'repo_11111111-1111-4111-8111-111111111111' },
+      choices: { primaryRemotes: { 'o/r': 'origin' }, exclusions: {} },
+      hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
+    })
+
+    assert.equal(preview.status, 'previewed', JSON.stringify(preview))
+    assert.equal(await treeDigest(home), before)
+    assert.equal(preview.plan.legacyConfig.sha256, createHash('sha256').update(legacyConfig).digest('hex'))
+    assert.equal(preview.plan.legacyState.status, 'present')
+    assert.equal(preview.plan.legacyState.fileCount, 1)
+    assert.equal(preview.plan.bindings[0].container.id, 'o/r')
+    assert.equal(preview.plan.bindings[0].repository.primaryRemote, 'origin')
+    assert.match(preview.plan.worktrees[0].porcelain, /worktree /)
+    assert.match(preview.fingerprint, /^[0-9a-f]{64}$/)
+    assert.equal(preview.plan.paths.activeState, join(clickvibe, 'state'))
+    assert.equal(preview.plan.paths.stateBackup, join(clickvibe, 'state-v0.1-backup-20260827T160000000Z-preview-a'))
+    assert.equal(
+      preview.plan.paths.configBackup,
+      join(clickvibe, 'config-v0.1-backup-20260827T160000000Z-preview-a.yaml'),
+    )
+
+    const parsed = parseClickVibeConfigV1(parseYaml(preview.plan.targetConfig.yaml))
+    assert.equal(parsed.projectBindings[0].repository.repositoryId, 'repo_11111111-1111-4111-8111-111111111111')
+    assert.equal(parsed.fetchTtlSeconds, 45)
+    assert.equal(parsed.diagnosticsMaxBytes, 10_485_760)
+  } finally {
+    await rm(home, { recursive: true, force: true })
+  }
+})
+
+test('preview fails closed for invalid inputs and binds explicit exclusions into the fingerprint', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'clickvibe-v02-preview-blocked-'))
+  const clickvibe = join(home, '.clickvibe')
+  const configPath = join(clickvibe, 'config.yaml')
+  try {
+    await mkdir(clickvibe, { recursive: true })
+    await writeFile(configPath, `repos:\n  dead/repo: ${join(home, 'missing')}\nfetchTtlSeconds: 29\n`)
+    const invalid = await previewV02Upgrade({
+      home,
+      baselineSha: 'baseline',
+      now: '2026-08-27T16:00:00.000Z',
+      nonce: 'blocked',
+      choices: { primaryRemotes: {}, exclusions: {} },
+      hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
+    })
+    assert.equal(invalid.status, 'blocked')
+    assert.match(invalid.blocked.map((item) => item.error).join('\n'), /fetchTtlSeconds/)
+
+    await writeFile(configPath, `repos:\n  dead/repo: ${join(home, 'missing')}\n`)
+    const excluded = await previewV02Upgrade({
+      home,
+      baselineSha: 'baseline',
+      now: '2026-08-27T16:00:00.000Z',
+      nonce: 'excluded',
+      choices: {
+        primaryRemotes: {},
+        exclusions: { 'dead/repo': 'clone was intentionally removed' },
+      },
+      hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
+    })
+    assert.equal(excluded.status, 'previewed')
+    assert.equal(excluded.plan.bindings.length, 0)
+    assert.deepEqual(
+      excluded.plan.exclusions.map(({ repoKey, reason }) => ({ repoKey, reason })),
+      [{ repoKey: 'dead/repo', reason: 'clone was intentionally removed' }],
+    )
+
+    const changedReason = await previewV02Upgrade({
+      home,
+      baselineSha: 'baseline',
+      now: '2026-08-27T16:00:00.000Z',
+      nonce: 'excluded',
+      choices: { primaryRemotes: {}, exclusions: { 'dead/repo': 'different reason' } },
+      hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
+    })
+    assert.equal(changedReason.status, 'previewed')
+    assert.notEqual(changedReason.fingerprint, excluded.fingerprint)
+  } finally {
+    await rm(home, { recursive: true, force: true })
+  }
+})
+
+test('an unfinished or corrupt journal takes precedence over a fresh preview', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'clickvibe-v02-preview-recovery-'))
+  const clickvibe = join(home, '.clickvibe')
+  try {
+    await mkdir(clickvibe, { recursive: true })
+    await writeFile(join(clickvibe, 'config.yaml'), 'repos: {}\n')
+    await writeFile(join(clickvibe, 'upgrade-v0.2.json'), '{broken')
+    const preview = await previewV02Upgrade({
+      home,
+      baselineSha: 'baseline',
+      now: '2026-08-27T16:00:00.000Z',
+      nonce: 'recovery',
+      choices: { primaryRemotes: {}, exclusions: {} },
+      hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
+    })
+    assert.equal(preview.status, 'recovery')
+    assert.equal(preview.recovery.journal.status, 'corrupt')
+    assert.match(preview.recovery.assets.map((asset) => asset.path).join('\n'), /upgrade-v0\.2\.json/)
+  } finally {
+    await rm(home, { recursive: true, force: true })
+  }
+})
+
+test('legacy config validation rejects ambiguous shapes instead of inventing defaults', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'clickvibe-v02-invalid-config-'))
+  const root = join(home, '.clickvibe')
+  const configPath = join(root, 'config.yaml')
+  await mkdir(root, { recursive: true })
+  const invalid = [
+    '[broken',
+    '[]\n',
+    'unknown: true\n',
+    'repos: null\n',
+    'repos: []\n',
+    'repos:\n  invalid: /tmp/repo\n',
+    'repos:\n  o/r: 42\n',
+    "repos:\n  o/r: ''\n",
+    'worktreeRoot: 42\n',
+    "worktreeRoot: ''\n",
+    "fetchTtlSeconds: '45'\n",
+    'fetchTtlSeconds: 45.5\n',
+    'fetchTtlSeconds: 0\n',
+    'fetchTtlSeconds: 29\n',
+    'fetchTtlSeconds: 61\n',
+    "diagnosticsMaxBytes: 'large'\n",
+    'diagnosticsMaxBytes: 0\n',
+  ]
+  try {
+    for (const [index, raw] of invalid.entries()) {
+      await writeFile(configPath, raw)
+      const result = await previewV02Upgrade({
+        home,
+        baselineSha: 'baseline',
+        now: '2026-08-27T18:00:00.000Z',
+        nonce: `invalid-${index}`,
+        choices: { primaryRemotes: {}, exclusions: {} },
+        hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
+      })
+      assert.equal(result.status, 'blocked', `${index}: ${JSON.stringify(result)}`)
+      if (result.status === 'blocked') assert.equal(result.blocked[0].scope, 'config')
+    }
+
+    await writeFile(configPath, 'repos: {}\nworktreeRoot: ~\nfetchTtlSeconds: 30\ndiagnosticsMaxBytes: 1\n')
+    const valid = await previewV02Upgrade({
+      home,
+      baselineSha: 'baseline',
+      now: '2026-08-27T18:00:00.000Z',
+      nonce: 'valid-settings',
+      choices: { primaryRemotes: {}, exclusions: {} },
+      hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
+    })
+    assert.equal(valid.status, 'previewed')
+    assert.match(valid.plan.targetConfig.yaml, /fetchTtlSeconds: 30/)
+    assert.match(valid.plan.targetConfig.yaml, /diagnosticsMaxBytes: 1/)
+
+    await unlink(configPath)
+    await writeFile(join(root, 'config-target.yaml'), 'repos: {}\n')
+    await symlink(join(root, 'config-target.yaml'), configPath)
+    const linked = await previewV02Upgrade({
+      home,
+      baselineSha: 'baseline',
+      nonce: 'linked-config',
+      choices: { primaryRemotes: {}, exclusions: {} },
+      hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
+    })
+    assert.equal(linked.status, 'blocked')
+  } finally {
+    await rm(home, { recursive: true, force: true })
+  }
+})
+
+test('state and all host activity axes block an otherwise valid preview', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'clickvibe-v02-host-blocks-'))
+  const root = join(home, '.clickvibe')
+  await mkdir(root, { recursive: true })
+  await writeFile(join(root, 'config.yaml'), 'repos: {}\n')
+  try {
+    await writeFile(join(root, 'state'), 'not a directory')
+    const stateBlocked = await previewV02Upgrade({
+      home,
+      baselineSha: 'baseline',
+      nonce: 'state-file',
+      choices: { primaryRemotes: {}, exclusions: {} },
+      hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
+    })
+    assert.equal(stateBlocked.status, 'blocked')
+    await rm(join(root, 'state'))
+
+    const hostBlocked = await previewV02Upgrade({
+      home,
+      baselineSha: 'baseline',
+      nonce: 'host-activity',
+      choices: { primaryRemotes: {}, exclusions: {} },
+      hostActivity: { liveTasks: ['task-1'], liveJobs: ['job-1'], oldPluginProcesses: ['pid-1'] },
+    })
+    assert.equal(hostBlocked.status, 'blocked')
+    if (hostBlocked.status === 'blocked')
+      assert.deepEqual(
+        hostBlocked.blocked.map((item) => item.scope),
+        ['host', 'host', 'host'],
+      )
+  } finally {
+    await rm(home, { recursive: true, force: true })
+  }
+})

--- a/tests/v02-upgrade-preview.test.ts
+++ b/tests/v02-upgrade-preview.test.ts
@@ -12,6 +12,25 @@ import { previewV02Upgrade } from '../src/infra/v02-upgrade.ts'
 
 const execFileAsync = promisify(execFile)
 
+function testNonce(label: string): string {
+  const hex = createHash('sha256').update(label).digest('hex')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-4${hex.slice(13, 16)}-8${hex.slice(17, 20)}-${hex.slice(20, 32)}`
+}
+
+test('v0.2 preview rejects an injected nonce outside the UUIDv4 inventory contract', async () => {
+  await assert.rejects(
+    previewV02Upgrade({
+      home: '/unused',
+      baselineSha: '553a926405919bd3efc677fbd9bf0388f7c6a26d',
+      nonce: 'x',
+      proposedRepositoryIds: {},
+      choices: { primaryRemotes: {}, exclusions: {} },
+      hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
+    }),
+    /nonce.*UUIDv4/i,
+  )
+})
+
 async function git(cwd: string, ...args: string[]): Promise<string> {
   const result = await execFileAsync('git', ['-C', cwd, ...args], { encoding: 'utf8' })
   return result.stdout.trim()
@@ -74,7 +93,7 @@ test('v0.2 preview is zero-write and freezes exact config, state, repository and
       home,
       baselineSha: '553a926405919bd3efc677fbd9bf0388f7c6a26d',
       now: '2026-08-27T16:00:00.000Z',
-      nonce: 'preview-a',
+      nonce: testNonce('preview-a'),
       proposedRepositoryIds: { 'o/r': 'repo_11111111-1111-4111-8111-111111111111' },
       choices: { primaryRemotes: { 'o/r': 'origin' }, exclusions: {} },
       hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
@@ -90,10 +109,13 @@ test('v0.2 preview is zero-write and freezes exact config, state, repository and
     assert.match(preview.plan.worktrees[0].porcelain, /worktree /)
     assert.match(preview.fingerprint, /^[0-9a-f]{64}$/)
     assert.equal(preview.plan.paths.activeState, join(clickvibe, 'state'))
-    assert.equal(preview.plan.paths.stateBackup, join(clickvibe, 'state-v0.1-backup-20260827T160000000Z-preview-a'))
+    assert.equal(
+      preview.plan.paths.stateBackup,
+      join(clickvibe, `state-v0.1-backup-20260827T160000000Z-${testNonce('preview-a')}`),
+    )
     assert.equal(
       preview.plan.paths.configBackup,
-      join(clickvibe, 'config-v0.1-backup-20260827T160000000Z-preview-a.yaml'),
+      join(clickvibe, `config-v0.1-backup-20260827T160000000Z-${testNonce('preview-a')}.yaml`),
     )
 
     const parsed = parseClickVibeConfigV1(parseYaml(preview.plan.targetConfig.yaml))
@@ -116,7 +138,7 @@ test('preview fails closed for invalid inputs and binds explicit exclusions into
       home,
       baselineSha: 'baseline',
       now: '2026-08-27T16:00:00.000Z',
-      nonce: 'blocked',
+      nonce: testNonce('blocked'),
       choices: { primaryRemotes: {}, exclusions: {} },
       hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
     })
@@ -128,7 +150,7 @@ test('preview fails closed for invalid inputs and binds explicit exclusions into
       home,
       baselineSha: 'baseline',
       now: '2026-08-27T16:00:00.000Z',
-      nonce: 'excluded',
+      nonce: testNonce('excluded'),
       choices: {
         primaryRemotes: {},
         exclusions: { 'dead/repo': 'clone was intentionally removed' },
@@ -146,7 +168,7 @@ test('preview fails closed for invalid inputs and binds explicit exclusions into
       home,
       baselineSha: 'baseline',
       now: '2026-08-27T16:00:00.000Z',
-      nonce: 'excluded',
+      nonce: testNonce('excluded'),
       choices: { primaryRemotes: {}, exclusions: { 'dead/repo': 'different reason' } },
       hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
     })
@@ -168,7 +190,7 @@ test('an unfinished or corrupt journal takes precedence over a fresh preview', a
       home,
       baselineSha: 'baseline',
       now: '2026-08-27T16:00:00.000Z',
-      nonce: 'recovery',
+      nonce: testNonce('recovery'),
       choices: { primaryRemotes: {}, exclusions: {} },
       hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
     })
@@ -182,7 +204,7 @@ test('an unfinished or corrupt journal takes precedence over a fresh preview', a
       home,
       baselineSha: 'baseline',
       now: '2026-08-27T16:00:00.000Z',
-      nonce: 'missing-journal',
+      nonce: testNonce('missing-journal'),
       choices: { primaryRemotes: {}, exclusions: {} },
       hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
     })
@@ -196,7 +218,7 @@ test('an unfinished or corrupt journal takes precedence over a fresh preview', a
       home,
       baselineSha: 'baseline',
       now: '2026-08-27T16:00:00.000Z',
-      nonce: 'missing-journal',
+      nonce: testNonce('missing-journal'),
       choices: { primaryRemotes: {}, exclusions: {} },
       hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
     })
@@ -218,7 +240,7 @@ test('relative legacy repository paths resolve against the selected home, never 
     const preview = await previewV02Upgrade({
       home,
       baselineSha: 'baseline',
-      nonce: 'relative-path',
+      nonce: testNonce('relative-path'),
       proposedRepositoryIds: { 'o/r': 'repo_11111111-1111-4111-8111-111111111111' },
       choices: { primaryRemotes: { 'o/r': 'origin' }, exclusions: {} },
       hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
@@ -262,7 +284,7 @@ test('legacy config validation rejects ambiguous shapes instead of inventing def
         home,
         baselineSha: 'baseline',
         now: '2026-08-27T18:00:00.000Z',
-        nonce: `invalid-${index}`,
+        nonce: testNonce(`invalid-${index}`),
         choices: { primaryRemotes: {}, exclusions: {} },
         hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
       })
@@ -275,7 +297,7 @@ test('legacy config validation rejects ambiguous shapes instead of inventing def
       home,
       baselineSha: 'baseline',
       now: '2026-08-27T18:00:00.000Z',
-      nonce: 'valid-settings',
+      nonce: testNonce('valid-settings'),
       choices: { primaryRemotes: {}, exclusions: {} },
       hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
     })
@@ -289,7 +311,7 @@ test('legacy config validation rejects ambiguous shapes instead of inventing def
     const linked = await previewV02Upgrade({
       home,
       baselineSha: 'baseline',
-      nonce: 'linked-config',
+      nonce: testNonce('linked-config'),
       choices: { primaryRemotes: {}, exclusions: {} },
       hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
     })
@@ -309,7 +331,7 @@ test('state and all host activity axes block an otherwise valid preview', async 
     const stateBlocked = await previewV02Upgrade({
       home,
       baselineSha: 'baseline',
-      nonce: 'state-file',
+      nonce: testNonce('state-file'),
       choices: { primaryRemotes: {}, exclusions: {} },
       hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
     })
@@ -319,7 +341,7 @@ test('state and all host activity axes block an otherwise valid preview', async 
     const hostBlocked = await previewV02Upgrade({
       home,
       baselineSha: 'baseline',
-      nonce: 'host-activity',
+      nonce: testNonce('host-activity'),
       choices: { primaryRemotes: {}, exclusions: {} },
       hostActivity: { liveTasks: ['task-1'], liveJobs: ['job-1'], oldPluginProcesses: ['pid-1'] },
     })

--- a/tests/v02-upgrade-preview.test.ts
+++ b/tests/v02-upgrade-preview.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { execFile } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { mkdtemp, mkdir, readFile, readdir, rm, symlink, unlink, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, readdir, realpath, rm, symlink, unlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { promisify } from 'node:util'
@@ -175,6 +175,43 @@ test('an unfinished or corrupt journal takes precedence over a fresh preview', a
     assert.equal(preview.status, 'recovery')
     assert.equal(preview.recovery.journal.status, 'corrupt')
     assert.match(preview.recovery.assets.map((asset) => asset.path).join('\n'), /upgrade-v0\.2\.json/)
+
+    await unlink(join(clickvibe, 'upgrade-v0.2.json'))
+    await writeFile(join(clickvibe, 'config-v0.1-backup-evidence.yaml'), 'repos: {}\n')
+    const missing = await previewV02Upgrade({
+      home,
+      baselineSha: 'baseline',
+      now: '2026-08-27T16:00:00.000Z',
+      nonce: 'missing-journal',
+      choices: { primaryRemotes: {}, exclusions: {} },
+      hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
+    })
+    assert.equal(missing.status, 'recovery')
+    if (missing.status === 'recovery') assert.equal(missing.recovery.journal.status, 'missing')
+  } finally {
+    await rm(home, { recursive: true, force: true })
+  }
+})
+
+test('relative legacy repository paths resolve against the selected home, never the process cwd', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'clickvibe-v02-relative-path-'))
+  const repository = join(home, 'relative-repo')
+  const root = join(home, '.clickvibe')
+  try {
+    await initRepository(repository)
+    await mkdir(root, { recursive: true })
+    await writeFile(join(root, 'config.yaml'), 'repos:\n  o/r: ./relative-repo\n')
+    const preview = await previewV02Upgrade({
+      home,
+      baselineSha: 'baseline',
+      nonce: 'relative-path',
+      proposedRepositoryIds: { 'o/r': 'repo_11111111-1111-4111-8111-111111111111' },
+      choices: { primaryRemotes: { 'o/r': 'origin' }, exclusions: {} },
+      hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
+    })
+    assert.equal(preview.status, 'previewed', JSON.stringify(preview))
+    if (preview.status === 'previewed')
+      assert.equal(preview.plan.bindings[0].repository.localPath, await realpath(repository))
   } finally {
     await rm(home, { recursive: true, force: true })
   }

--- a/tests/v02-upgrade-recovery.test.ts
+++ b/tests/v02-upgrade-recovery.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import { execFile } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -16,6 +17,11 @@ import { previewV02UpgradeRecovery, resumeV02Upgrade, rollbackV02Upgrade } from 
 import { previewV02Upgrade } from '../src/infra/v02-upgrade.ts'
 
 const execFileAsync = promisify(execFile)
+
+function testNonce(label: string): string {
+  const hex = createHash('sha256').update(label).digest('hex')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-4${hex.slice(13, 16)}-8${hex.slice(17, 20)}-${hex.slice(20, 32)}`
+}
 
 async function git(cwd: string, ...args: string[]): Promise<void> {
   await execFileAsync('git', ['-C', cwd, ...args])
@@ -39,7 +45,7 @@ async function fixture(name: string, statePresent = true) {
     home,
     baselineSha: '553a926405919bd3efc677fbd9bf0388f7c6a26d',
     now: '2026-08-27T17:00:00.000Z',
-    nonce: name,
+    nonce: testNonce(name),
     proposedRepositoryIds: { 'o/r': 'repo_33333333-3333-4333-8333-333333333333' },
     choices: { primaryRemotes: { 'o/r': 'origin' }, exclusions: {} },
     hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
@@ -124,7 +130,7 @@ test('authorized rollback restores the exact v0.1 config/state pair without dele
       home: item.home,
       baselineSha: item.preview.plan.baselineSha,
       now: '2026-08-27T17:10:00.000Z',
-      nonce: 'retry-after-rollback',
+      nonce: testNonce('retry-after-rollback'),
       choices: { primaryRemotes: { 'o/r': 'origin' }, exclusions: {} },
       hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
     })
@@ -343,6 +349,30 @@ test('online recovery refusal writes no lock and an offline retry succeeds immed
     })
     assert.equal(retried.status, 'verified', JSON.stringify(retried))
   } finally {
+    await rm(item.home, { recursive: true, force: true })
+  }
+})
+
+test('recovery still releases the cross-process lock when generation-fence release fails', async () => {
+  const item = await fixture('release-failure')
+  try {
+    await failBeforeConfigActivation(item)
+    const recovery = await previewV02UpgradeRecovery({ home: item.home })
+    assert.equal(recovery.status, 'recovery-previewed')
+    await assert.rejects(
+      resumeV02Upgrade({
+        plan: recovery.plan,
+        fingerprint: recovery.fingerprint,
+        fence: fence(),
+        checkpoint(name) {
+          if (name === 'after-terminal-journal:verified') resetV02GenerationFenceForTest()
+        },
+      }),
+      /failed to release v0\.2 recovery ownership/,
+    )
+    await assert.rejects(stat(item.preview.plan.paths.lock), { code: 'ENOENT' })
+  } finally {
+    resetV02GenerationFenceForTest()
     await rm(item.home, { recursive: true, force: true })
   }
 })

--- a/tests/v02-upgrade-recovery.test.ts
+++ b/tests/v02-upgrade-recovery.test.ts
@@ -108,6 +108,16 @@ test('authorized rollback restores the exact v0.1 config/state pair without dele
     assert.equal((await stat(item.root)).isDirectory(), true)
     assert.equal(JSON.parse(await readFile(item.preview.plan.paths.journal, 'utf8')).phase, 'rolled_back')
 
+    const terminal = await previewV02UpgradeRecovery({ home: item.home })
+    assert.equal(terminal.status, 'recovery-previewed')
+    const invalidResume = await resumeV02Upgrade({
+      plan: terminal.plan,
+      fingerprint: terminal.fingerprint,
+      fence: fence(),
+    })
+    assert.equal(invalidResume.status, 'failed')
+    if (invalidResume.status === 'failed') assert.match(invalidResume.error, /rolled_back.*new upgrade preview/)
+
     const retry = await previewV02Upgrade({
       home: item.home,
       baselineSha: item.preview.plan.baselineSha,
@@ -120,6 +130,111 @@ test('authorized rollback restores the exact v0.1 config/state pair without dele
     assert.notEqual(retry.plan.expectedJournal, 'absent')
     const reapplied = await applyV02Upgrade({ plan: retry.plan, fingerprint: retry.fingerprint, fence: fence() })
     assert.equal(reapplied.status, 'verified', JSON.stringify(reapplied))
+  } finally {
+    await rm(item.home, { recursive: true, force: true })
+  }
+})
+
+test('resume rejects a verified terminal journal instead of re-entering cutover', async () => {
+  const item = await fixture('verified-terminal')
+  try {
+    const applied = await applyV02Upgrade({
+      plan: item.preview.plan,
+      fingerprint: item.preview.fingerprint,
+      fence: fence(),
+    })
+    assert.equal(applied.status, 'verified')
+    const recovery = await previewV02UpgradeRecovery({ home: item.home })
+    assert.equal(recovery.status, 'recovery-previewed')
+    const resumed = await resumeV02Upgrade({ plan: recovery.plan, fingerprint: recovery.fingerprint, fence: fence() })
+    assert.equal(resumed.status, 'failed')
+    if (resumed.status === 'failed') assert.match(resumed.error, /verified.*terminal/)
+  } finally {
+    await rm(item.home, { recursive: true, force: true })
+  }
+})
+
+test('recovery checkpoints preserve resumability across unresolved rename and terminal journal windows', async () => {
+  const item = await fixture('recovery-checkpoints')
+  try {
+    const first = await applyV02Upgrade({
+      plan: item.preview.plan,
+      fingerprint: item.preview.fingerprint,
+      fence: fence(),
+      checkpoint(current) {
+        if (current === `after-rename:${item.preview.plan.paths.activeState}->${item.preview.plan.paths.stateBackup}`) {
+          throw new Error('crash after legacy state rename')
+        }
+      },
+    })
+    assert.equal(first.status, 'failed')
+    const recovery = await previewV02UpgradeRecovery({ home: item.home })
+    assert.equal(recovery.status, 'recovery-previewed')
+    const interrupted = await resumeV02Upgrade({
+      plan: recovery.plan,
+      fingerprint: recovery.fingerprint,
+      fence: fence(),
+      checkpoint(current) {
+        if (
+          current === `before-rename:${item.preview.plan.paths.stagedState}->${item.preview.plan.paths.activeState}`
+        ) {
+          throw new Error('recovery state activation crash')
+        }
+      },
+    })
+    assert.equal(interrupted.status, 'failed')
+    const retry = await previewV02UpgradeRecovery({ home: item.home })
+    assert.equal(retry.status, 'recovery-previewed')
+    const resumed = await resumeV02Upgrade({ plan: retry.plan, fingerprint: retry.fingerprint, fence: fence() })
+    assert.equal(resumed.status, 'verified', JSON.stringify(resumed))
+  } finally {
+    await rm(item.home, { recursive: true, force: true })
+  }
+})
+
+test('apply exposes a terminal verification checkpoint and never claims verified before its durable journal', async () => {
+  const item = await fixture('terminal-checkpoint')
+  try {
+    const failed = await applyV02Upgrade({
+      plan: item.preview.plan,
+      fingerprint: item.preview.fingerprint,
+      fence: fence(),
+      checkpoint(current) {
+        if (current === 'before-terminal-journal:verified') throw new Error('terminal journal unavailable')
+      },
+    })
+    assert.equal(failed.status, 'failed')
+    const recovery = await previewV02UpgradeRecovery({ home: item.home })
+    assert.equal(recovery.status, 'recovery-previewed')
+    const resumed = await resumeV02Upgrade({ plan: recovery.plan, fingerprint: recovery.fingerprint, fence: fence() })
+    assert.equal(resumed.status, 'verified', JSON.stringify(resumed))
+  } finally {
+    await rm(item.home, { recursive: true, force: true })
+  }
+})
+
+test('rollback checkpoints preserve enough journal evidence for an exact retry', async () => {
+  const item = await fixture('rollback-checkpoint')
+  try {
+    await failBeforeConfigActivation(item)
+    const recovery = await previewV02UpgradeRecovery({ home: item.home })
+    assert.equal(recovery.status, 'recovery-previewed')
+    const interrupted = await rollbackV02Upgrade({
+      plan: recovery.plan,
+      fingerprint: recovery.fingerprint,
+      fence: fence(),
+      checkpoint(current) {
+        if (current === `after-rename:${item.preview.plan.paths.activeState}->${item.preview.plan.paths.stagedState}`) {
+          throw new Error('rollback quarantine crash')
+        }
+      },
+    })
+    assert.equal(interrupted.status, 'failed')
+    const retry = await previewV02UpgradeRecovery({ home: item.home })
+    assert.equal(retry.status, 'recovery-previewed')
+    const rolledBack = await rollbackV02Upgrade({ plan: retry.plan, fingerprint: retry.fingerprint, fence: fence() })
+    assert.equal(rolledBack.status, 'rolled-back', JSON.stringify(rolledBack))
+    assert.equal(await readFile(item.preview.plan.paths.activeConfig, 'utf8'), item.config)
   } finally {
     await rm(item.home, { recursive: true, force: true })
   }

--- a/tests/v02-upgrade-recovery.test.ts
+++ b/tests/v02-upgrade-recovery.test.ts
@@ -1,0 +1,220 @@
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { promisify } from 'node:util'
+import test from 'node:test'
+import type { V02UpgradeGenerationFence } from '../src/infra/v02-upgrade-execution.ts'
+import { applyV02Upgrade } from '../src/infra/v02-upgrade-execution.ts'
+import { previewV02UpgradeRecovery, resumeV02Upgrade, rollbackV02Upgrade } from '../src/infra/v02-upgrade-recovery.ts'
+import { previewV02Upgrade } from '../src/infra/v02-upgrade.ts'
+
+const execFileAsync = promisify(execFile)
+
+async function git(cwd: string, ...args: string[]): Promise<void> {
+  await execFileAsync('git', ['-C', cwd, ...args])
+}
+
+async function fixture(name: string, statePresent = true) {
+  const home = await mkdtemp(join(tmpdir(), `clickvibe-v02-recovery-${name}-`))
+  const repository = join(home, 'repo')
+  const root = join(home, '.clickvibe')
+  await git(dirname(repository), 'init', repository)
+  await git(repository, 'config', 'user.name', 'clickvibe-test')
+  await git(repository, 'config', 'user.email', 'clickvibe-test@example.invalid')
+  await git(repository, 'commit', '--allow-empty', '-m', 'base')
+  await git(repository, 'remote', 'add', 'origin', 'https://github.com/o/r.git')
+  await mkdir(root, { recursive: true })
+  if (statePresent) await mkdir(join(root, 'state', 'o', 'r', 'issue-9'), { recursive: true })
+  const config = `repos:\n  o/r: ${repository}\n`
+  await writeFile(join(root, 'config.yaml'), config)
+  if (statePresent) await writeFile(join(root, 'state', 'o', 'r', 'issue-9', 'workflow.json'), '{"legacy":true}\n')
+  const preview = await previewV02Upgrade({
+    home,
+    baselineSha: '553a926405919bd3efc677fbd9bf0388f7c6a26d',
+    now: '2026-08-27T17:00:00.000Z',
+    nonce: name,
+    proposedRepositoryIds: { 'o/r': 'repo_33333333-3333-4333-8333-333333333333' },
+    choices: { primaryRemotes: { 'o/r': 'origin' }, exclusions: {} },
+    hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
+  })
+  assert.equal(preview.status, 'previewed')
+  return { home, root, config, preview }
+}
+
+function fence(): V02UpgradeGenerationFence {
+  return {
+    async acquire() {
+      return {
+        activity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
+        async release() {},
+      }
+    },
+  }
+}
+
+async function failBeforeConfigActivation(item: Awaited<ReturnType<typeof fixture>>) {
+  const result = await applyV02Upgrade({
+    plan: item.preview.plan,
+    fingerprint: item.preview.fingerprint,
+    fence: fence(),
+    checkpoint(name) {
+      if (name === `before-rename:${item.preview.plan.paths.stagedConfig}->${item.preview.plan.paths.activeConfig}`) {
+        throw new Error('injected config activation crash')
+      }
+    },
+  })
+  assert.equal(result.status, 'failed')
+  assert.match(result.error, /injected config activation crash/)
+  assert.equal(await readFile(item.preview.plan.paths.activeConfig, 'utf8'), item.config)
+  assert.equal(
+    JSON.parse(await readFile(join(item.preview.plan.paths.activeState, '.clickvibe-state.json'), 'utf8')).generation,
+    'v0.2',
+  )
+}
+
+test('recovery preview is zero-write and authorized resume finishes a mixed-generation cutover', async () => {
+  const item = await fixture('resume')
+  try {
+    await failBeforeConfigActivation(item)
+    const journalBefore = await readFile(item.preview.plan.paths.journal)
+    const recovery = await previewV02UpgradeRecovery({ home: item.home })
+    assert.equal(recovery.status, 'recovery-previewed', JSON.stringify(recovery))
+    assert.deepEqual(await readFile(item.preview.plan.paths.journal), journalBefore)
+    const result = await resumeV02Upgrade({ plan: recovery.plan, fingerprint: recovery.fingerprint, fence: fence() })
+    assert.equal(result.status, 'verified', JSON.stringify(result))
+    const journal = JSON.parse(await readFile(item.preview.plan.paths.journal, 'utf8'))
+    assert.equal(journal.phase, 'verified')
+  } finally {
+    await rm(item.home, { recursive: true, force: true })
+  }
+})
+
+test('authorized rollback restores the exact v0.1 config/state pair without deleting Git or backups', async () => {
+  const item = await fixture('rollback')
+  try {
+    await failBeforeConfigActivation(item)
+    const recovery = await previewV02UpgradeRecovery({ home: item.home })
+    assert.equal(recovery.status, 'recovery-previewed')
+    const result = await rollbackV02Upgrade({ plan: recovery.plan, fingerprint: recovery.fingerprint, fence: fence() })
+    assert.equal(result.status, 'rolled-back', JSON.stringify(result))
+    assert.equal(await readFile(item.preview.plan.paths.activeConfig, 'utf8'), item.config)
+    assert.equal(
+      await readFile(join(item.preview.plan.paths.activeState, 'o', 'r', 'issue-9', 'workflow.json'), 'utf8'),
+      '{"legacy":true}\n',
+    )
+    assert.equal(await readFile(item.preview.plan.paths.configBackup, 'utf8'), item.config)
+    assert.equal((await stat(item.root)).isDirectory(), true)
+    assert.equal(JSON.parse(await readFile(item.preview.plan.paths.journal, 'utf8')).phase, 'rolled_back')
+
+    const retry = await previewV02Upgrade({
+      home: item.home,
+      baselineSha: item.preview.plan.baselineSha,
+      now: '2026-08-27T17:10:00.000Z',
+      nonce: 'retry-after-rollback',
+      choices: { primaryRemotes: { 'o/r': 'origin' }, exclusions: {} },
+      hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
+    })
+    assert.equal(retry.status, 'previewed', JSON.stringify(retry))
+    assert.notEqual(retry.plan.expectedJournal, 'absent')
+    const reapplied = await applyV02Upgrade({ plan: retry.plan, fingerprint: retry.fingerprint, fence: fence() })
+    assert.equal(reapplied.status, 'verified', JSON.stringify(reapplied))
+  } finally {
+    await rm(item.home, { recursive: true, force: true })
+  }
+})
+
+test('resume handles failures both before state activation and during early prepare', async () => {
+  for (const [name, crashAt] of [
+    ['before-state', 'before-rename:STATE'],
+    ['early-prepare', 'before-publish:CONFIG_BACKUP'],
+  ] as const) {
+    const item = await fixture(name)
+    try {
+      const checkpoint = crashAt
+        .replace('STATE', `${item.preview.plan.paths.stagedState}->${item.preview.plan.paths.activeState}`)
+        .replace('CONFIG_BACKUP', item.preview.plan.paths.configBackup)
+      const failed = await applyV02Upgrade({
+        plan: item.preview.plan,
+        fingerprint: item.preview.fingerprint,
+        fence: fence(),
+        checkpoint(current) {
+          if (current === checkpoint) throw new Error(`injected ${name}`)
+        },
+      })
+      assert.equal(failed.status, 'failed')
+      const recovery = await previewV02UpgradeRecovery({ home: item.home })
+      assert.equal(recovery.status, 'recovery-previewed')
+      const resumed = await resumeV02Upgrade({ plan: recovery.plan, fingerprint: recovery.fingerprint, fence: fence() })
+      assert.equal(resumed.status, 'verified', JSON.stringify(resumed))
+    } finally {
+      await rm(item.home, { recursive: true, force: true })
+    }
+  }
+})
+
+test('rollback preserves an initially absent legacy state and rejects changed recovery evidence', async () => {
+  const item = await fixture('absent-rollback', false)
+  try {
+    const failed = await applyV02Upgrade({
+      plan: item.preview.plan,
+      fingerprint: item.preview.fingerprint,
+      fence: fence(),
+      checkpoint(current) {
+        if (
+          current === `before-rename:${item.preview.plan.paths.stagedConfig}->${item.preview.plan.paths.activeConfig}`
+        )
+          throw new Error('mixed absent state')
+      },
+    })
+    assert.equal(failed.status, 'failed')
+    const stale = await previewV02UpgradeRecovery({ home: item.home })
+    assert.equal(stale.status, 'recovery-previewed')
+    await writeFile(item.preview.plan.paths.journal, `${await readFile(item.preview.plan.paths.journal, 'utf8')} `)
+    const changed = await rollbackV02Upgrade({ plan: stale.plan, fingerprint: stale.fingerprint, fence: fence() })
+    assert.equal(changed.status, 'facts-changed')
+
+    const current = await previewV02UpgradeRecovery({ home: item.home })
+    assert.equal(current.status, 'recovery-previewed')
+    const rolledBack = await rollbackV02Upgrade({
+      plan: current.plan,
+      fingerprint: current.fingerprint,
+      fence: fence(),
+    })
+    assert.equal(rolledBack.status, 'rolled-back', JSON.stringify(rolledBack))
+    await assert.rejects(stat(item.preview.plan.paths.activeState), { code: 'ENOENT' })
+  } finally {
+    await rm(item.home, { recursive: true, force: true })
+  }
+})
+
+test('recovery fence acquisition failure releases the cross-process lock for an immediate retry', async () => {
+  const item = await fixture('fence-failure')
+  try {
+    await failBeforeConfigActivation(item)
+    const recovery = await previewV02UpgradeRecovery({ home: item.home })
+    assert.equal(recovery.status, 'recovery-previewed')
+    const unavailable: V02UpgradeGenerationFence = {
+      async acquire() {
+        throw new Error('generation fence unavailable')
+      },
+    }
+    const failed = await resumeV02Upgrade({
+      plan: recovery.plan,
+      fingerprint: recovery.fingerprint,
+      fence: unavailable,
+    })
+    assert.equal(failed.status, 'failed')
+    if (failed.status === 'failed') assert.match(failed.error, /generation fence unavailable/)
+    await assert.rejects(stat(item.preview.plan.paths.lock), { code: 'ENOENT' })
+    const retried = await resumeV02Upgrade({
+      plan: recovery.plan,
+      fingerprint: recovery.fingerprint,
+      fence: fence(),
+    })
+    assert.equal(retried.status, 'verified', JSON.stringify(retried))
+  } finally {
+    await rm(item.home, { recursive: true, force: true })
+  }
+})

--- a/tests/v02-upgrade-recovery.test.ts
+++ b/tests/v02-upgrade-recovery.test.ts
@@ -5,8 +5,13 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { promisify } from 'node:util'
 import test from 'node:test'
-import type { V02UpgradeGenerationFence } from '../src/infra/v02-upgrade-execution.ts'
 import { applyV02Upgrade } from '../src/infra/v02-upgrade-execution.ts'
+import {
+  createOfflineV02GenerationFence,
+  createOnlineV02GenerationFence,
+  resetV02GenerationFenceForTest,
+  V02_OFFLINE_HOST_DECLARATION,
+} from '../src/infra/v02-generation-fence.ts'
 import { previewV02UpgradeRecovery, resumeV02Upgrade, rollbackV02Upgrade } from '../src/infra/v02-upgrade-recovery.ts'
 import { previewV02Upgrade } from '../src/infra/v02-upgrade.ts'
 
@@ -43,15 +48,12 @@ async function fixture(name: string, statePresent = true) {
   return { home, root, config, preview }
 }
 
-function fence(): V02UpgradeGenerationFence {
-  return {
-    async acquire() {
-      return {
-        activity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
-        async release() {},
-      }
-    },
-  }
+function fence() {
+  resetV02GenerationFenceForTest()
+  return createOfflineV02GenerationFence({
+    declaration: V02_OFFLINE_HOST_DECLARATION,
+    enumerateOldPluginProcesses: async () => [],
+  })
 }
 
 async function failBeforeConfigActivation(item: Awaited<ReturnType<typeof fixture>>) {
@@ -304,24 +306,35 @@ test('rollback preserves an initially absent legacy state and rejects changed re
   }
 })
 
-test('recovery fence acquisition failure releases the cross-process lock for an immediate retry', async () => {
+test('online recovery refusal writes no lock and an offline retry succeeds immediately', async () => {
   const item = await fixture('fence-failure')
   try {
     await failBeforeConfigActivation(item)
     const recovery = await previewV02UpgradeRecovery({ home: item.home })
     assert.equal(recovery.status, 'recovery-previewed')
-    const unavailable: V02UpgradeGenerationFence = {
+    const unregistered = {
       async acquire() {
-        throw new Error('generation fence unavailable')
+        throw new Error('unregistered fence must never acquire')
       },
     }
-    const failed = await resumeV02Upgrade({
-      plan: recovery.plan,
-      fingerprint: recovery.fingerprint,
-      fence: unavailable,
-    })
-    assert.equal(failed.status, 'failed')
-    if (failed.status === 'failed') assert.match(failed.error, /generation fence unavailable/)
+    await assert.rejects(
+      resumeV02Upgrade({
+        plan: recovery.plan,
+        fingerprint: recovery.fingerprint,
+        fence: unregistered,
+      }),
+      /approved generation fence factory/i,
+    )
+    await assert.rejects(stat(item.preview.plan.paths.lock), { code: 'ENOENT' })
+    const unavailable = createOnlineV02GenerationFence()
+    await assert.rejects(
+      resumeV02Upgrade({
+        plan: recovery.plan,
+        fingerprint: recovery.fingerprint,
+        fence: unavailable,
+      }),
+      /online.*disabled.*host integration/i,
+    )
     await assert.rejects(stat(item.preview.plan.paths.lock), { code: 'ENOENT' })
     const retried = await resumeV02Upgrade({
       plan: recovery.plan,


### PR DESCRIPTION
## 这次做什么

完成 #134 的 Slice 2：把 v0.1 本地配置与状态升级为 v0.2 的显式 clean break 流程。

- `preview` 只盘点配置、状态、Git 仓库和 worktree，不写磁盘，并生成确定性的升级指纹
- `apply` 必须绑定刚才的 preview；执行时重新核对现场，任何漂移都拒绝升级
- 当前 Slice 2 只开放显式离线 fence：必须确认 DSH 宿主已停止且升级期间不会重启；在线 fence 在宿主 capability 真正接线前固定拒绝
- `apply` / `resume` / `rollback` 只接受批准 factory 产生的 fence，调用方自造或 no-op fence 在锁候选写入前拒绝
- 升级过程使用跨进程锁、持久化 journal、原配置精确备份和读回校验
- 中途崩溃后提供明确的 resume / rollback；损坏的 journal 只报告事实，不猜测恢复
- v0.2 运行时只接受 schema 1、已完成 marker、匹配的配置哈希和 repository identity
- legacy 状态写入在升级接管后 fail closed，避免新旧两代同时写同一份状态

## 安全边界

- 本 PR 不提供在线 apply：DSH 宿主关闭 legacy entry 的 capability 接线属于后续宿主集成；在其落地前在线 factory 始终失败关闭
- 离线 factory 的 host-stopped 声明覆盖无法从 argv 识别的 DSH 进程内插件；OS 进程枚举只是识别独立 legacy 二进制的第二信号
- 不自动修改 Git 仓库、分支、worktree 或用户代码
- 不静默迁移历史状态；这是已确认的 v0.2 clean break
- 配置、升级计划、journal、marker 与 state 都经过持久化写入和一致性校验
- 本 PR 的测试只使用临时目录和真实临时 Git 仓库，没有执行真实用户目录升级

## 设计与基线

- 实现基线：`553a926405919bd3efc677fbd9bf0388f7c6a26d`
- 不变量记录：`docs/plans/2026-08-27-v02-upgrade-slice-2-invariants.md`

## 验证

- `pnpm test`: 577/577
- `pnpm run coverage`
  - lines: 93.38%
  - branches: 85.44%
  - functions: 89.66%
- `pnpm run build`
- `pnpm run check`
- `git diff --check`

构建仍会显示仓库已有的 tsdown `external` / `noExternal` 弃用 WARNING，但所有门禁均通过。

Closes #134
