### PR TITLE
docs(v0.2): correct access-plane issue ownership

### DIFF
--- a/docs/baselines/v0.2-access-baseline.md
+++ b/docs/baselines/v0.2-access-baseline.md
@@ -6,6 +6,7 @@
 > Raw evidence: [v0.2-access-baseline-evidence-raw.jsonl](v0.2-access-baseline-evidence-raw.jsonl)
 > Curated summary: [v0.2-access-baseline-evidence.json](v0.2-access-baseline-evidence.json)
 > Reproducer: [`scripts/measure-access-baseline.mjs`](../../scripts/measure-access-baseline.mjs)
+> Ownership correction: #131 owns the GitHub REST Gateway and #135 owns the Remote Git Coordinator; measurements and frozen thresholds are unchanged.
 
 This baseline is inventory and measurement only. It does not implement Local Git Snapshot, Remote Git Coordinator or GitHub REST Gateway, and it does not change production cache, concurrency, refresh, invalidation or rate-limit behavior.
 
@@ -110,7 +111,7 @@ rg -n 'rest\.(json|paginate|mutate|cachedResource|cachedAggregate|invalidate)|gi
 | Merge (`src/workflow/merge.ts:369-388`) | merge action | `gh pr merge` write then forced PR detail/reviews read | Direct write; invalidates PR/repo then forced authoritative readback. | Fails closed if reread does not confirm MERGED. |
 | Issue close (`src/workflow/merge.ts:497-505`) | post-merge delivery | read state; direct `gh issue close`; invalidate; later workflow path rereads | Direct write outside reader. | Cleanup ledger preserves failure and allows retry. |
 
-The direct write bypasses are migration obligations for #135. Calling the current reader a complete “Gateway” would be dishonest.
+The direct write bypasses are migration obligations for #131. Calling the current reader a complete “Gateway” would be dishonest.
 
 ## Agent-owned access
 
@@ -202,6 +203,6 @@ node --test tests/access-baseline-script.test.ts
 Downstream obligations:
 
 - #122 owns the Local Git count reductions and deterministic invalidation on writes/task completion.
-- #131 owns Remote Git singleflight/serialization, post-write ref reread and repository isolation.
-- #135 owns all Controller GitHub call paths, including the six direct `gh` constructors, metrics/rate evidence, invalidation and write readback.
+- #131 owns all Controller GitHub call paths, including the six direct `gh` constructors, metrics/rate evidence, invalidation and write readback.
+- #135 owns Remote Git singleflight/serialization, post-write ref reread and repository isolation.
 - All three must report Controller and Agent-owned evidence separately and bind results to their implementation SHA plus this baseline version.


### PR DESCRIPTION
## Summary

- correct the frozen baseline ownership: #131 owns GitHub REST Gateway and #135 owns Remote Git Coordinator
- record the correction explicitly without changing measurements or frozen thresholds

## Verification

- `pnpm run typecheck`
- `pnpm run build`
- `pnpm test`: 579 passed
- `pnpm run coverage`: lines 93.35%, branches 85.51%, functions 89.58%
- lint, format, size, layers, style-token and state-write gates passed
- `git diff --check`
