### PR TITLE
refactor(derive): extract pure deriveWorkflowStateFromFacts (#122 slice A)

### DIFF
--- a/src/workflow/derive-from-facts.ts
+++ b/src/workflow/derive-from-facts.ts
@@ -1,0 +1,264 @@
+/**
+ * Pure derivation of one workflow's panel state from already-sampled facts
+ * (issue #122). Same inputs always produce the same output: no shell, fs,
+ * network, clock or process handles here. `deriveWorkflowState` samples local
+ * git and task ownership, then delegates; the Local Git Snapshot feeds the
+ * same WorktreeGitFacts without re-running git.
+ */
+
+import type { DeriveOptions } from '../infra/git.ts'
+import type { TaskOwnership } from '../infra/task-ownership.ts'
+import { type IssueContractSnapshot, type IssueWorkflow } from '../infra/state.ts'
+import { latestDevelopmentHash } from './delivery-audit.ts'
+import { deriveFreshSessionAvailability, type FreshSessionAvailability } from './fresh-session.ts'
+import {
+  deriveNextAction,
+  deriveReviewStartDecision,
+  deriveWorkflowStatus,
+  type IssueContractStatus,
+  type IssueContractUnknownReason,
+  type NextAction,
+  type ReviewStartDecision,
+  type WorkflowFacts,
+  type WorkflowStatus,
+  workflowBaseBranch,
+} from './state-view.ts'
+
+/** Worktree facts derived from git, GitHub and durable workflow events. */
+export interface WorkflowDerived {
+  taskRef: { kind: 'dev' | 'review'; taskId: string } | null
+  head: string | null
+  branch: string | null
+  mainHead: string | null
+  originMainHead: string | null
+  upstreamHead: string | null
+  aheadOfMain: number
+  behindMain: number
+  aheadOfBase: number
+  behindBase: number
+  aheadOfUpstream: number | null
+  behindUpstream: number | null
+  needsSync: boolean
+  mergeConflict: boolean
+  branchExists: boolean
+  worktreeExists: boolean
+  worktreeValid: boolean
+  hasUncommittedChanges: boolean
+  hasCommits: boolean
+  lastDevHash: string | null
+  lastReviewHash: string | null
+  reviewedHash: string | null
+  reviewedIssueBodyHash: string | null
+  currentIssueBodyHash: string | null
+  reviewedIssueUpdatedAt: string | null
+  currentIssueUpdatedAt: string | null
+  issueContractCurrent: boolean
+  issueContractStatus: IssueContractStatus
+  issueContractUnknownReason: IssueContractUnknownReason
+  hasNewCommits: boolean
+  verdictCurrent: boolean
+  nextAction: NextAction
+  reviewStart: ReviewStartDecision
+  status: WorkflowStatus
+  baseBranch: string
+  /** False when the frozen origin/<base> ref no longer exists after fetch. */
+  baseRefAvailable: boolean
+  freshSession: FreshSessionAvailability
+}
+
+/** One sampled observation of a worktree's local git state (absent refs = null). */
+export interface WorktreeGitFacts {
+  exists: boolean
+  head: string | null
+  branch: string | null
+  hasUncommittedChanges: boolean
+  mainHead: string | null
+  aheadOfMain: number
+  behindMain: number
+  originMainHead: string | null
+  aheadOfBase: number
+  behindBase: number
+  upstreamHead: string | null
+  aheadOfUpstream: number | null
+  behindUpstream: number | null
+  mergeConflict: boolean
+}
+
+/**
+ * Derive the authoritative state of a workflow from git facts + event history
+ * (issue #5). Pure: consumes a WorktreeGitFacts observation and a task
+ * ownership verdict instead of touching git or the live-task registry.
+ */
+export function deriveWorkflowStateFromFacts(
+  workflow: IssueWorkflow,
+  gitFacts: WorktreeGitFacts,
+  ownership: TaskOwnership,
+  options: DeriveOptions = {},
+): IssueWorkflow & { runStartedAt: number | null; derived: WorkflowDerived } {
+  const {
+    exists,
+    head,
+    branch,
+    hasUncommittedChanges,
+    mainHead,
+    aheadOfMain,
+    behindMain,
+    originMainHead,
+    aheadOfBase,
+    behindBase,
+    upstreamHead,
+    aheadOfUpstream,
+    behindUpstream,
+    mergeConflict,
+  } = gitFacts
+  const workflowPrNumber = workflow.prNumber == null ? null : String(workflow.prNumber)
+  const baseBranch = workflowBaseBranch(workflow.baseRef, options.defaultBranch ?? 'main')
+  const events = workflow.events ?? []
+  const lastDevHash = latestDevelopmentHash(events) ?? null
+  let lastReviewHash: string | null = null
+  let lastReviewContract: IssueContractSnapshot | null = null
+  let lastReviewBase: { ref: string; sha: string } | null = null
+  for (const ev of events) {
+    if (ev.kind === 'review') {
+      lastReviewHash = ev.hash ?? lastReviewHash
+      lastReviewContract = ev.issueContract ?? null
+      lastReviewBase = ev.reviewBase ?? null
+    }
+  }
+
+  // 有新提交 = worktree HEAD 不等于最近一次 dev/rework/resume 交付哈希
+  const hasNewCommits = head !== null && lastDevHash !== null && head !== lastDevHash
+  // worktree 落后其冻结的远端基线或远端同名分支 → 需要同步。
+  const needsSync = behindBase > 0 || (behindUpstream ?? 0) > 0
+  const githubReviewPassed =
+    options.pr?.reviewDecision === 'APPROVED' ? true : options.pr?.reviewDecision === 'CHANGES_REQUESTED' ? false : null
+  const reviewPassed = workflow.reviewResult?.passed ?? githubReviewPassed
+  const reviewedHash = lastReviewHash ?? (githubReviewPassed !== null ? head : null)
+  const currentIssueContract = options.issueContract ?? null
+  // updatedAt 是审计证据；正文 hash 才是契约身份，避免评论/标签更新误杀结论。
+  const issueContractStatus: IssueContractStatus =
+    lastReviewContract === null
+      ? 'unknown'
+      : currentIssueContract === null
+        ? 'unknown'
+        : lastReviewContract.bodyHash === currentIssueContract.bodyHash
+          ? 'current'
+          : 'changed'
+  const issueContractUnknownReason: IssueContractUnknownReason =
+    issueContractStatus !== 'unknown'
+      ? null
+      : lastReviewContract === null
+        ? 'missing-review-snapshot'
+        : 'current-contract-unavailable'
+  const issueContractCurrent = issueContractStatus === 'current'
+  // 结论同时绑定当前 HEAD 与验收契约；旧事件缺契约快照时 fail closed。
+  const verdictCurrent =
+    reviewPassed !== null &&
+    head !== null &&
+    reviewedHash !== null &&
+    head === reviewedHash &&
+    issueContractCurrent &&
+    (!options.pr?.baseRefName ||
+      !options.pr?.baseRefOid ||
+      (lastReviewBase?.ref === options.pr.baseRefName && lastReviewBase.sha === options.pr.baseRefOid))
+
+  const taskRunning = ownership.state === 'running'
+  const taskKind = ownership.state === 'running' ? ownership.kind : null
+  const taskInterrupted =
+    ownership.state === 'interrupted' || (workflow.stage === 'developing' && workflow.devInterrupted)
+  const taskUnknown = !taskInterrupted && ownership.state === 'unknown'
+
+  const branchExists = options.branchExists ?? branch !== null
+  const worktreeValid = !exists || branch === workflow.branch
+  const hasCommits = options.hasCommits ?? aheadOfBase > 0
+  const facts: WorkflowFacts = {
+    issueOpen: (workflow.issueState ?? 'OPEN') !== 'CLOSED',
+    prMerged:
+      workflow.delivery !== undefined ||
+      options.pr?.state === 'MERGED' ||
+      (options.pr?.mergedAt !== null && options.pr?.mergedAt !== undefined),
+    cleanupPending: workflow.delivery !== undefined && workflow.delivery.status !== 'archived',
+    prState: options.pr?.state ?? null,
+    prStatusKnown: options.prStatusKnown,
+    prNumber: options.pr?.number ?? workflowPrNumber,
+    stage: workflow.stage,
+    devInterrupted: workflow.devInterrupted,
+    taskRunning,
+    taskKind,
+    taskUnknown,
+    taskInterrupted,
+    head,
+    reviewedHash,
+    reviewPassed,
+    issueContractStatus,
+    issueContractUnknownReason,
+    hasNewCommits,
+    needsSync,
+    mergeConflict,
+    branchExists,
+    worktreeExists: exists,
+    worktreeValid,
+    hasUncommittedChanges,
+    hasCommits,
+    hasResumeSession: workflow.devSessionId !== null,
+    baseBranch,
+    baseRefAvailable: originMainHead !== null,
+    workflowCachePresent: options.workflowCachePresent,
+    // The live PR head is the newest GitHub delivery fact. During completion
+    // persistence it can legitimately advance before the local event cache.
+    deliveryHash: options.pr?.headRefOid ?? lastDevHash,
+  }
+  const reviewStart = deriveReviewStartDecision(facts)
+  const nextAction = deriveNextAction(facts)
+  const status = deriveWorkflowStatus(facts)
+  const freshSession = deriveFreshSessionAvailability(
+    events,
+    workflow.devSessionId !== null && workflow.devSessionAgent === workflow.devAgent,
+    workflow.reviewSessionId !== null && workflow.reviewSessionAgent === workflow.reviewAgent,
+  )
+
+  return {
+    ...workflow,
+    prNumber: options.pr?.number ?? workflowPrNumber,
+    runStartedAt: ownership.state === 'running' ? ownership.startedAt : null,
+    derived: {
+      taskRef: ownership.state === 'none' ? null : { kind: ownership.kind, taskId: ownership.taskId },
+      head,
+      branch,
+      mainHead,
+      originMainHead,
+      upstreamHead,
+      aheadOfMain,
+      behindMain,
+      aheadOfBase,
+      behindBase,
+      aheadOfUpstream,
+      behindUpstream,
+      needsSync,
+      mergeConflict,
+      branchExists,
+      worktreeExists: exists,
+      worktreeValid,
+      hasUncommittedChanges,
+      hasCommits,
+      lastDevHash,
+      lastReviewHash,
+      reviewedHash,
+      reviewedIssueBodyHash: lastReviewContract?.bodyHash ?? null,
+      currentIssueBodyHash: currentIssueContract?.bodyHash ?? null,
+      reviewedIssueUpdatedAt: lastReviewContract?.updatedAt ?? null,
+      currentIssueUpdatedAt: currentIssueContract?.updatedAt ?? null,
+      issueContractCurrent,
+      issueContractStatus,
+      issueContractUnknownReason,
+      hasNewCommits,
+      verdictCurrent,
+      reviewStart,
+      nextAction,
+      status,
+      baseBranch,
+      baseRefAvailable: originMainHead !== null,
+      freshSession,
+    },
+  }
+}

--- a/src/workflow/derive.ts
+++ b/src/workflow/derive.ts
@@ -23,96 +23,30 @@ import type { Context } from '@deepseek-ai/cordis'
 import { frozenBaseHash } from '../agent/baseline.ts'
 import { type DeriveOptions, hasMergeConflict, readBranch, readRefShort, readRevCount } from '../infra/git.ts'
 import { liveTasks, readWorktreeHead, runCommand } from '../infra/runtime.ts'
-import { type IssueContractSnapshot, type IssueWorkflow } from '../infra/state.ts'
+import type { IssueWorkflow } from '../infra/state.ts'
 import { observeTaskOwnership, type TaskOwnershipContext } from '../infra/task-ownership.ts'
-import { latestDevelopmentHash } from './delivery-audit.ts'
-import { deriveFreshSessionAvailability, type FreshSessionAvailability } from './fresh-session.ts'
-import {
-  deriveNextAction,
-  deriveReviewStartDecision,
-  deriveWorkflowStatus,
-  type IssueContractStatus,
-  type IssueContractUnknownReason,
-  type NextAction,
-  type ReviewStartDecision,
-  type WorkflowFacts,
-  type WorkflowStatus,
-  workflowBaseBranch,
-} from './state-view.ts'
+import { deriveWorkflowStateFromFacts, type WorkflowDerived } from './derive-from-facts.ts'
+import { workflowBaseBranch } from './state-view.ts'
 
-/** Worktree facts derived from git, GitHub and durable workflow events. */
-export interface WorkflowDerived {
-  taskRef: { kind: 'dev' | 'review'; taskId: string } | null
-  head: string | null
-  branch: string | null
-  mainHead: string | null
-  originMainHead: string | null
-  upstreamHead: string | null
-  aheadOfMain: number
-  behindMain: number
-  aheadOfBase: number
-  behindBase: number
-  aheadOfUpstream: number | null
-  behindUpstream: number | null
-  needsSync: boolean
-  mergeConflict: boolean
-  branchExists: boolean
-  worktreeExists: boolean
-  worktreeValid: boolean
-  hasUncommittedChanges: boolean
-  hasCommits: boolean
-  lastDevHash: string | null
-  lastReviewHash: string | null
-  reviewedHash: string | null
-  reviewedIssueBodyHash: string | null
-  currentIssueBodyHash: string | null
-  reviewedIssueUpdatedAt: string | null
-  currentIssueUpdatedAt: string | null
-  issueContractCurrent: boolean
-  issueContractStatus: IssueContractStatus
-  issueContractUnknownReason: IssueContractUnknownReason
-  hasNewCommits: boolean
-  verdictCurrent: boolean
-  nextAction: NextAction
-  reviewStart: ReviewStartDecision
-  status: WorkflowStatus
-  baseBranch: string
-  /** False when the frozen origin/<base> ref no longer exists after fetch. */
-  baseRefAvailable: boolean
-  freshSession: FreshSessionAvailability
-}
+export type { WorkflowDerived } from './derive-from-facts.ts'
 
 /**
  * Derive the authoritative state of a workflow from git facts + event history
- * (issue #5). Runs on every /state request so the panel never needs a
- * restart/refresh to see current status; the stored `stage`/`reviewResult`
- * stay as-is, and `derived` carries the three-way comparison (worktree /
- * main / remote), the review-verdict HEAD binding and the single next action.
+ * (issue #5). Exported for integration tests; /state calls it on every request.
+ * This is the I/O half (issue #122): sample local git and task ownership, then
+ * delegate to the pure deriveWorkflowStateFromFacts. The Local Git Snapshot
+ * will feed the same WorktreeGitFacts without re-running these commands within
+ * one refresh generation.
  */
-/** Derive the authoritative state of a workflow from git facts + event history.
- *  Exported for integration tests; /state calls it on every request. */
 export async function deriveWorkflowState(
   ctx: Context,
   workflow: IssueWorkflow,
   options: DeriveOptions = {},
 ): Promise<IssueWorkflow & { runStartedAt: number | null; derived: WorkflowDerived }> {
-  const workflowPrNumber = workflow.prNumber == null ? null : String(workflow.prNumber)
   const baseBranch = workflowBaseBranch(workflow.baseRef, options.defaultBranch ?? 'main')
   const remoteBaseRef = `origin/${baseBranch}`
   const worktree = workflow.worktree
   const exists = existsSync(worktree)
-  const events = workflow.events ?? []
-  const lastDevHash = latestDevelopmentHash(events) ?? null
-  let lastReviewHash: string | null = null
-  let lastReviewContract: IssueContractSnapshot | null = null
-  let lastReviewBase: { ref: string; sha: string } | null = null
-  for (const ev of events) {
-    if (ev.kind === 'review') {
-      lastReviewHash = ev.hash ?? lastReviewHash
-      lastReviewContract = ev.issueContract ?? null
-      lastReviewBase = ev.reviewBase ?? null
-    }
-  }
 
   const head = exists ? await readWorktreeHead(ctx, worktree) : null
   const branch = exists ? await readBranch(ctx, worktree) : null
@@ -166,43 +100,7 @@ export async function deriveWorkflowState(
     }
   }
 
-  // 有新提交 = worktree HEAD 不等于最近一次 dev/rework/resume 交付哈希
-  const hasNewCommits = head !== null && lastDevHash !== null && head !== lastDevHash
-  // worktree 落后其冻结的远端基线或远端同名分支 → 需要同步。
-  const needsSync = behindBase > 0 || (behindUpstream ?? 0) > 0
-  // 未完成的冲突合并(MERGE_HEAD 存在):sync 只会再次失败,必须由 agent 收拾(issue #26)
   const mergeConflict = exists && (await hasMergeConflict(ctx, worktree))
-  const githubReviewPassed =
-    options.pr?.reviewDecision === 'APPROVED' ? true : options.pr?.reviewDecision === 'CHANGES_REQUESTED' ? false : null
-  const reviewPassed = workflow.reviewResult?.passed ?? githubReviewPassed
-  const reviewedHash = lastReviewHash ?? (githubReviewPassed !== null ? head : null)
-  const currentIssueContract = options.issueContract ?? null
-  // updatedAt 是审计证据；正文 hash 才是契约身份，避免评论/标签更新误杀结论。
-  const issueContractStatus: IssueContractStatus =
-    lastReviewContract === null
-      ? 'unknown'
-      : currentIssueContract === null
-        ? 'unknown'
-        : lastReviewContract.bodyHash === currentIssueContract.bodyHash
-          ? 'current'
-          : 'changed'
-  const issueContractUnknownReason: IssueContractUnknownReason =
-    issueContractStatus !== 'unknown'
-      ? null
-      : lastReviewContract === null
-        ? 'missing-review-snapshot'
-        : 'current-contract-unavailable'
-  const issueContractCurrent = issueContractStatus === 'current'
-  // 结论同时绑定当前 HEAD 与验收契约；旧事件缺契约快照时 fail closed。
-  const verdictCurrent =
-    reviewPassed !== null &&
-    head !== null &&
-    reviewedHash !== null &&
-    head === reviewedHash &&
-    issueContractCurrent &&
-    (!options.pr?.baseRefName ||
-      !options.pr?.baseRefOid ||
-      (lastReviewBase?.ref === options.pr.baseRefName && lastReviewBase.sha === options.pr.baseRefOid))
 
   const ownership = observeTaskOwnership(
     ctx as unknown as TaskOwnershipContext,
@@ -213,103 +111,26 @@ export async function deriveWorkflowState(
     },
     (taskId) => liveTasks.get(taskId)?.startedAt ?? null,
   )
-  const taskRunning = ownership.state === 'running'
-  const taskKind = ownership.state === 'running' ? ownership.kind : null
-  const taskInterrupted =
-    ownership.state === 'interrupted' || (workflow.stage === 'developing' && workflow.devInterrupted)
-  const taskUnknown = !taskInterrupted && ownership.state === 'unknown'
 
-  const branchExists = options.branchExists ?? branch !== null
-  const worktreeValid = !exists || branch === workflow.branch
-  const hasCommits = options.hasCommits ?? aheadOfBase > 0
-  const facts: WorkflowFacts = {
-    issueOpen: (workflow.issueState ?? 'OPEN') !== 'CLOSED',
-    prMerged:
-      workflow.delivery !== undefined ||
-      options.pr?.state === 'MERGED' ||
-      (options.pr?.mergedAt !== null && options.pr?.mergedAt !== undefined),
-    cleanupPending: workflow.delivery !== undefined && workflow.delivery.status !== 'archived',
-    prState: options.pr?.state ?? null,
-    prStatusKnown: options.prStatusKnown,
-    prNumber: options.pr?.number ?? workflowPrNumber,
-    stage: workflow.stage,
-    devInterrupted: workflow.devInterrupted,
-    taskRunning,
-    taskKind,
-    taskUnknown,
-    taskInterrupted,
-    head,
-    reviewedHash,
-    reviewPassed,
-    issueContractStatus,
-    issueContractUnknownReason,
-    hasNewCommits,
-    needsSync,
-    mergeConflict,
-    branchExists,
-    worktreeExists: exists,
-    worktreeValid,
-    hasUncommittedChanges,
-    hasCommits,
-    hasResumeSession: workflow.devSessionId !== null,
-    baseBranch,
-    baseRefAvailable: originMainHead !== null,
-    workflowCachePresent: options.workflowCachePresent,
-    // The live PR head is the newest GitHub delivery fact. During completion
-    // persistence it can legitimately advance before the local event cache.
-    deliveryHash: options.pr?.headRefOid ?? lastDevHash,
-  }
-  const reviewStart = deriveReviewStartDecision(facts)
-  const nextAction = deriveNextAction(facts)
-  const status = deriveWorkflowStatus(facts)
-  const freshSession = deriveFreshSessionAvailability(
-    events,
-    workflow.devSessionId !== null && workflow.devSessionAgent === workflow.devAgent,
-    workflow.reviewSessionId !== null && workflow.reviewSessionAgent === workflow.reviewAgent,
-  )
-
-  return {
-    ...workflow,
-    prNumber: options.pr?.number ?? workflowPrNumber,
-    runStartedAt: ownership.state === 'running' ? ownership.startedAt : null,
-    derived: {
-      taskRef: ownership.state === 'none' ? null : { kind: ownership.kind, taskId: ownership.taskId },
+  return deriveWorkflowStateFromFacts(
+    workflow,
+    {
+      exists,
       head,
       branch,
+      hasUncommittedChanges,
       mainHead,
-      originMainHead,
-      upstreamHead,
       aheadOfMain,
       behindMain,
+      originMainHead,
       aheadOfBase,
       behindBase,
+      upstreamHead,
       aheadOfUpstream,
       behindUpstream,
-      needsSync,
       mergeConflict,
-      branchExists,
-      worktreeExists: exists,
-      worktreeValid,
-      hasUncommittedChanges,
-      hasCommits,
-      lastDevHash,
-      lastReviewHash,
-      reviewedHash,
-      reviewedIssueBodyHash: lastReviewContract?.bodyHash ?? null,
-      currentIssueBodyHash: currentIssueContract?.bodyHash ?? null,
-      reviewedIssueUpdatedAt: lastReviewContract?.updatedAt ?? null,
-      currentIssueUpdatedAt: currentIssueContract?.updatedAt ?? null,
-      issueContractCurrent,
-      issueContractStatus,
-      issueContractUnknownReason,
-      hasNewCommits,
-      verdictCurrent,
-      reviewStart,
-      nextAction,
-      status,
-      baseBranch,
-      baseRefAvailable: originMainHead !== null,
-      freshSession,
     },
-  }
+    ownership,
+    options,
+  )
 }

--- a/tests/derive-from-facts.test.ts
+++ b/tests/derive-from-facts.test.ts
@@ -1,0 +1,304 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import type { Context } from '@deepseek-ai/cordis'
+import type { TaskOwnership } from '../src/infra/task-ownership.ts'
+import type { IssueWorkflow, WorkflowEvent } from '../src/infra/state.ts'
+import { deriveWorkflowState } from '../src/workflow/derive.ts'
+import { deriveWorkflowStateFromFacts, type WorktreeGitFacts } from '../src/workflow/derive-from-facts.ts'
+
+function makeWorkflow(overrides: Partial<IssueWorkflow> = {}): IssueWorkflow {
+  return {
+    key: 'ai-daming/clickvibe#122',
+    url: 'https://github.com/ai-daming/clickvibe/issues/122',
+    repoKey: 'ai-daming/clickvibe',
+    worktree: '/tmp/clickvibe-issue-122',
+    branch: 'clickvibe-issue-122',
+    stage: 'review-ready',
+    devAgent: 'codex',
+    devTaskId: null,
+    devSessionId: null,
+    devSessionAgent: null,
+    devInterrupted: false,
+    reviewAgent: null,
+    reviewTaskId: null,
+    reviewSessionId: null,
+    reviewSessionAgent: null,
+    reviewResult: null,
+    prNumber: null,
+    issueState: 'OPEN',
+    baseRef: 'main',
+    updatedAt: 0,
+    events: [],
+    ...overrides,
+  }
+}
+
+/** One sampled local-git observation set for an existing, clean, in-sync worktree. */
+function makeFacts(overrides: Partial<WorktreeGitFacts> = {}): WorktreeGitFacts {
+  return {
+    exists: true,
+    head: 'abc1234',
+    branch: 'clickvibe-issue-122',
+    hasUncommittedChanges: false,
+    mainHead: 'aaa0000',
+    aheadOfMain: 1,
+    behindMain: 0,
+    originMainHead: 'bbb0000',
+    aheadOfBase: 2,
+    behindBase: 0,
+    upstreamHead: 'abc1234',
+    aheadOfUpstream: 0,
+    behindUpstream: 0,
+    mergeConflict: false,
+    ...overrides,
+  }
+}
+
+const NONE_OWNERSHIP: TaskOwnership = { state: 'none', startedAt: null, source: 'not-in-flight' }
+
+function reviewEvent(overrides: Partial<WorkflowEvent> = {}): WorkflowEvent {
+  return { kind: 'review', at: '2026-08-29T00:00:00.000Z', ...overrides }
+}
+
+test('sampled git facts pass through into derived fields unchanged', () => {
+  const workflow = makeWorkflow()
+  const result = deriveWorkflowStateFromFacts(workflow, makeFacts(), NONE_OWNERSHIP)
+
+  assert.equal(result.key, workflow.key)
+  assert.equal(result.stage, workflow.stage)
+  assert.equal(result.runStartedAt, null)
+  assert.equal(result.derived.head, 'abc1234')
+  assert.equal(result.derived.branch, 'clickvibe-issue-122')
+  assert.equal(result.derived.mainHead, 'aaa0000')
+  assert.equal(result.derived.originMainHead, 'bbb0000')
+  assert.equal(result.derived.upstreamHead, 'abc1234')
+  assert.equal(result.derived.aheadOfMain, 1)
+  assert.equal(result.derived.aheadOfBase, 2)
+  assert.equal(result.derived.mergeConflict, false)
+  assert.equal(result.derived.hasUncommittedChanges, false)
+  assert.equal(result.derived.worktreeExists, true)
+  assert.equal(result.derived.worktreeValid, true)
+  assert.equal(result.derived.needsSync, false)
+  assert.equal(result.derived.baseRefAvailable, true)
+  assert.equal(result.derived.hasCommits, true)
+  assert.equal(result.derived.hasNewCommits, false)
+})
+
+test('behind the frozen origin base means needsSync', () => {
+  const result = deriveWorkflowStateFromFacts(makeWorkflow(), makeFacts({ behindBase: 3 }), NONE_OWNERSHIP)
+  assert.equal(result.derived.needsSync, true)
+})
+
+test('behind the remote upstream branch means needsSync', () => {
+  const result = deriveWorkflowStateFromFacts(makeWorkflow(), makeFacts({ behindUpstream: 2 }), NONE_OWNERSHIP)
+  assert.equal(result.derived.needsSync, true)
+})
+
+test('missing origin/<base> ref falls back to frozen base counts and marks baseRefAvailable false', () => {
+  const result = deriveWorkflowStateFromFacts(
+    makeWorkflow(),
+    makeFacts({ originMainHead: null, aheadOfBase: 0, behindBase: 4 }),
+    NONE_OWNERSHIP,
+  )
+  assert.equal(result.derived.baseRefAvailable, false)
+  assert.equal(result.derived.needsSync, true)
+})
+
+test('worktree on a foreign branch is invalid; missing worktree keeps branch decision', () => {
+  const foreign = deriveWorkflowStateFromFacts(
+    makeWorkflow(),
+    makeFacts({ branch: 'some-other-branch' }),
+    NONE_OWNERSHIP,
+  )
+  assert.equal(foreign.derived.worktreeValid, false)
+
+  const missing = deriveWorkflowStateFromFacts(
+    makeWorkflow(),
+    makeFacts({
+      exists: false,
+      head: null,
+      branch: null,
+      hasUncommittedChanges: false,
+      mainHead: null,
+      aheadOfMain: 0,
+      behindMain: 0,
+      originMainHead: null,
+      aheadOfBase: 0,
+      behindBase: 0,
+      upstreamHead: null,
+      aheadOfUpstream: null,
+      behindUpstream: null,
+    }),
+    NONE_OWNERSHIP,
+  )
+  assert.equal(missing.derived.worktreeExists, false)
+  assert.equal(missing.derived.worktreeValid, true)
+  assert.equal(missing.derived.head, null)
+  assert.equal(missing.derived.baseRefAvailable, false)
+})
+
+test('hasNewCommits compares HEAD against the latest development delivery hash', () => {
+  const moved = deriveWorkflowStateFromFacts(
+    makeWorkflow({ events: [{ kind: 'dev', at: '2026-08-29T00:00:00.000Z', hash: 'deadbee' }] }),
+    makeFacts(),
+    NONE_OWNERSHIP,
+  )
+  assert.equal(moved.derived.hasNewCommits, true)
+  assert.equal(moved.derived.lastDevHash, 'deadbee')
+
+  const anchored = deriveWorkflowStateFromFacts(
+    makeWorkflow({ events: [{ kind: 'dev', at: '2026-08-29T00:00:00.000Z', hash: 'abc1234' }] }),
+    makeFacts(),
+    NONE_OWNERSHIP,
+  )
+  assert.equal(anchored.derived.hasNewCommits, false)
+})
+
+test('a missing worktree cannot produce hasNewCommits even with a delivery hash', () => {
+  const result = deriveWorkflowStateFromFacts(
+    makeWorkflow({ events: [{ kind: 'dev', at: '2026-08-29T00:00:00.000Z', hash: 'deadbee' }] }),
+    makeFacts({ exists: false, head: null, branch: null }),
+    NONE_OWNERSHIP,
+  )
+  assert.equal(result.derived.hasNewCommits, false)
+})
+
+function verdictFixture(): { workflow: IssueWorkflow; contract: { bodyHash: string; updatedAt: string } } {
+  const contract = { bodyHash: 'contract-hash-1', updatedAt: '2026-08-28T00:00:00.000Z' }
+  const workflow = makeWorkflow({
+    reviewResult: { passed: true, issues: [] },
+    events: [reviewEvent({ hash: 'abc1234', issueContract: contract })],
+  })
+  return { workflow, contract }
+}
+
+test('verdict bound to current HEAD and current contract is current', () => {
+  const { workflow, contract } = verdictFixture()
+  const result = deriveWorkflowStateFromFacts(workflow, makeFacts(), NONE_OWNERSHIP, {
+    issueContract: contract,
+  })
+  assert.equal(result.derived.issueContractStatus, 'current')
+  assert.equal(result.derived.issueContractCurrent, true)
+  assert.equal(result.derived.issueContractUnknownReason, null)
+  assert.equal(result.derived.verdictCurrent, true)
+  assert.equal(result.derived.reviewedHash, 'abc1234')
+  assert.equal(result.derived.reviewedIssueBodyHash, 'contract-hash-1')
+})
+
+test('changed issue contract fail-closes the verdict', () => {
+  const { workflow } = verdictFixture()
+  const result = deriveWorkflowStateFromFacts(workflow, makeFacts(), NONE_OWNERSHIP, {
+    issueContract: { bodyHash: 'contract-hash-2', updatedAt: '2026-08-29T00:00:00.000Z' },
+  })
+  assert.equal(result.derived.issueContractStatus, 'changed')
+  assert.equal(result.derived.verdictCurrent, false)
+})
+
+test('review without a frozen contract snapshot is unknown with the missing-snapshot reason', () => {
+  const result = deriveWorkflowStateFromFacts(makeWorkflow(), makeFacts(), NONE_OWNERSHIP)
+  assert.equal(result.derived.issueContractStatus, 'unknown')
+  assert.equal(result.derived.issueContractUnknownReason, 'missing-review-snapshot')
+})
+
+test('verdict on a moved HEAD is stale even with a current contract', () => {
+  const { workflow, contract } = verdictFixture()
+  const result = deriveWorkflowStateFromFacts(
+    workflow,
+    makeFacts({ head: 'ffffff', upstreamHead: 'ffffff' }),
+    NONE_OWNERSHIP,
+    { issueContract: contract },
+  )
+  assert.equal(result.derived.verdictCurrent, false)
+})
+
+test('running ownership surfaces runStartedAt and the task ref', () => {
+  const ownership: TaskOwnership = {
+    state: 'running',
+    startedAt: 4200,
+    source: 'local-map',
+    kind: 'dev',
+    taskId: 'task-1',
+  }
+  const result = deriveWorkflowStateFromFacts(
+    makeWorkflow({ stage: 'developing', devTaskId: 'task-1' }),
+    makeFacts(),
+    ownership,
+  )
+  assert.equal(result.runStartedAt, 4200)
+  assert.deepEqual(result.derived.taskRef, { kind: 'dev', taskId: 'task-1' })
+})
+
+test('interrupted ownership yields no runStartedAt', () => {
+  const ownership: TaskOwnership = {
+    state: 'interrupted',
+    startedAt: 4200,
+    source: 'host-terminal',
+    kind: 'dev',
+    taskId: 'task-1',
+  }
+  const result = deriveWorkflowStateFromFacts(
+    makeWorkflow({ stage: 'developing', devTaskId: 'task-1' }),
+    makeFacts(),
+    ownership,
+  )
+  assert.equal(result.runStartedAt, null)
+  assert.deepEqual(result.derived.taskRef, { kind: 'dev', taskId: 'task-1' })
+})
+
+test('missing events history behaves like an empty one', () => {
+  const workflow = makeWorkflow()
+  delete (workflow as Partial<IssueWorkflow>).events
+  const result = deriveWorkflowStateFromFacts(workflow, makeFacts(), NONE_OWNERSHIP)
+  assert.equal(result.derived.lastDevHash, null)
+  assert.deepEqual(result.derived.freshSession, { round: 1, develop: false, review: false })
+})
+
+test('options.pr number overrides the stored workflow pr number in the envelope', () => {
+  const result = deriveWorkflowStateFromFacts(makeWorkflow({ prNumber: null }), makeFacts(), NONE_OWNERSHIP, {
+    pr: { number: 55, state: 'OPEN' } as NonNullable<Parameters<typeof deriveWorkflowStateFromFacts>[3]>['pr'],
+  })
+  assert.equal(result.prNumber, 55)
+})
+
+test('deriveWorkflowState with a canned shell matches deriveWorkflowStateFromFacts on identical facts', async () => {
+  const outputs = new Map<string, { exitCode: number; stdout: string }>([
+    ['git rev-parse --short HEAD', { exitCode: 0, stdout: 'abc1234\n' }],
+    ['git branch --show-current', { exitCode: 0, stdout: 'clickvibe-issue-122\n' }],
+    ['git status --porcelain', { exitCode: 0, stdout: '' }],
+    ["git rev-parse --short 'main'", { exitCode: 0, stdout: 'aaa0000\n' }],
+    ["git rev-list --left-right --count 'main'...'HEAD'", { exitCode: 0, stdout: '0 1\n' }],
+    ["git rev-parse --short 'origin/main'", { exitCode: 0, stdout: 'bbb0000\n' }],
+    ["git rev-list --left-right --count 'origin/main'...'HEAD'", { exitCode: 0, stdout: '0 2\n' }],
+    ["git rev-parse --short 'origin/clickvibe-issue-122'", { exitCode: 0, stdout: 'abc1234\n' }],
+    ["git rev-list --left-right --count 'origin/clickvibe-issue-122'...'HEAD'", { exitCode: 0, stdout: '0 0\n' }],
+    ["git rev-parse --short 'MERGE_HEAD'", { exitCode: 1, stdout: '' }],
+  ])
+  const commands: string[] = []
+  const ctx = {
+    shell: {
+      resolve: (spec: { command: string }) => spec,
+      run: async (spec: { command: string }) => {
+        commands.push(spec.command)
+        const canned = outputs.get(spec.command)
+        if (!canned) throw new Error(`unexpected shell command: ${spec.command}`)
+        return { exitCode: canned.exitCode, stdout: { text: canned.stdout }, stderr: { text: '' } }
+      },
+    },
+  } as unknown as Context
+
+  // The wrapper probes the real filesystem first; an existing plain directory
+  // (no git) exercises the full sampling path against the canned shell.
+  const worktree = mkdtempSync(join(tmpdir(), 'clickvibe-derive-facts-'))
+  try {
+    const viaShell = await deriveWorkflowState(ctx, makeWorkflow({ worktree }))
+    const viaFacts = deriveWorkflowStateFromFacts(makeWorkflow({ worktree }), makeFacts(), NONE_OWNERSHIP)
+
+    assert.deepEqual(viaShell, viaFacts)
+    assert.deepEqual(commands.sort(), [...outputs.keys()].sort(), 'sampler must issue exactly the canned command set')
+  } finally {
+    rmSync(worktree, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
Closes toward #122. Baseline: Coding/Architecture \`dc7be34\`（决策台账见 issue 评论）。

## 本切片范围（台账·切片 A「derive 纯化」）

把「给定 git 事实 → 推导状态」抽成纯函数 `deriveWorkflowStateFromFacts`（`src/workflow/derive-from-facts.ts`），`deriveWorkflowState` 保持签名不变、退化为 I/O 薄壳：本地 git 采样（`WorktreeGitFacts`）+ 任务所有权判定，然后委托纯函数。**零行为变化**——这是切片 B（Local Git Snapshot 注入）的铺路：快照将以同一条 `WorktreeGitFacts` 供给同一输出。

## TDD 证据

- 先写失败测试（red）：`tests/derive-from-facts.test.ts` 16 例，覆盖 needsSync/冻结基线回退（`baseRefAvailable`）/worktree 有效性/`hasNewCommits` 绑定/契约与 verdict 绑定/所有权透传。
- 等价测试：canned shell 驱动 `deriveWorkflowState`，与相同事实下的纯函数输出 **deepEqual 全等**，并钉死采样命令集（10 条）——切片 B 的 compound 采样器必须复现同一事实集。
- 现有 `state-view-integration` / `sync-conflict` / `task-ref-state` 断言零修改全绿。

## 门禁（全绿）

- typecheck ✓ build ✓ test 595/595 ✓
- coverage：lines 93.44% / branches 85.70% / functions 89.59%（≥85）✓
- lint ✓ format ✓ check:size ✓ check:layers ✓ check:style-tokens ✓ check:state-writes ✓

## 不在本切片

快照注册表、compound 采样、失效触发点与 `check:local-git-writes` 门禁（切片 B）；repo-scope 迁移、observation/未知渲染、冻结场景复测（切片 C）。错误路径 `.catch(() => false)` 行为在本切片保持原样（零变化约束），按台账在切片 B/C 修正。