### PR TITLE
refactor(remote-git): remote fetch/push entry points (#135 slice A)

### DIFF
--- a/scripts/check-local-git-writes.mjs
+++ b/scripts/check-local-git-writes.mjs
@@ -37,6 +37,8 @@ export const ALLOWLIST = new Map(
     'src/agent/develop.ts': 'command construction only; executed via ensureWorktree which invalidates',
     'src/agent/prompts.ts':
       'prompt text only: instructs the Agent (Agent-owned calls), Controller executes nothing here',
+    'src/infra/remote-git.ts':
+      'low-level remote adapter (issue #135 slice A); call-site invalidation today, Coordinator owns it in slice B',
   }),
 )
 

--- a/src/agent/worktree.ts
+++ b/src/agent/worktree.ts
@@ -99,6 +99,7 @@ export async function ensureWorktree(
   // 新分支只能从 fetch 后的远端默认分支创建,不能继承配置仓库碰巧停留的 HEAD。
   const policy = { mode: 'danger-full-access' as const, workspaceRoot: expandedRepo }
   await remoteFetch(ctx, {
+    repoKey,
     workdir: expandedRepo,
     sandboxPolicy: policy,
     timeoutMs: 60_000,

--- a/src/agent/worktree.ts
+++ b/src/agent/worktree.ts
@@ -21,6 +21,7 @@
 import { existsSync } from 'node:fs'
 import { basename, dirname, join, resolve } from 'node:path'
 import type { Context } from '@deepseek-ai/cordis'
+import { remoteFetch } from '../infra/remote-git.ts'
 import { notifyLocalGitMutation } from '../infra/local-git-snapshot.ts'
 import { buildWorktreeAddCommand, decideWorktreeRecovery, shellQuote } from '../infra/develop-core.ts'
 import { expandHome, loadConfig, runCommand } from '../infra/runtime.ts'
@@ -97,7 +98,7 @@ export async function ensureWorktree(
 
   // 新分支只能从 fetch 后的远端默认分支创建,不能继承配置仓库碰巧停留的 HEAD。
   const policy = { mode: 'danger-full-access' as const, workspaceRoot: expandedRepo }
-  await runCommand(ctx, 'git fetch origin --prune', {
+  await remoteFetch(ctx, {
     workdir: expandedRepo,
     sandboxPolicy: policy,
     timeoutMs: 60_000,

--- a/src/github/pr.ts
+++ b/src/github/pr.ts
@@ -52,6 +52,7 @@ export async function ensurePullRequest(
   })
   if (dirty !== '') throw new Error('worktree 有未提交改动,拒绝创建 PR')
   await remotePush(ctx, {
+    repoKey: input.repoKey,
     workdir: input.worktree,
     timeoutMs: 120_000,
     sandboxPolicy: policy,

--- a/src/github/pr.ts
+++ b/src/github/pr.ts
@@ -1,4 +1,5 @@
 import type { Context } from '@deepseek-ai/cordis'
+import { remotePush } from '../infra/remote-git.ts'
 import { notifyLocalGitMutation } from '../infra/local-git-snapshot.ts'
 import { shellQuote } from '../infra/develop-core.ts'
 import { runCommand } from '../infra/runtime.ts'
@@ -50,10 +51,12 @@ export async function ensurePullRequest(
     sandboxPolicy: { mode: 'read-only', workspaceRoot: input.worktree },
   })
   if (dirty !== '') throw new Error('worktree 有未提交改动,拒绝创建 PR')
-  await runCommand(ctx, `git push --set-upstream origin ${shellQuote(input.branch)}`, {
+  await remotePush(ctx, {
     workdir: input.worktree,
     timeoutMs: 120_000,
     sandboxPolicy: policy,
+    refspec: shellQuote(input.branch),
+    setUpstream: true,
   })
   notifyLocalGitMutation(
     { repoKey: input.repoKey, worktreePath: input.worktree },

--- a/src/infra/baseline-restore-git.ts
+++ b/src/infra/baseline-restore-git.ts
@@ -42,12 +42,13 @@ export async function latestKnownBaseHash(ctx: Context, repoPath: string, hashes
 /** Atomically recreate one missing origin branch at an exact existing commit. */
 export async function restoreMissingOriginBranch(
   ctx: Context,
+  repoKey: string,
   repoPath: string,
   branch: string,
   hash: string,
 ): Promise<void> {
   const policy = { mode: 'danger-full-access' as const, workspaceRoot: repoPath }
-  await remoteFetch(ctx, { workdir: repoPath, timeoutMs: 60_000, sandboxPolicy: policy })
+  await remoteFetch(ctx, { repoKey, workdir: repoPath, timeoutMs: 60_000, sandboxPolicy: policy })
   const remoteRef = `refs/remotes/origin/${branch}`
   const existing = await runCommand(ctx, `git rev-parse --verify ${shellQuote(remoteRef)}`, {
     workdir: repoPath,

--- a/src/infra/baseline-restore-git.ts
+++ b/src/infra/baseline-restore-git.ts
@@ -1,4 +1,5 @@
 import type { Context } from '@deepseek-ai/cordis'
+import { remoteFetch } from './remote-git.ts'
 import { shellQuote } from './develop-core.ts'
 import { runCommand } from './runtime.ts'
 import type { WorkflowStorageIdentity } from './state-layout.ts'
@@ -46,7 +47,7 @@ export async function restoreMissingOriginBranch(
   hash: string,
 ): Promise<void> {
   const policy = { mode: 'danger-full-access' as const, workspaceRoot: repoPath }
-  await runCommand(ctx, 'git fetch origin --prune', { workdir: repoPath, timeoutMs: 60_000, sandboxPolicy: policy })
+  await remoteFetch(ctx, { workdir: repoPath, timeoutMs: 60_000, sandboxPolicy: policy })
   const remoteRef = `refs/remotes/origin/${branch}`
   const existing = await runCommand(ctx, `git rev-parse --verify ${shellQuote(remoteRef)}`, {
     workdir: repoPath,

--- a/src/infra/git.ts
+++ b/src/infra/git.ts
@@ -18,6 +18,7 @@
  *                      └── rework ────────┘
  */
 import type { Context } from '@deepseek-ai/cordis'
+import { remoteFetch } from './remote-git.ts'
 import { shellQuote } from './develop-core.ts'
 import { runCommand } from './runtime.ts'
 import { type IssueContractSnapshot } from './state.ts'
@@ -200,7 +201,7 @@ export async function fetchOriginBranches(
   repoPath: string,
 ): Promise<{ defaultRemoteBase: string; refs: string[] }> {
   const policy = { mode: 'danger-full-access' as const, workspaceRoot: repoPath }
-  await runCommand(ctx, 'git fetch origin --prune', { workdir: repoPath, timeoutMs: 60_000, sandboxPolicy: policy })
+  await remoteFetch(ctx, { workdir: repoPath, timeoutMs: 60_000, sandboxPolicy: policy })
   let defaultRemoteBase = await runCommand(ctx, 'git symbolic-ref --quiet --short refs/remotes/origin/HEAD', {
     workdir: repoPath,
     timeoutMs: 10_000,

--- a/src/infra/git.ts
+++ b/src/infra/git.ts
@@ -198,10 +198,11 @@ export function conflictFileSuffix(files: string[]): string {
 /** Fetch and enumerate origin remote branches for a first-development preview. */
 export async function fetchOriginBranches(
   ctx: Context,
+  repoKey: string,
   repoPath: string,
 ): Promise<{ defaultRemoteBase: string; refs: string[] }> {
   const policy = { mode: 'danger-full-access' as const, workspaceRoot: repoPath }
-  await remoteFetch(ctx, { workdir: repoPath, timeoutMs: 60_000, sandboxPolicy: policy })
+  await remoteFetch(ctx, { repoKey, workdir: repoPath, timeoutMs: 60_000, sandboxPolicy: policy })
   let defaultRemoteBase = await runCommand(ctx, 'git symbolic-ref --quiet --short refs/remotes/origin/HEAD', {
     workdir: repoPath,
     timeoutMs: 10_000,

--- a/src/infra/remote-git.ts
+++ b/src/infra/remote-git.ts
@@ -5,13 +5,28 @@
  * shared runCommand semantics. The Remote Git Coordinator (slice B) will own
  * these entry points — singleflight, the per-repository critical section, the
  * authoritative post-push readback and the snapshot invalidation broadcast
- * all wrap here, so no call site can bypass them.
+ * all wrap here for every migrated call site (the two compound flows pending
+ * in slice C still go direct).
  */
 
 import type { Context } from '@deepseek-ai/cordis'
 import { runCommand } from './runtime.ts'
 
 export interface RemoteGitCommandOptions {
+  /**
+   * Stable coordination identity (grill Q1): the configured repoKey today.
+   * The Coordinator (slice B) keys singleflight and the per-(repoKey, remote)
+   * critical section on this value — never on a worktree path.
+   */
+  repoKey: string
+  /**
+   * Placeholder for ProjectBinding.repositoryId (grill Q1): carried but not
+   * consumed until project bindings are complete, so the later switch is a
+   * value change, not a signature change.
+   */
+  repositoryId?: string | null
+  /** Remote name (grill Q3 scope); defaults to 'origin'. */
+  remote?: string
   workdir: string
   timeoutMs?: number
   sandboxPolicy?: {
@@ -20,17 +35,27 @@ export interface RemoteGitCommandOptions {
   }
 }
 
-/** `git fetch origin [--prune]` — mutates local remote-tracking refs. */
+/** `git fetch <remote> [--prune]` — mutates local remote-tracking refs. */
 export function remoteFetch(ctx: Context, options: RemoteGitCommandOptions & { prune?: boolean }): Promise<string> {
-  const { prune = true, ...command } = options
-  return runCommand(ctx, prune ? 'git fetch origin --prune' : 'git fetch origin', command)
+  const { prune = true } = options
+  const remote = options.remote ?? 'origin'
+  return runCommand(ctx, prune ? `git fetch ${remote} --prune` : `git fetch ${remote}`, {
+    workdir: options.workdir,
+    timeoutMs: options.timeoutMs,
+    sandboxPolicy: options.sandboxPolicy,
+  })
 }
 
-/** `git push [--set-upstream] origin <refspec>` — mutates the remote. */
+/** `git push [--set-upstream] <remote> <refspec>` — mutates the remote. */
 export function remotePush(
   ctx: Context,
   options: RemoteGitCommandOptions & { refspec: string; setUpstream?: boolean },
 ): Promise<string> {
-  const { refspec, setUpstream = false, ...command } = options
-  return runCommand(ctx, `git push ${setUpstream ? '--set-upstream ' : ''}origin ${refspec}`, command)
+  const { refspec, setUpstream = false } = options
+  const remote = options.remote ?? 'origin'
+  return runCommand(ctx, `git push ${setUpstream ? '--set-upstream ' : ''}${remote} ${refspec}`, {
+    workdir: options.workdir,
+    timeoutMs: options.timeoutMs,
+    sandboxPolicy: options.sandboxPolicy,
+  })
 }

--- a/src/infra/remote-git.ts
+++ b/src/infra/remote-git.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared entry points for Controller-owned remote Git operations (issue #135
+ * slice A). Thin, zero-behavior extraction: the command strings, timeouts and
+ * sandbox policies match the call sites verbatim, and non-zero exits keep the
+ * shared runCommand semantics. The Remote Git Coordinator (slice B) will own
+ * these entry points — singleflight, the per-repository critical section, the
+ * authoritative post-push readback and the snapshot invalidation broadcast
+ * all wrap here, so no call site can bypass them.
+ */
+
+import type { Context } from '@deepseek-ai/cordis'
+import { runCommand } from './runtime.ts'
+
+export interface RemoteGitCommandOptions {
+  workdir: string
+  timeoutMs?: number
+  sandboxPolicy?: {
+    mode: 'read-only' | 'workspace-write' | 'danger-full-access'
+    workspaceRoot: string
+  }
+}
+
+/** `git fetch origin [--prune]` — mutates local remote-tracking refs. */
+export function remoteFetch(ctx: Context, options: RemoteGitCommandOptions & { prune?: boolean }): Promise<string> {
+  const { prune = true, ...command } = options
+  return runCommand(ctx, prune ? 'git fetch origin --prune' : 'git fetch origin', command)
+}
+
+/** `git push [--set-upstream] origin <refspec>` — mutates the remote. */
+export function remotePush(
+  ctx: Context,
+  options: RemoteGitCommandOptions & { refspec: string; setUpstream?: boolean },
+): Promise<string> {
+  const { refspec, setUpstream = false, ...command } = options
+  return runCommand(ctx, `git push ${setUpstream ? '--set-upstream ' : ''}origin ${refspec}`, command)
+}

--- a/src/infra/runtime.ts
+++ b/src/infra/runtime.ts
@@ -27,6 +27,7 @@ import { notifyLocalGitMutation } from './local-git-invalidate.ts'
  *                      └── rework ────────┘
  */
 import type { Context } from '@deepseek-ai/cordis'
+import { remoteFetch } from './remote-git.ts'
 import { parse as parseYaml } from 'yaml'
 import { parseClickVibeConfigV1 } from './project-binding.ts'
 import { verifyProjectBindingRepository } from './repository-identity.ts'
@@ -362,7 +363,7 @@ export async function ensureConfiguredRepoFresh(
     fetchTtlMs(config),
     async () => {
       try {
-        await runCommand(ctx, 'git fetch origin --prune', {
+        await remoteFetch(ctx, {
           workdir: repoPath,
           timeoutMs: 30_000,
           sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: repoPath },

--- a/src/infra/runtime.ts
+++ b/src/infra/runtime.ts
@@ -364,6 +364,7 @@ export async function ensureConfiguredRepoFresh(
     async () => {
       try {
         await remoteFetch(ctx, {
+          repoKey,
           workdir: repoPath,
           timeoutMs: 30_000,
           sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: repoPath },

--- a/src/workflow/baseline-restore.ts
+++ b/src/workflow/baseline-restore.ts
@@ -72,7 +72,7 @@ export async function restoreBaseBranch(
       if (target.baseBranch !== authorizedTarget.baseBranch || target.baseHash !== authorizedTarget.baseHash) {
         throw new Error('恢复基线目标已变化,请刷新预览并重新确认')
       }
-      await restoreMissingOriginBranch(ctx, expandHome(configured), target.baseBranch, target.baseHash)
+      await restoreMissingOriginBranch(ctx, repoKey, expandHome(configured), target.baseBranch, target.baseHash)
       notifyLocalGitMutation({ repoKey }, 'baseline-restore', 'restoreBaseBranch')
       return { ok: true as const, ...target }
     })

--- a/src/workflow/develop-baseline-preview.ts
+++ b/src/workflow/develop-baseline-preview.ts
@@ -57,7 +57,7 @@ export async function developBaselinePreview(
   const repoPath = resolve(expandHome(configuredPath))
   let branches: Awaited<ReturnType<typeof fetchOriginBranches>>
   try {
-    branches = await fetchOriginBranches(ctx, repoPath)
+    branches = await fetchOriginBranches(ctx, repoKey, repoPath)
     notifyLocalGitMutation({ repoKey }, 'remote-fetch', 'developBaselinePreview')
   } catch (error) {
     if (selected !== 'origin/HEAD') throw error

--- a/src/workflow/merge-gates.ts
+++ b/src/workflow/merge-gates.ts
@@ -19,6 +19,7 @@ import { existsSync } from 'node:fs'
  *                      └── rework ────────┘
  */
 import type { Context } from '@deepseek-ai/cordis'
+import { remoteFetch } from '../infra/remote-git.ts'
 import { fetchIssueRestDetail } from '../github/reads.ts'
 import { type MergeOverrideGate, shellQuote } from '../infra/develop-core.ts'
 import { parseUrl, runCommand } from '../infra/runtime.ts'
@@ -115,7 +116,12 @@ export async function isSyncEquivalentMerge(
   }
   const remoteBase = `origin/${baseBranch}`
   // 先同步远端:被检的 H(远端分支 HEAD)与最新冻结基线对象必须在本地可解析
-  if (!(await gitOk('fetch origin --prune', 60_000))) return false
+  if (
+    !(await remoteFetch(ctx, { workdir: worktree, timeoutMs: 60_000, sandboxPolicy: policy })
+      .then(() => true)
+      .catch(() => false))
+  )
+    return false
   const head = await gitOut(`rev-parse --verify ${shellQuote(`${prHead}^{commit}`)}`)
   const reviewed = await gitOut(`rev-parse --verify ${shellQuote(`${reviewedHash}^{commit}`)}`)
   if (!head || !reviewed || head === reviewed) return false

--- a/src/workflow/merge-gates.ts
+++ b/src/workflow/merge-gates.ts
@@ -86,6 +86,7 @@ export interface MergeGateFailure {
  */
 export async function isSyncEquivalentMerge(
   ctx: Context,
+  repoKey: string,
   worktree: string,
   reviewedHash: string,
   prHead: string,
@@ -117,7 +118,7 @@ export async function isSyncEquivalentMerge(
   const remoteBase = `origin/${baseBranch}`
   // 先同步远端:被检的 H(远端分支 HEAD)与最新冻结基线对象必须在本地可解析
   if (
-    !(await remoteFetch(ctx, { workdir: worktree, timeoutMs: 60_000, sandboxPolicy: policy })
+    !(await remoteFetch(ctx, { repoKey, workdir: worktree, timeoutMs: 60_000, sandboxPolicy: policy })
       .then(() => true)
       .catch(() => false))
   )
@@ -148,6 +149,7 @@ export async function isSyncEquivalentMerge(
  */
 export async function assertReviewHeadMatchesPr(
   ctx: Context,
+  repoKey: string,
   worktree: string,
   reviewedHash: string | null,
   prHead: string | null | undefined,
@@ -155,7 +157,7 @@ export async function assertReviewHeadMatchesPr(
 ): Promise<void> {
   if (prHead && reviewedHash) {
     if (sameCommitHash(reviewedHash, prHead)) return
-    if (await isSyncEquivalentMerge(ctx, worktree, reviewedHash, prHead, baseBranch)) return
+    if (await isSyncEquivalentMerge(ctx, repoKey, worktree, reviewedHash, prHead, baseBranch)) return
   }
   throw new Error('合并门禁拒绝:实时 PR HEAD 与最近一次通过的 review 结论哈希不一致,且不满足同步等价,需重新 Review')
 }
@@ -183,6 +185,7 @@ export async function collectMergeGateFailures(
     !!reviewedHash &&
     (await isSyncEquivalentMerge(
       ctx,
+      workflow.repoKey,
       workflow.worktree,
       reviewedHash,
       prHead,

--- a/src/workflow/repository-sync.ts
+++ b/src/workflow/repository-sync.ts
@@ -2,6 +2,7 @@
 import { existsSync } from 'node:fs'
 import { resolve } from 'node:path'
 import type { Context } from '@deepseek-ai/cordis'
+import { remoteFetch } from '../infra/remote-git.ts'
 import { logTaskDiagnostic } from '../infra/task-diagnostics.ts'
 import { notifyLocalGitMutation } from '../infra/local-git-invalidate.ts'
 import type { LocalGitSnapshotReader } from '../infra/local-git-snapshot.ts'
@@ -98,7 +99,7 @@ export async function syncConfiguredRepository(
   if (!repoKey || !repoPath) return { ok: false, error: `未配置或无法访问项目 ${repoKey || '(空)'}` }
 
   try {
-    await runCommand(ctx, 'git fetch origin --prune', {
+    await remoteFetch(ctx, {
       workdir: repoPath,
       timeoutMs: 60_000,
       sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: repoPath },

--- a/src/workflow/repository-sync.ts
+++ b/src/workflow/repository-sync.ts
@@ -100,6 +100,7 @@ export async function syncConfiguredRepository(
 
   try {
     await remoteFetch(ctx, {
+      repoKey,
       workdir: repoPath,
       timeoutMs: 60_000,
       sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: repoPath },

--- a/src/workflow/resume.ts
+++ b/src/workflow/resume.ts
@@ -18,6 +18,7 @@
  *                      └── rework ────────┘
  */
 import type { Context } from '@deepseek-ai/cordis'
+import { remoteFetch } from '../infra/remote-git.ts'
 import { notifyLocalGitMutation } from '../infra/local-git-snapshot.ts'
 import { buildResumePrompt, resolvePromptSnapshot } from '../agent/prompts.ts'
 import {
@@ -29,7 +30,7 @@ import {
 } from '../agent/task-supervisor.ts'
 import { buildFreshAgentCommand, buildResumeAgentCommand } from '../infra/develop-core.ts'
 import { buildMergePreface } from '../infra/git.ts'
-import { type LiveTask, parseUrl, readWorktreeHead, resumeTaskGate, runCommand, taskId } from '../infra/runtime.ts'
+import { type LiveTask, parseUrl, readWorktreeHead, resumeTaskGate, taskId } from '../infra/runtime.ts'
 import { clearStaleSessionId, issueKey, loadWorkflow, resolveSessionForAgent } from '../infra/state.ts'
 import {
   observeWorkflowTask,
@@ -118,9 +119,10 @@ export async function resumeDevelop(
   const command = launch.startsFresh ? buildFreshAgentCommand(agent) : buildResumeAgentCommand(agent, sessionId)
   // 续会话前也同步远端(并行开发时 base 会变化)
   try {
-    await runCommand(ctx, 'git fetch origin', {
+    await remoteFetch(ctx, {
       workdir: workflow.worktree,
       timeoutMs: 30000,
+      prune: false,
       sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: workflow.worktree },
     })
     pushTaskLine(live, `[clickvibe] 已同步远端(origin)`)

--- a/src/workflow/resume.ts
+++ b/src/workflow/resume.ts
@@ -120,6 +120,7 @@ export async function resumeDevelop(
   // 续会话前也同步远端(并行开发时 base 会变化)
   try {
     await remoteFetch(ctx, {
+      repoKey: workflow.repoKey,
       workdir: workflow.worktree,
       timeoutMs: 30000,
       prune: false,

--- a/src/workflow/review-flow.ts
+++ b/src/workflow/review-flow.ts
@@ -11,6 +11,7 @@
 
 import { existsSync } from 'node:fs'
 import type { Context } from '@deepseek-ai/cordis'
+import { remoteFetch } from '../infra/remote-git.ts'
 import { notifyLocalGitMutation } from '../infra/local-git-snapshot.ts'
 import { type AgentKind } from '../agent/agent-stream.ts'
 import {
@@ -153,7 +154,7 @@ export async function startReview(
     },
   }
   try {
-    await runCommand(ctx, 'git fetch origin --prune', {
+    await remoteFetch(ctx, {
       workdir: workflow.worktree,
       timeoutMs: 60_000,
       sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: workflow.worktree },

--- a/src/workflow/review-flow.ts
+++ b/src/workflow/review-flow.ts
@@ -155,6 +155,7 @@ export async function startReview(
   }
   try {
     await remoteFetch(ctx, {
+      repoKey: workflow.repoKey,
       workdir: workflow.worktree,
       timeoutMs: 60_000,
       sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: workflow.worktree },

--- a/src/workflow/sync.ts
+++ b/src/workflow/sync.ts
@@ -83,6 +83,7 @@ async function syncWorktreeLocked(ctx: Context, key: string): Promise<SyncResult
     }
     await appendLog(workflow.key, 'dev', '[clickvibe] 同步:git fetch origin…')
     await remoteFetch(ctx, {
+      repoKey: workflow.repoKey,
       workdir: workflow.worktree,
       timeoutMs: 60_000,
       sandboxPolicy: policy,
@@ -175,6 +176,7 @@ async function syncWorktreeLocked(ctx: Context, key: string): Promise<SyncResult
     const head = await readWorktreeHead(ctx, workflow.worktree)
     await appendLog(workflow.key, 'dev', `[clickvibe] 同步:推送 ${workflow.branch} 到 origin…`)
     await remotePush(ctx, {
+      repoKey: workflow.repoKey,
       workdir: workflow.worktree,
       timeoutMs: 60_000,
       sandboxPolicy: policy,

--- a/src/workflow/sync.ts
+++ b/src/workflow/sync.ts
@@ -20,6 +20,7 @@
 
 import { existsSync } from 'node:fs'
 import type { Context } from '@deepseek-ai/cordis'
+import { remoteFetch, remotePush } from '../infra/remote-git.ts'
 import { notifyLocalGitMutation } from '../infra/local-git-snapshot.ts'
 import { updateBaseTip } from '../agent/baseline.ts'
 import { shellQuote } from '../infra/develop-core.ts'
@@ -81,7 +82,7 @@ async function syncWorktreeLocked(ctx: Context, key: string): Promise<SyncResult
       if (changes) throw new Error('worktree 有未提交改动,请先提交或清理后再同步')
     }
     await appendLog(workflow.key, 'dev', '[clickvibe] 同步:git fetch origin…')
-    await runCommand(ctx, 'git fetch origin --prune', {
+    await remoteFetch(ctx, {
       workdir: workflow.worktree,
       timeoutMs: 60_000,
       sandboxPolicy: policy,
@@ -173,10 +174,11 @@ async function syncWorktreeLocked(ctx: Context, key: string): Promise<SyncResult
     }
     const head = await readWorktreeHead(ctx, workflow.worktree)
     await appendLog(workflow.key, 'dev', `[clickvibe] 同步:推送 ${workflow.branch} 到 origin…`)
-    await runCommand(ctx, `git push origin ${shellQuote(workflow.branch)}`, {
+    await remotePush(ctx, {
       workdir: workflow.worktree,
       timeoutMs: 60_000,
       sandboxPolicy: policy,
+      refspec: shellQuote(workflow.branch),
     })
     await appendLog(workflow.key, 'dev', `[clickvibe] 同步并推送完成,HEAD ${head ?? '未知'}`)
     // 记录同步事件到权威时间线(不改变开发/审查语义)

--- a/tests/git-helpers.test.ts
+++ b/tests/git-helpers.test.ts
@@ -61,7 +61,7 @@ test('origin branch enumeration falls back to main and rejects repositories with
     if (command.includes('for-each-ref')) return { exitCode: 0, stdout: 'origin/main\n\norigin/release\n' }
     return { exitCode: 0 }
   })
-  assert.deepEqual(await fetchOriginBranches(fallback as never, '/repo'), {
+  assert.deepEqual(await fetchOriginBranches(fallback as never, 'o/r', '/repo'), {
     defaultRemoteBase: 'origin/main',
     refs: ['origin/main', 'origin/release'],
   })
@@ -70,5 +70,5 @@ test('origin branch enumeration falls back to main and rejects repositories with
       ? { exitCode: 1 }
       : { exitCode: 0, stdout: command.includes('show-ref') ? '1' : '' },
   )
-  await assert.rejects(fetchOriginBranches(missing as never, '/repo'), /无法确定 origin 默认分支/)
+  await assert.rejects(fetchOriginBranches(missing as never, 'o/r', '/repo'), /无法确定 origin 默认分支/)
 })

--- a/tests/remote-git.test.ts
+++ b/tests/remote-git.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import type { Context } from '@deepseek-ai/cordis'
+import { remoteFetch, remotePush } from '../src/infra/remote-git.ts'
+
+function recordingShell(exitCode = 0) {
+  const commands: Array<{ command: string; workdir?: string; timeoutMs?: number }> = []
+  const ctx = {
+    shell: {
+      resolve: (spec: unknown) => spec,
+      run: async (spec: { command: string; workdir?: string; timeoutMs?: number }) => {
+        commands.push(spec)
+        return { exitCode, stdout: { text: 'out\n' }, stderr: { text: '' } }
+      },
+    },
+  } as unknown as Context
+  return { ctx, commands }
+}
+
+test('remoteFetch builds the exact legacy command strings and forwards options', async () => {
+  const pruned = recordingShell()
+  await remoteFetch(pruned.ctx, {
+    workdir: '/repo',
+    timeoutMs: 60_000,
+    sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: '/repo' },
+  })
+  assert.equal(pruned.commands[0].command, 'git fetch origin --prune')
+  assert.equal(pruned.commands[0].workdir, '/repo')
+  assert.equal(pruned.commands[0].timeoutMs, 60_000)
+
+  const plain = recordingShell()
+  await remoteFetch(plain.ctx, { workdir: '/repo', timeoutMs: 30_000, prune: false })
+  assert.equal(plain.commands[0].command, 'git fetch origin')
+})
+
+test('remotePush builds the exact legacy push forms', async () => {
+  const push = recordingShell()
+  await remotePush(push.ctx, { workdir: '/wt', timeoutMs: 60_000, refspec: "'clickvibe-issue-5'" })
+  assert.equal(push.commands[0].command, "git push origin 'clickvibe-issue-5'")
+
+  const upstream = recordingShell()
+  await remotePush(upstream.ctx, {
+    workdir: '/wt',
+    timeoutMs: 120_000,
+    refspec: "'feature'",
+    setUpstream: true,
+  })
+  assert.equal(upstream.commands[0].command, "git push --set-upstream origin 'feature'")
+})
+
+test('non-zero exits reject through the shared runCommand semantics', async () => {
+  const failing = recordingShell(128)
+  await assert.rejects(remoteFetch(failing.ctx, { workdir: '/repo', timeoutMs: 30_000 }), /命令退出码 128/)
+})

--- a/tests/remote-git.test.ts
+++ b/tests/remote-git.test.ts
@@ -20,6 +20,7 @@ function recordingShell(exitCode = 0) {
 test('remoteFetch builds the exact legacy command strings and forwards options', async () => {
   const pruned = recordingShell()
   await remoteFetch(pruned.ctx, {
+    repoKey: 'ai-daming/clickvibe',
     workdir: '/repo',
     timeoutMs: 60_000,
     sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: '/repo' },
@@ -29,17 +30,28 @@ test('remoteFetch builds the exact legacy command strings and forwards options',
   assert.equal(pruned.commands[0].timeoutMs, 60_000)
 
   const plain = recordingShell()
-  await remoteFetch(plain.ctx, { workdir: '/repo', timeoutMs: 30_000, prune: false })
+  await remoteFetch(plain.ctx, {
+    repoKey: 'ai-daming/clickvibe',
+    workdir: '/repo',
+    timeoutMs: 30_000,
+    prune: false,
+  })
   assert.equal(plain.commands[0].command, 'git fetch origin')
 })
 
 test('remotePush builds the exact legacy push forms', async () => {
   const push = recordingShell()
-  await remotePush(push.ctx, { workdir: '/wt', timeoutMs: 60_000, refspec: "'clickvibe-issue-5'" })
+  await remotePush(push.ctx, {
+    repoKey: 'ai-daming/clickvibe',
+    workdir: '/wt',
+    timeoutMs: 60_000,
+    refspec: "'clickvibe-issue-5'",
+  })
   assert.equal(push.commands[0].command, "git push origin 'clickvibe-issue-5'")
 
   const upstream = recordingShell()
   await remotePush(upstream.ctx, {
+    repoKey: 'ai-daming/clickvibe',
     workdir: '/wt',
     timeoutMs: 120_000,
     refspec: "'feature'",
@@ -51,4 +63,23 @@ test('remotePush builds the exact legacy push forms', async () => {
 test('non-zero exits reject through the shared runCommand semantics', async () => {
   const failing = recordingShell(128)
   await assert.rejects(remoteFetch(failing.ctx, { workdir: '/repo', timeoutMs: 30_000 }), /命令退出码 128/)
+})
+
+test('coordination identity is carried, never leaked into the command', async () => {
+  const recording = recordingShell()
+  await remoteFetch(recording.ctx, {
+    repoKey: 'ai-daming/clickvibe',
+    repositoryId: 'future-binding-id',
+    workdir: '/repo',
+    timeoutMs: 30_000,
+  })
+  assert.equal(recording.commands[0].command, 'git fetch origin --prune')
+  assert.equal(recording.commands[0].workdir, '/repo')
+  assert.equal(recording.commands[0].timeoutMs, 30_000)
+
+  const customRemote = recordingShell()
+  await remoteFetch(customRemote.ctx, { repoKey: 'o/r', remote: 'upstream', workdir: '/repo' })
+  assert.equal(customRemote.commands[0].command, 'git fetch upstream --prune')
+  await remotePush(customRemote.ctx, { repoKey: 'o/r', remote: 'upstream', workdir: '/repo', refspec: "'x'" })
+  assert.equal(customRemote.commands[1].command, "git push upstream 'x'")
 })

--- a/tests/sync-equivalence.test.ts
+++ b/tests/sync-equivalence.test.ts
@@ -106,11 +106,11 @@ test('pure sync merge of R with origin/main is sync-equivalent (issue #48)', asy
     const head = await scene.remoteBranchHead()
     assert.notEqual(head, scene.reviewedFull)
 
-    assert.equal(await isSyncEquivalentMerge(ctx, scene.worktree, scene.reviewedShort, head), true)
+    assert.equal(await isSyncEquivalentMerge(ctx, 'owner/repo', scene.worktree, scene.reviewedShort, head), true)
     // 全量哈希与短哈希均可判定
-    assert.equal(await isSyncEquivalentMerge(ctx, scene.worktree, scene.reviewedFull, head), true)
+    assert.equal(await isSyncEquivalentMerge(ctx, 'owner/repo', scene.worktree, scene.reviewedFull, head), true)
     // 门禁:H 为纯同步合并时放行
-    await assert.doesNotReject(assertReviewHeadMatchesPr(ctx, scene.worktree, scene.reviewedShort, head))
+    await assert.doesNotReject(assertReviewHeadMatchesPr(ctx, 'owner/repo', scene.worktree, scene.reviewedShort, head))
   } finally {
     await rm(scene.root, { recursive: true, force: true })
   }
@@ -128,8 +128,13 @@ test('pure sync merge follows a custom frozen baseline', async () => {
     const releaseHead = (await scene.wt('rev-parse', 'origin/release/2.0')).stdout.trim()
     assert.equal(parents.includes(reviewed), true)
     assert.equal(parents.includes(releaseHead), true)
-    assert.equal(await isSyncEquivalentMerge(ctx, scene.worktree, scene.reviewedShort, head, 'release/2.0'), true)
-    await assert.doesNotReject(assertReviewHeadMatchesPr(ctx, scene.worktree, scene.reviewedShort, head, 'release/2.0'))
+    assert.equal(
+      await isSyncEquivalentMerge(ctx, 'owner/repo', scene.worktree, scene.reviewedShort, head, 'release/2.0'),
+      true,
+    )
+    await assert.doesNotReject(
+      assertReviewHeadMatchesPr(ctx, 'owner/repo', scene.worktree, scene.reviewedShort, head, 'release/2.0'),
+    )
   } finally {
     await rm(scene.root, { recursive: true, force: true })
   }
@@ -172,7 +177,9 @@ test('pure sync merge accepts the exact advanced PR base without a review-base f
 
 test('identical hashes pass the gate without any git access (regression, issue #48)', async () => {
   // worktree 指向不存在的路径,证明哈希相等时完全短路、不触发 git
-  await assert.doesNotReject(assertReviewHeadMatchesPr(ctx, '/nonexistent/worktree', 'abc1234', 'abc1234def5678'))
+  await assert.doesNotReject(
+    assertReviewHeadMatchesPr(ctx, 'owner/repo', '/nonexistent/worktree', 'abc1234', 'abc1234def5678'),
+  )
 })
 
 test('manual conflict resolution in the sync merge breaks equivalence (issue #48)', async () => {
@@ -186,8 +193,11 @@ test('manual conflict resolution in the sync merge breaks equivalence (issue #48
     await scene.wt('push', 'origin', scene.branch)
     const head = await scene.remoteBranchHead()
 
-    assert.equal(await isSyncEquivalentMerge(ctx, scene.worktree, scene.reviewedShort, head), false)
-    await assert.rejects(assertReviewHeadMatchesPr(ctx, scene.worktree, scene.reviewedShort, head), /合并门禁拒绝/)
+    assert.equal(await isSyncEquivalentMerge(ctx, 'owner/repo', scene.worktree, scene.reviewedShort, head), false)
+    await assert.rejects(
+      assertReviewHeadMatchesPr(ctx, 'owner/repo', scene.worktree, scene.reviewedShort, head),
+      /合并门禁拒绝/,
+    )
   } finally {
     await rm(scene.root, { recursive: true, force: true })
   }
@@ -204,8 +214,11 @@ test('branch-side commit after the sync merge is rejected (issue #48)', async ()
     await scene.wt('push', 'origin', scene.branch)
     const head = await scene.remoteBranchHead()
 
-    assert.equal(await isSyncEquivalentMerge(ctx, scene.worktree, scene.reviewedShort, head), false)
-    await assert.rejects(assertReviewHeadMatchesPr(ctx, scene.worktree, scene.reviewedShort, head), /合并门禁拒绝/)
+    assert.equal(await isSyncEquivalentMerge(ctx, 'owner/repo', scene.worktree, scene.reviewedShort, head), false)
+    await assert.rejects(
+      assertReviewHeadMatchesPr(ctx, 'owner/repo', scene.worktree, scene.reviewedShort, head),
+      /合并门禁拒绝/,
+    )
   } finally {
     await rm(scene.root, { recursive: true, force: true })
   }
@@ -219,7 +232,7 @@ test('PR head older than R (force-push fork) is rejected (issue #48)', async () 
     await scene.git('push', '-f', 'origin', `${parent}:refs/heads/${scene.branch}`)
     const head = await scene.remoteBranchHead()
 
-    assert.equal(await isSyncEquivalentMerge(ctx, scene.worktree, scene.reviewedShort, head), false)
+    assert.equal(await isSyncEquivalentMerge(ctx, 'owner/repo', scene.worktree, scene.reviewedShort, head), false)
   } finally {
     await rm(scene.root, { recursive: true, force: true })
   }
@@ -239,7 +252,7 @@ test('merging a non-main branch into R is not sync-equivalent (issue #48)', asyn
     await scene.wt('push', 'origin', scene.branch)
     const head = await scene.remoteBranchHead()
 
-    assert.equal(await isSyncEquivalentMerge(ctx, scene.worktree, scene.reviewedShort, head), false)
+    assert.equal(await isSyncEquivalentMerge(ctx, 'owner/repo', scene.worktree, scene.reviewedShort, head), false)
   } finally {
     await rm(scene.root, { recursive: true, force: true })
   }
@@ -251,7 +264,7 @@ test('missing reviewed commit locally fails closed (issue #48)', async () => {
     // R 在本地不存在(如对象被回收):无法核实即不满足
     const head = await scene.remoteBranchHead()
     assert.equal(
-      await isSyncEquivalentMerge(ctx, scene.worktree, '0123456789abcdef0123456789abcdef01234567', head),
+      await isSyncEquivalentMerge(ctx, 'owner/repo', scene.worktree, '0123456789abcdef0123456789abcdef01234567', head),
       false,
     )
   } finally {


### PR DESCRIPTION
Toward #135（grill 台账 [Q7 切片 A](https://github.com/ai-daming/clickvibe/issues/135#issuecomment-5462704651)）。Coding baseline：`e4030ed`（已在 #135 登记）。

## 本片范围：零行为变化的铺路

**11 个普通调用点**的 Controller-owned 远端 fetch/push 收敛到单一适配层 `src/infra/remote-git.ts`（`remoteFetch` / `remotePush`）：

- **协调身份显式携带**（review 修正，台账 Q1/Q3）：`repoKey` 必填（当前稳定身份）、`repositoryId` 留位（ProjectBinding 全量后切换）、`remote` 显式（默认 `origin`，origin 命令串逐字不变）；身份字段不泄漏进 shell 命令与选项（专项测试锁定）。
- 命令串、超时、沙箱策略逐字保留——钉死命令串的现有断言零修改通过；非零退出沿用 `runCommand` 语义。
- 无协调、无回读、无失效变更——切片 B 的 Coordinator 将**拥有这 11 个入口**：singleflight、per-(repoKey,remote) 临界区、push 后权威回读、快照失效广播都在入口内实现。

**覆盖边界（诚实声明）**：两条复合流仍直连 `runCommand`，属切片 C 迁移范围——`baseline-restore-git.ts` 的 force-with-lease push、`merge.ts` 清理的 ls-remote + push-delete。本片之后远端调用**并非 100% 经过共享入口**。

换点清单（11）：`ensureConfiguredRepoFresh`、`ensureWorktree`、`syncConfiguredRepository`、`syncWorktree`（fetch+push）、review 前置 fetch、resume fetch（无 prune）、PR 创建 `push --set-upstream`、`fetchOriginBranches`、baseline restore fetch、merge gate fetch。

## 概念预算自检（AGENTS.md §2.5 原则 11）

新增概念：`remoteFetch`、`remotePush`、三个身份字段（台账 Q1/Q3 点名）。消费者：11 个调用点（本片）+ Coordinator（切片 B）；`repositoryId` 的具名消费者是未来的 ProjectBinding 切换——正是 Q1 批准的留位形态。无其他新类型/表/层。

## 门禁（全绿）

typecheck ✓ build ✓ test **648/648**（模块契约测试 4 例：命令串逐字锁定 + 身份不泄漏 + 非 origin remote 形态 + 退出码语义）✓ coverage **93.06/85.62/89.02** ✓ lint ✓ format ✓ size ✓ layers ✓ style-tokens ✓ state-writes ✓ local-git-writes（remote-git.ts 按低层适配器登记豁免，切片 B 由 Coordinator 收回）✓