### PR TITLE
feat(gateway): access metrics in the frozen #133 units (#131 slice A)

### DIFF
--- a/scripts/file-size-exceptions.json
+++ b/scripts/file-size-exceptions.json
@@ -29,5 +29,10 @@
     "path": "tests/local-git-sampler-equivalence.test.ts",
     "reason": "Issue #122 real-git equivalence, the final-behavior matrix (review round 4/5) and the deleted-base/non-git regressions share one fixture builder; splitting the matrix from equivalence is deferred.",
     "issueRef": "#122"
+  },
+  {
+    "path": "src/github/rest.ts",
+    "reason": "Issue #131 keeps the REST transport (lane, circuit, parsing), the read caches and the access-metric instrumentation in one reader module so the #133 units are measured at the exact decision points they describe; splitting is deferred until the Gateway mechanism (slice B) settles its final shape.",
+    "issueRef": "#131"
   }
 ]

--- a/src/github/rest.ts
+++ b/src/github/rest.ts
@@ -362,6 +362,17 @@ export class GithubRestReader {
       record.status = 'observed'
       record.observedAt = now
       record.observedKey = key
+      // The completion is a durable fact (#133: invalidation without a
+      // recorded re-observation stays unknown), persisted readback-able.
+      logTaskDiagnostic('github-rest-invalidation-observed', {
+        seq: record.seq,
+        generation: record.generation,
+        prefix: record.prefix,
+        reason: record.reason,
+        trigger: record.trigger,
+        observedKey: record.observedKey,
+        observedAt: record.observedAt,
+      })
     }
   }
 
@@ -450,10 +461,13 @@ export class GithubRestReader {
       this.recordBudgetSnapshot(response.headers)
       const detail = [result.stderr?.text, response.body].filter(Boolean).join('\n')
       if (isRateLimited(response, detail)) {
-        this.recordUpstreamFailure(requestOperation, new GithubRateLimitError(resetFrom(response.headers, Date.now())))
-        this.circuitUntil = resetFrom(response.headers, Date.now())
         const kind: GithubRateLimitKind =
           response.headers.get('x-ratelimit-remaining') === '0' ? 'primary' : 'secondary'
+        this.recordUpstreamFailure(
+          requestOperation,
+          new GithubRateLimitError(resetFrom(response.headers, Date.now()), kind),
+        )
+        this.circuitUntil = resetFrom(response.headers, Date.now())
         this.circuitKind = kind
         const resource = response.headers.get('x-ratelimit-resource') ?? 'core'
         logTaskDiagnostic('github-rate-circuit-trip', {
@@ -489,7 +503,10 @@ export class GithubRestReader {
       const response = await this.request(path, accept, timeoutMs)
       try {
         return JSON.parse(response.body || 'null') as T
-      } catch {
+      } catch (parseError) {
+        // The upstream child returned an unparseable body: it is upstream
+        // evidence even though the child itself exited zero (review round 3).
+        this.recordUpstreamFailure(`GET ${path}`, parseError)
         throw new Error(`GitHub REST 返回了无效 JSON: ${path}`)
       }
     } catch (error) {
@@ -503,7 +520,8 @@ export class GithubRestReader {
       const response = await this.request(path, undefined, timeoutMs, { method, body })
       try {
         return JSON.parse(response.body || 'null') as T
-      } catch {
+      } catch (parseError) {
+        this.recordUpstreamFailure(`${method} ${path}`, parseError)
         throw new Error(`GitHub REST 返回了无效 JSON: ${path}`)
       }
     } catch (error) {

--- a/src/github/rest.ts
+++ b/src/github/rest.ts
@@ -383,14 +383,10 @@ export class GithubRestReader {
    * bare response is distinguishable from "no response happened" and never
    * drops an already-seen bucket/limit/reset.
    */
-  private recordBudgetSnapshot(headers: Map<string, string>): void {
-    const hasAnyHeader = [
-      'x-ratelimit-remaining',
-      'x-ratelimit-limit',
-      'x-ratelimit-reset',
-      'x-ratelimit-resource',
-    ].some((name) => headers.get(name) !== undefined)
-    const resource = headers.get('x-ratelimit-resource') ?? (hasAnyHeader ? 'core' : null)
+  private recordBudgetSnapshot(headers: Map<string, string>): RateLimitSample {
+    // A missing resource header stays unknown (review round 5): no `core`
+    // fabrication, no named-bucket update from an unattributed response.
+    const resource = headers.get('x-ratelimit-resource') ?? null
     const limitRaw = Number(headers.get('x-ratelimit-limit'))
     const remainingRaw = Number(headers.get('x-ratelimit-remaining'))
     const resetSeconds = Number(headers.get('x-ratelimit-reset'))
@@ -409,6 +405,7 @@ export class GithubRestReader {
       this.evidence.rateLimitSamples.splice(0, this.evidence.rateLimitSamples.length - MAX_GATEWAY_EVIDENCE_RECORDS)
     }
     if (resource !== null) this.evidence.rateLimitBuckets[resource] = sample
+    return sample
   }
 
   private async request(
@@ -470,7 +467,7 @@ export class GithubRestReader {
         this.recordUpstreamFailure(requestOperation, parseError)
         throw parseError
       }
-      this.recordBudgetSnapshot(response.headers)
+      const currentSample = this.recordBudgetSnapshot(response.headers)
       const detail = [result.stderr?.text, response.body].filter(Boolean).join('\n')
       if (isRateLimited(response, detail)) {
         const kind: GithubRateLimitKind =
@@ -481,12 +478,14 @@ export class GithubRestReader {
         )
         this.circuitUntil = resetFrom(response.headers, Date.now())
         this.circuitKind = kind
-        const resource = response.headers.get('x-ratelimit-resource') ?? 'core'
         logTaskDiagnostic('github-rate-circuit-trip', {
           kind,
           path,
-          resource,
-          bucket: this.evidence.rateLimitBuckets[resource] ?? null,
+          // Bound to THIS response's observation (review round 5): unknown
+          // stays unknown; a prior response's bucket never leaks onto the
+          // trip event.
+          resource: currentSample.resource,
+          bucket: currentSample.resource !== null ? currentSample : null,
           retryAfter: response.headers.get('retry-after'),
           until: this.circuitUntil,
         })

--- a/src/github/rest.ts
+++ b/src/github/rest.ts
@@ -20,13 +20,17 @@ interface CachedValue<T> {
 }
 
 /**
- * Gateway access metrics in the frozen #133 units (issue #131 slice A):
- * every logical request lands in exactly one of hit / join / execution /
- * failure; upstream children, rate-limit budget snapshots, invalidations
- * and queue waits are recorded alongside as evidence.
+ * Gateway evidence in the frozen #133 units (issue #131 slice A). Numeric
+ * access counters (logical/hit/join/execution/wait) are deferred to the
+ * slice that consumes them — the threshold assertions and scheduling of the
+ * Gateway mechanism — per the concept-budget discipline; what ships here is
+ * the evidence that already has production consumers: failures and
+ * invalidations land in the persisted diagnostics channel, the per-response
+ * rate-limit series feeds the circuit-trip diagnostic.
  */
-/** One observed rate-limit bucket from response headers (#133 unit: per resource). */
-export interface RateLimitBucketSnapshot {
+
+/** One observed rate-limit sample from a single response (#133: every response records the bucket). */
+export interface RateLimitSample {
   resource: string
   limit: number | null
   remaining: number | null
@@ -44,43 +48,34 @@ export interface AccessFailureRecord {
   scope: string | null
 }
 
-/** One invalidation evidence row (#133 unit: object, reason, triggering action, sequence). */
+/** One invalidation evidence row (#133 unit: object, reason, triggering action, generation, subsequent observation). */
 export interface InvalidationRecord {
   seq: number
+  /** Per-prefix invalidation generation; distinguishes repeat invalidations of the same scope. */
+  generation: number
   prefix: string
-  reason: string | null
-  trigger: string | null
+  reason: string
+  trigger: string
+  /** observed once a subsequent cached load repopulated a matching key; pending = unknown. */
+  status: 'pending' | 'observed'
+  observedAt: number | null
+  observedKey: string | null
 }
 
-export interface GithubAccessCounters {
-  logicalRequests: number
-  cacheHits: number
-  singleflightJoins: number
-  executions: number
-  failures: number
-  upstreamRequests: number
-  invalidations: number
-  waitCount: number
-  waitMsTotal: number
-  /** Per-resource budget snapshots; every observed bucket survives (#133). */
-  rateLimitBuckets: Record<string, RateLimitBucketSnapshot>
+export interface GithubAccessEvidence {
+  /** Append-only per-response series (capped); same-bucket responses never overwrite each other. */
+  rateLimitSamples: RateLimitSample[]
+  /** Latest snapshot per resource bucket; consumed by the circuit-trip diagnostic. */
+  rateLimitBuckets: Record<string, RateLimitSample>
   failureRecords: AccessFailureRecord[]
   invalidationRecords: InvalidationRecord[]
 }
 
 const MAX_GATEWAY_EVIDENCE_RECORDS = 200
 
-function emptyCounters(): GithubAccessCounters {
+function emptyEvidence(): GithubAccessEvidence {
   return {
-    logicalRequests: 0,
-    cacheHits: 0,
-    singleflightJoins: 0,
-    executions: 0,
-    failures: 0,
-    upstreamRequests: 0,
-    invalidations: 0,
-    waitCount: 0,
-    waitMsTotal: 0,
+    rateLimitSamples: [],
     rateLimitBuckets: {},
     failureRecords: [],
     invalidationRecords: [],
@@ -106,11 +101,10 @@ interface HostGithubRequestLane {
 }
 
 /**
- * Per-intent composition scope (review finding 1): marks upstream calls a
- * cached loader composes for one already-counted access. Instance-level
- * state leaked across concurrent accesses — a sibling direct request was
- * misclassified and its logical intent vanished. Async context is isolated
- * per access chain, including across awaits.
+ * Composition scope: upstream calls a cached loader composes for one access
+ * intent. Evidence routing uses it — a composed failure records its access
+ * level at the wrapper (which knows the true scope), while direct calls
+ * record their own access level.
  */
 const accessCompositionScope = new AsyncLocalStorage<{ composed: boolean }>()
 
@@ -242,8 +236,9 @@ export class GithubRestReader {
   private readonly ctx: ShellContext
   private readonly minimumIntervalMs: number
   private readonly now: () => number
-  readonly counters: GithubAccessCounters = emptyCounters()
+  readonly evidence: GithubAccessEvidence = emptyEvidence()
   private invalidationSeq = 0
+  private readonly prefixGenerations = new Map<string, number>()
   private readonly resources = new Map<string, CachedValue<unknown>>()
   private readonly aggregates = new Map<string, CachedValue<unknown>>()
   private readonly inFlight = new Map<string, Promise<unknown>>()
@@ -260,7 +255,6 @@ export class GithubRestReader {
   }
 
   private recordFailure(operation: string, error: unknown, scope: string | null = null): void {
-    this.counters.failures++
     this.pushFailureRecord({
       level: 'access',
       operation,
@@ -280,9 +274,9 @@ export class GithubRestReader {
   }
 
   private pushFailureRecord(record: AccessFailureRecord): void {
-    this.counters.failureRecords.push(record)
-    if (this.counters.failureRecords.length > MAX_GATEWAY_EVIDENCE_RECORDS) {
-      this.counters.failureRecords.splice(0, this.counters.failureRecords.length - MAX_GATEWAY_EVIDENCE_RECORDS)
+    this.evidence.failureRecords.push(record)
+    if (this.evidence.failureRecords.length > MAX_GATEWAY_EVIDENCE_RECORDS) {
+      this.evidence.failureRecords.splice(0, this.evidence.failureRecords.length - MAX_GATEWAY_EVIDENCE_RECORDS)
     }
     // Production consumer + 错误不埋葬: failures land in the persisted
     // diagnostics channel the panel can query.
@@ -292,14 +286,6 @@ export class GithubRestReader {
       scope: record.scope,
       message: record.message,
     })
-  }
-
-  private withLoaderDepth<T>(loader: () => Promise<T>): () => Promise<T> {
-    return () => accessCompositionScope.run({ composed: true }, loader)
-  }
-
-  private isComposed(): boolean {
-    return accessCompositionScope.getStore()?.composed === true
   }
 
   rateLimitError(now = Date.now()): GithubRateLimitError | null {
@@ -314,15 +300,25 @@ export class GithubRestReader {
     return this.versions.get(key) ?? null
   }
 
-  invalidate(prefix: string, reason: string | null = null, trigger: string | null = null): void {
-    this.counters.invalidations++
+  invalidate(prefix: string, reason: string, trigger: string): void {
     this.invalidationSeq++
-    const record = { seq: this.invalidationSeq, prefix, reason, trigger }
-    this.counters.invalidationRecords.push(record)
-    if (this.counters.invalidationRecords.length > MAX_GATEWAY_EVIDENCE_RECORDS) {
-      this.counters.invalidationRecords.splice(
+    const generation = (this.prefixGenerations.get(prefix) ?? 0) + 1
+    this.prefixGenerations.set(prefix, generation)
+    const record: InvalidationRecord = {
+      seq: this.invalidationSeq,
+      generation,
+      prefix,
+      reason,
+      trigger,
+      status: 'pending',
+      observedAt: null,
+      observedKey: null,
+    }
+    this.evidence.invalidationRecords.push(record)
+    if (this.evidence.invalidationRecords.length > MAX_GATEWAY_EVIDENCE_RECORDS) {
+      this.evidence.invalidationRecords.splice(
         0,
-        this.counters.invalidationRecords.length - MAX_GATEWAY_EVIDENCE_RECORDS,
+        this.evidence.invalidationRecords.length - MAX_GATEWAY_EVIDENCE_RECORDS,
       )
     }
     logTaskDiagnostic('github-rest-invalidation', { ...record })
@@ -357,6 +353,18 @@ export class GithubRestReader {
     return stdout.text
   }
 
+  /** A subsequent cached load completes every pending invalidation whose prefix covers the key (#133: invalidation without re-observation stays unknown). */
+  private observeInvalidationsFor(key: string): void {
+    const now = this.now()
+    for (const record of this.evidence.invalidationRecords) {
+      if (record.status !== 'pending') continue
+      if (key !== record.prefix && !key.startsWith(`${record.prefix}/`)) continue
+      record.status = 'observed'
+      record.observedAt = now
+      record.observedKey = key
+    }
+  }
+
   private recordBudgetSnapshot(headers: Map<string, string>): void {
     const remainingRaw = headers.get('x-ratelimit-remaining')
     if (remainingRaw === undefined) return
@@ -365,7 +373,7 @@ export class GithubRestReader {
     const resource = headers.get('x-ratelimit-resource') ?? 'core'
     const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : null
     const remaining = Number.isFinite(Number(remainingRaw)) ? Number(remainingRaw) : null
-    this.counters.rateLimitBuckets[resource] = {
+    const sample: RateLimitSample = {
       resource,
       limit,
       remaining,
@@ -373,6 +381,11 @@ export class GithubRestReader {
       reset: Number.isFinite(resetSeconds) && resetSeconds > 0 ? resetSeconds * 1000 : null,
       observedAt: this.now(),
     }
+    this.evidence.rateLimitSamples.push(sample)
+    if (this.evidence.rateLimitSamples.length > MAX_GATEWAY_EVIDENCE_RECORDS) {
+      this.evidence.rateLimitSamples.splice(0, this.evidence.rateLimitSamples.length - MAX_GATEWAY_EVIDENCE_RECORDS)
+    }
+    this.evidence.rateLimitBuckets[resource] = sample
   }
 
   private async request(
@@ -381,18 +394,9 @@ export class GithubRestReader {
     timeoutMs = 30_000,
     mutation?: { method: 'POST' | 'PATCH'; body: unknown },
   ): Promise<IncludedResponse> {
-    const enteredAt = this.now()
     return serializeGithubRequest(this.minimumIntervalMs, async () => {
       // A request queued before another resource trips the circuit must not hit GitHub afterwards.
       this.assertCircuitOpen()
-      // Queue wait (#133): access entry → physical dispatch. Service time
-      // after dispatch is not queue wait and is not accumulated here.
-      const waitMs = this.now() - enteredAt
-      if (waitMs > 0) {
-        this.counters.waitCount++
-        this.counters.waitMsTotal += waitMs
-      }
-      this.counters.upstreamRequests++
       const command = [
         'gh api --include',
         shellQuote(path),
@@ -406,14 +410,25 @@ export class GithubRestReader {
         timeoutMs,
         ...(mutation ? { stdin: JSON.stringify(mutation.body) } : {}),
       })
-      const result = await this.ctx.shell.run(spec)
-      const stdout = await this.output(result)
+      const requestOperation = `${mutation?.method ?? 'GET'} ${path}`
+      let result: Awaited<ReturnType<ShellContext['shell']['run']>>
+      let stdout: string
+      try {
+        result = await this.ctx.shell.run(spec)
+        stdout = await this.output(result)
+      } catch (transportError) {
+        // The child was dispatched and the transport failed (shell reject,
+        // spill read): upstream-level evidence must survive (review round 2).
+        this.recordUpstreamFailure(requestOperation, transportError)
+        throw transportError
+      }
       let response: IncludedResponse
       try {
         response = parseIncludedResponse(stdout)
       } catch (parseError) {
         const detail = [result.stderr?.text, stdout].filter(Boolean).join('\n').trim()
         if (result.exitCode !== 0 && /(?:rate limit|secondary rate)/i.test(detail)) {
+          this.recordUpstreamFailure(requestOperation, new GithubRateLimitError(Date.now() + 60 * 60_000, 'unknown'))
           this.circuitUntil = Date.now() + 60 * 60_000
           this.circuitKind = 'unknown'
           logTaskDiagnostic('github-rate-circuit-trip', {
@@ -424,11 +439,15 @@ export class GithubRestReader {
           })
           throw new GithubRateLimitError(this.circuitUntil, 'unknown')
         }
-        if (result.exitCode !== 0) throw new Error(detail || `gh api 执行失败(exit ${result.exitCode})`)
+        if (result.exitCode !== 0) {
+          const cliFailure = new Error(detail || `gh api 执行失败(exit ${result.exitCode})`)
+          this.recordUpstreamFailure(requestOperation, cliFailure)
+          throw cliFailure
+        }
+        this.recordUpstreamFailure(requestOperation, parseError)
         throw parseError
       }
       this.recordBudgetSnapshot(response.headers)
-      const requestOperation = `${mutation?.method ?? 'GET'} ${path}`
       const detail = [result.stderr?.text, response.body].filter(Boolean).join('\n')
       if (isRateLimited(response, detail)) {
         this.recordUpstreamFailure(requestOperation, new GithubRateLimitError(resetFrom(response.headers, Date.now())))
@@ -436,11 +455,12 @@ export class GithubRestReader {
         const kind: GithubRateLimitKind =
           response.headers.get('x-ratelimit-remaining') === '0' ? 'primary' : 'secondary'
         this.circuitKind = kind
+        const resource = response.headers.get('x-ratelimit-resource') ?? 'core'
         logTaskDiagnostic('github-rate-circuit-trip', {
           kind,
           path,
-          remaining: response.headers.get('x-ratelimit-remaining'),
-          reset: response.headers.get('x-ratelimit-reset'),
+          resource,
+          bucket: this.evidence.rateLimitBuckets[resource] ?? null,
           retryAfter: response.headers.get('retry-after'),
           until: this.circuitUntil,
         })
@@ -465,64 +485,42 @@ export class GithubRestReader {
   }
 
   async json<T = unknown>(path: string, accept?: string, timeoutMs?: number): Promise<T> {
-    const direct = !this.isComposed()
-    if (direct) this.counters.logicalRequests++
     try {
       const response = await this.request(path, accept, timeoutMs)
       try {
-        const parsed = JSON.parse(response.body || 'null') as T
-        if (direct) this.counters.executions++
-        return parsed
+        return JSON.parse(response.body || 'null') as T
       } catch {
         throw new Error(`GitHub REST 返回了无效 JSON: ${path}`)
       }
     } catch (error) {
-      if (direct) this.recordFailure(`GET ${path}`, error)
+      if (!this.isComposed()) this.recordFailure(`GET ${path}`, error, null)
       throw error
     }
   }
 
   async mutate<T = unknown>(path: string, method: 'POST' | 'PATCH', body: unknown, timeoutMs?: number): Promise<T> {
-    const direct = !this.isComposed()
-    if (direct) this.counters.logicalRequests++
     try {
       const response = await this.request(path, undefined, timeoutMs, { method, body })
       try {
-        const parsed = JSON.parse(response.body || 'null') as T
-        if (direct) this.counters.executions++
-        return parsed
+        return JSON.parse(response.body || 'null') as T
       } catch {
         throw new Error(`GitHub REST 返回了无效 JSON: ${path}`)
       }
     } catch (error) {
-      if (direct) this.recordFailure(`${method} ${path}`, error)
+      if (!this.isComposed()) this.recordFailure(`${method} ${path}`, error, null)
       throw error
     }
   }
 
   async paginate<T>(path: string, accept?: string, timeoutMs?: number): Promise<T[]> {
-    const direct = !this.isComposed()
-    if (direct) this.counters.logicalRequests++
-    return accessCompositionScope.run({ composed: true }, async () => {
-      try {
-        const values: T[] = []
-        for (let page = 1; ; page++) {
-          const separator = path.includes('?') ? '&' : '?'
-          const batch = await this.json<T[]>(`${path}${separator}per_page=100&page=${page}`, accept, timeoutMs)
-          if (!Array.isArray(batch)) throw new Error('GitHub REST 分页返回格式无效')
-          values.push(...batch)
-          if (batch.length < 100) {
-            if (direct) this.counters.executions++
-            return values
-          }
-        }
-      } catch (error) {
-        if (direct) this.recordFailure(`GET ${path} (paginate)`, error)
-        throw error
-      } finally {
-        // scope closed by the wrapping run
-      }
-    })
+    const values: T[] = []
+    for (let page = 1; ; page++) {
+      const separator = path.includes('?') ? '&' : '?'
+      const batch = await this.json<T[]>(`${path}${separator}per_page=100&page=${page}`, accept, timeoutMs)
+      if (!Array.isArray(batch)) throw new Error('GitHub REST 分页返回格式无效')
+      values.push(...batch)
+      if (batch.length < 100) return values
+    }
   }
 
   async cachedResource<T>(
@@ -531,16 +529,14 @@ export class GithubRestReader {
     loader: () => Promise<T>,
     options: { ttlMs?: number; force?: boolean; versionOf?: (value: T) => string | null | undefined } = {},
   ): Promise<T> {
-    this.counters.logicalRequests++
     try {
       this.assertCircuitOpen()
     } catch (error) {
-      this.recordFailure(`access ${key}`, error)
+      this.recordFailure(`access ${key}`, error, key)
       throw error
     }
     const forcedPending = this.forcedResources.get(key) as Promise<T> | undefined
     if (!options.force && forcedPending) {
-      this.counters.singleflightJoins++
       return forcedPending
     }
     const knownVersion = version || null
@@ -552,7 +548,6 @@ export class GithubRestReader {
       cached.expiresAt > now &&
       (knownVersion === null || cached.version === knownVersion)
     ) {
-      this.counters.cacheHits++
       return cached.value
     }
     const load = this.withLoaderDepth(async () => {
@@ -569,6 +564,7 @@ export class GithubRestReader {
           expiresAt: Date.now() + (options.ttlMs ?? 30_000),
         })
         if (loadedVersion) this.versions.set(key, loadedVersion)
+        this.observeInvalidationsFor(key)
       }
       return value
     })
@@ -586,21 +582,20 @@ export class GithubRestReader {
   }
 
   async cachedAggregate<T>(key: string, ttlMs: number, force: boolean, loader: () => Promise<T>): Promise<T> {
-    this.counters.logicalRequests++
     try {
       this.assertCircuitOpen()
     } catch (error) {
-      this.recordFailure(`access ${key}`, error)
+      this.recordFailure(`access ${key}`, error, key)
       throw error
     }
     const cached = this.aggregates.get(key) as CachedValue<T> | undefined
     if (!force && cached && cached.expiresAt > Date.now()) {
-      this.counters.cacheHits++
       return cached.value
     }
     return this.deduplicate(`aggregate:${key}`, async () => {
       const value = await this.withLoaderDepth(loader)()
       this.aggregates.set(key, { value, version: null, expiresAt: Date.now() + ttlMs })
+      this.observeInvalidationsFor(key)
       return value
     })
   }
@@ -608,7 +603,6 @@ export class GithubRestReader {
   private async deduplicate<T>(key: string, loader: () => Promise<T>): Promise<T> {
     const pending = this.inFlight.get(key) as Promise<T> | undefined
     if (pending) {
-      this.counters.singleflightJoins++
       return pending
     }
     // `key` is an internal dedup handle (`resource:ordinary:…`); the scope
@@ -619,12 +613,18 @@ export class GithubRestReader {
     return created
   }
 
-  /** Leader outcome lands in exactly one bucket; joiners are already counted. */
+  private isComposed(): boolean {
+    return accessCompositionScope.getStore()?.composed === true
+  }
+
+  private withLoaderDepth<T>(loader: () => Promise<T>): () => Promise<T> {
+    return () => accessCompositionScope.run({ composed: true }, loader)
+  }
+
+  /** The access scope a leader failure surfaced through; evidence only (counters land with their consumers in slice B). */
   private async withOutcome<T>(scope: string, promise: Promise<T>): Promise<T> {
     try {
-      const value = await promise
-      this.counters.executions++
-      return value
+      return await promise
     } catch (error) {
       this.recordFailure(`access ${scope}`, error, scope)
       throw error

--- a/src/github/rest.ts
+++ b/src/github/rest.ts
@@ -481,11 +481,14 @@ export class GithubRestReader {
         logTaskDiagnostic('github-rate-circuit-trip', {
           kind,
           path,
-          // Bound to THIS response's observation (review round 5): unknown
-          // stays unknown; a prior response's bucket never leaks onto the
-          // trip event.
+          // Bound to THIS response's observation (review round 5/6): the
+          // resource stays unknown when the header is missing, a prior
+          // response's bucket never leaks — but the numeric budget fields
+          // this response DID carry are always persisted (review round 6:
+          // dropping the whole sample because one field is unknown erases
+          // known evidence).
           resource: currentSample.resource,
-          bucket: currentSample.resource !== null ? currentSample : null,
+          bucket: currentSample,
           retryAfter: response.headers.get('retry-after'),
           until: this.circuitUntil,
         })

--- a/src/github/rest.ts
+++ b/src/github/rest.ts
@@ -31,7 +31,8 @@ interface CachedValue<T> {
 
 /** One observed rate-limit sample from a single response (#133: every response records the bucket). */
 export interface RateLimitSample {
-  resource: string
+  /** null when the response carried no rate headers at all. */
+  resource: string | null
   limit: number | null
   remaining: number | null
   /** limit − remaining when both are known. */
@@ -376,14 +377,25 @@ export class GithubRestReader {
     }
   }
 
+  /**
+   * Every response leaves an observation (review round 4): present fields
+   * survive, missing ones are explicit null (unknown) — a partial-header or
+   * bare response is distinguishable from "no response happened" and never
+   * drops an already-seen bucket/limit/reset.
+   */
   private recordBudgetSnapshot(headers: Map<string, string>): void {
-    const remainingRaw = headers.get('x-ratelimit-remaining')
-    if (remainingRaw === undefined) return
-    const resetSeconds = Number(headers.get('x-ratelimit-reset'))
+    const hasAnyHeader = [
+      'x-ratelimit-remaining',
+      'x-ratelimit-limit',
+      'x-ratelimit-reset',
+      'x-ratelimit-resource',
+    ].some((name) => headers.get(name) !== undefined)
+    const resource = headers.get('x-ratelimit-resource') ?? (hasAnyHeader ? 'core' : null)
     const limitRaw = Number(headers.get('x-ratelimit-limit'))
-    const resource = headers.get('x-ratelimit-resource') ?? 'core'
+    const remainingRaw = Number(headers.get('x-ratelimit-remaining'))
+    const resetSeconds = Number(headers.get('x-ratelimit-reset'))
     const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : null
-    const remaining = Number.isFinite(Number(remainingRaw)) ? Number(remainingRaw) : null
+    const remaining = Number.isFinite(remainingRaw) ? Number(remainingRaw) : null
     const sample: RateLimitSample = {
       resource,
       limit,
@@ -396,7 +408,7 @@ export class GithubRestReader {
     if (this.evidence.rateLimitSamples.length > MAX_GATEWAY_EVIDENCE_RECORDS) {
       this.evidence.rateLimitSamples.splice(0, this.evidence.rateLimitSamples.length - MAX_GATEWAY_EVIDENCE_RECORDS)
     }
-    this.evidence.rateLimitBuckets[resource] = sample
+    if (resource !== null) this.evidence.rateLimitBuckets[resource] = sample
   }
 
   private async request(
@@ -534,8 +546,17 @@ export class GithubRestReader {
     const values: T[] = []
     for (let page = 1; ; page++) {
       const separator = path.includes('?') ? '&' : '?'
-      const batch = await this.json<T[]>(`${path}${separator}per_page=100&page=${page}`, accept, timeoutMs)
-      if (!Array.isArray(batch)) throw new Error('GitHub REST 分页返回格式无效')
+      const pagePath = `${path}${separator}per_page=100&page=${page}`
+      const batch = await this.json<T[]>(pagePath, accept, timeoutMs)
+      if (!Array.isArray(batch)) {
+        // The upstream child answered 2xx with the wrong shape: the raw page
+        // operation is the evidence (review round 4), at both levels — this
+        // access (or the composed wrapper's scope) plus the upstream GET.
+        const shapeFailure = new Error(`GitHub REST 分页返回格式无效: ${JSON.stringify(batch).slice(0, 120)}`)
+        this.recordUpstreamFailure(`GET ${pagePath}`, shapeFailure)
+        if (!this.isComposed()) this.recordFailure(`GET ${path} (paginate)`, shapeFailure, null)
+        throw shapeFailure
+      }
       values.push(...batch)
       if (batch.length < 100) return values
     }

--- a/src/github/rest.ts
+++ b/src/github/rest.ts
@@ -20,13 +20,15 @@ interface CachedValue<T> {
 }
 
 /**
- * Gateway evidence in the frozen #133 units (issue #131 slice A). Numeric
- * access counters (logical/hit/join/execution/wait) are deferred to the
- * slice that consumes them — the threshold assertions and scheduling of the
- * Gateway mechanism — per the concept-budget discipline; what ships here is
- * the evidence that already has production consumers: failures and
- * invalidations land in the persisted diagnostics channel, the per-response
- * rate-limit series feeds the circuit-trip diagnostic.
+ * Gateway evidence (issue #131 slice A). Numeric access counters
+ * (logical/hit/join/execution/wait) and in-memory rate series are deferred
+ * to the slice that consumes them — threshold assertions and scheduling of
+ * the Gateway mechanism — per the concept-budget discipline. What ships
+ * here is the evidence with production consumers now: two-level failure
+ * records (upstream operation + access scope) and invalidation records
+ * (generation, reason/trigger, observed completion) persist to the
+ * diagnostics channel, and the circuit-trip event carries the current
+ * response's rate-limit observation with unknown fields kept unknown.
  */
 
 /** One observed rate-limit sample from a single response (#133: every response records the bucket). */

--- a/src/github/rest.ts
+++ b/src/github/rest.ts
@@ -18,6 +18,47 @@ interface CachedValue<T> {
   expiresAt: number
 }
 
+/**
+ * Gateway access metrics in the frozen #133 units (issue #131 slice A):
+ * every logical request lands in exactly one of hit / join / execution /
+ * failure; upstream children, rate-limit budget snapshots, invalidations
+ * and queue waits are recorded alongside as evidence.
+ */
+export interface GithubAccessCounters {
+  logicalRequests: number
+  cacheHits: number
+  singleflightJoins: number
+  executions: number
+  failures: number
+  upstreamRequests: number
+  invalidations: number
+  waitCount: number
+  waitMsTotal: number
+  /** Last observed account budget from response headers. */
+  rateLimit: { resource: string; limit: number | null; remaining: number | null; reset: number | null } | null
+  failureRecords: Array<{ operation: string; message: string }>
+  invalidationRecords: string[]
+}
+
+const MAX_GATEWAY_EVIDENCE_RECORDS = 200
+
+function emptyCounters(): GithubAccessCounters {
+  return {
+    logicalRequests: 0,
+    cacheHits: 0,
+    singleflightJoins: 0,
+    executions: 0,
+    failures: 0,
+    upstreamRequests: 0,
+    invalidations: 0,
+    waitCount: 0,
+    waitMsTotal: 0,
+    rateLimit: null,
+    failureRecords: [],
+    invalidationRecords: [],
+  }
+}
+
 interface GithubReviewRest {
   id?: number
   user?: { login?: string } | null
@@ -163,6 +204,10 @@ export function deriveReviewDecision(reviews: GithubReviewRest[]): 'APPROVED' | 
 export class GithubRestReader {
   private readonly ctx: ShellContext
   private readonly minimumIntervalMs: number
+  private readonly now: () => number
+  readonly counters: GithubAccessCounters = emptyCounters()
+  /** >0 while a cached loader composes upstream calls for one already-counted intent. */
+  private loaderDepth = 0
   private readonly resources = new Map<string, CachedValue<unknown>>()
   private readonly aggregates = new Map<string, CachedValue<unknown>>()
   private readonly inFlight = new Map<string, Promise<unknown>>()
@@ -172,9 +217,32 @@ export class GithubRestReader {
   private circuitUntil = 0
   private circuitKind: GithubRateLimitKind = 'unknown'
 
-  constructor(ctx: ShellContext, options: { minimumIntervalMs?: number } = {}) {
+  constructor(ctx: ShellContext, options: { minimumIntervalMs?: number; now?: () => number } = {}) {
     this.ctx = ctx
     this.minimumIntervalMs = Math.max(0, options.minimumIntervalMs ?? HOST_GITHUB_MINIMUM_INTERVAL_MS)
+    this.now = options.now ?? Date.now
+  }
+
+  private recordFailure(operation: string, error: unknown): void {
+    this.counters.failures++
+    this.counters.failureRecords.push({
+      operation,
+      message: error instanceof Error ? error.message : String(error),
+    })
+    if (this.counters.failureRecords.length > MAX_GATEWAY_EVIDENCE_RECORDS) {
+      this.counters.failureRecords.splice(0, this.counters.failureRecords.length - MAX_GATEWAY_EVIDENCE_RECORDS)
+    }
+  }
+
+  private withLoaderDepth<T>(loader: () => Promise<T>): () => Promise<T> {
+    return async () => {
+      this.loaderDepth++
+      try {
+        return await loader()
+      } finally {
+        this.loaderDepth--
+      }
+    }
   }
 
   rateLimitError(now = Date.now()): GithubRateLimitError | null {
@@ -190,6 +258,14 @@ export class GithubRestReader {
   }
 
   invalidate(prefix: string): void {
+    this.counters.invalidations++
+    this.counters.invalidationRecords.push(prefix)
+    if (this.counters.invalidationRecords.length > MAX_GATEWAY_EVIDENCE_RECORDS) {
+      this.counters.invalidationRecords.splice(
+        0,
+        this.counters.invalidationRecords.length - MAX_GATEWAY_EVIDENCE_RECORDS,
+      )
+    }
     for (const key of this.resources.keys()) {
       if (key === prefix || key.startsWith(`${prefix}/`)) this.resources.delete(key)
     }
@@ -221,15 +297,37 @@ export class GithubRestReader {
     return stdout.text
   }
 
+  private recordBudgetSnapshot(headers: Map<string, string>): void {
+    const remainingRaw = headers.get('x-ratelimit-remaining')
+    if (remainingRaw === undefined) return
+    const resetSeconds = Number(headers.get('x-ratelimit-reset'))
+    const limitRaw = Number(headers.get('x-ratelimit-limit'))
+    this.counters.rateLimit = {
+      resource: headers.get('x-ratelimit-resource') ?? 'core',
+      limit: Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : null,
+      remaining: Number.isFinite(Number(remainingRaw)) ? Number(remainingRaw) : null,
+      reset: Number.isFinite(resetSeconds) && resetSeconds > 0 ? resetSeconds * 1000 : null,
+    }
+  }
+
   private async request(
     path: string,
     accept?: string,
     timeoutMs = 30_000,
     mutation?: { method: 'POST' | 'PATCH'; body: unknown },
   ): Promise<IncludedResponse> {
+    const enteredAt = this.now()
     return serializeGithubRequest(this.minimumIntervalMs, async () => {
       // A request queued before another resource trips the circuit must not hit GitHub afterwards.
       this.assertCircuitOpen()
+      // Queue wait (#133): access entry → physical dispatch. Service time
+      // after dispatch is not queue wait and is not accumulated here.
+      const waitMs = this.now() - enteredAt
+      if (waitMs > 0) {
+        this.counters.waitCount++
+        this.counters.waitMsTotal += waitMs
+      }
+      this.counters.upstreamRequests++
       const command = [
         'gh api --include',
         shellQuote(path),
@@ -264,6 +362,7 @@ export class GithubRestReader {
         if (result.exitCode !== 0) throw new Error(detail || `gh api 执行失败(exit ${result.exitCode})`)
         throw parseError
       }
+      this.recordBudgetSnapshot(response.headers)
       const detail = [result.stderr?.text, response.body].filter(Boolean).join('\n')
       if (isRateLimited(response, detail)) {
         this.circuitUntil = resetFrom(response.headers, Date.now())
@@ -295,31 +394,62 @@ export class GithubRestReader {
   }
 
   async json<T = unknown>(path: string, accept?: string, timeoutMs?: number): Promise<T> {
-    const response = await this.request(path, accept, timeoutMs)
+    const direct = this.loaderDepth === 0
+    if (direct) this.counters.logicalRequests++
     try {
-      return JSON.parse(response.body || 'null') as T
-    } catch {
-      throw new Error(`GitHub REST 返回了无效 JSON: ${path}`)
+      const response = await this.request(path, accept, timeoutMs)
+      try {
+        const parsed = JSON.parse(response.body || 'null') as T
+        if (direct) this.counters.executions++
+        return parsed
+      } catch {
+        throw new Error(`GitHub REST 返回了无效 JSON: ${path}`)
+      }
+    } catch (error) {
+      if (direct) this.recordFailure(`GET ${path}`, error)
+      throw error
     }
   }
 
   async mutate<T = unknown>(path: string, method: 'POST' | 'PATCH', body: unknown, timeoutMs?: number): Promise<T> {
-    const response = await this.request(path, undefined, timeoutMs, { method, body })
+    const direct = this.loaderDepth === 0
+    if (direct) this.counters.logicalRequests++
     try {
-      return JSON.parse(response.body || 'null') as T
-    } catch {
-      throw new Error(`GitHub REST 返回了无效 JSON: ${path}`)
+      const response = await this.request(path, undefined, timeoutMs, { method, body })
+      try {
+        const parsed = JSON.parse(response.body || 'null') as T
+        if (direct) this.counters.executions++
+        return parsed
+      } catch {
+        throw new Error(`GitHub REST 返回了无效 JSON: ${path}`)
+      }
+    } catch (error) {
+      if (direct) this.recordFailure(`${method} ${path}`, error)
+      throw error
     }
   }
 
   async paginate<T>(path: string, accept?: string, timeoutMs?: number): Promise<T[]> {
-    const values: T[] = []
-    for (let page = 1; ; page++) {
-      const separator = path.includes('?') ? '&' : '?'
-      const batch = await this.json<T[]>(`${path}${separator}per_page=100&page=${page}`, accept, timeoutMs)
-      if (!Array.isArray(batch)) throw new Error('GitHub REST 分页返回格式无效')
-      values.push(...batch)
-      if (batch.length < 100) return values
+    const direct = this.loaderDepth === 0
+    if (direct) this.counters.logicalRequests++
+    this.loaderDepth++
+    try {
+      const values: T[] = []
+      for (let page = 1; ; page++) {
+        const separator = path.includes('?') ? '&' : '?'
+        const batch = await this.json<T[]>(`${path}${separator}per_page=100&page=${page}`, accept, timeoutMs)
+        if (!Array.isArray(batch)) throw new Error('GitHub REST 分页返回格式无效')
+        values.push(...batch)
+        if (batch.length < 100) {
+          if (direct) this.counters.executions++
+          return values
+        }
+      }
+    } catch (error) {
+      if (direct) this.recordFailure(`GET ${path} (paginate)`, error)
+      throw error
+    } finally {
+      this.loaderDepth--
     }
   }
 
@@ -329,9 +459,18 @@ export class GithubRestReader {
     loader: () => Promise<T>,
     options: { ttlMs?: number; force?: boolean; versionOf?: (value: T) => string | null | undefined } = {},
   ): Promise<T> {
-    this.assertCircuitOpen()
+    this.counters.logicalRequests++
+    try {
+      this.assertCircuitOpen()
+    } catch (error) {
+      this.recordFailure(`access ${key}`, error)
+      throw error
+    }
     const forcedPending = this.forcedResources.get(key) as Promise<T> | undefined
-    if (!options.force && forcedPending) return forcedPending
+    if (!options.force && forcedPending) {
+      this.counters.singleflightJoins++
+      return forcedPending
+    }
     const knownVersion = version || null
     const cached = this.resources.get(key) as CachedValue<T> | undefined
     const now = Date.now()
@@ -340,9 +479,11 @@ export class GithubRestReader {
       cached &&
       cached.expiresAt > now &&
       (knownVersion === null || cached.version === knownVersion)
-    )
+    ) {
+      this.counters.cacheHits++
       return cached.value
-    const load = async () => {
+    }
+    const load = this.withLoaderDepth(async () => {
       const sequence = (this.resourceLoadSequence.get(key) ?? 0) + 1
       this.resourceLoadSequence.set(key, sequence)
       const value = await loader()
@@ -358,12 +499,12 @@ export class GithubRestReader {
         if (loadedVersion) this.versions.set(key, loadedVersion)
       }
       return value
-    }
+    })
     if (!options.force) return this.deduplicate(`resource:ordinary:${key}`, load)
 
     // `force` means fresh from this invocation point. It must not coalesce
     // with an earlier force call whose GitHub fact may already be obsolete.
-    const forced = load()
+    const forced = this.withOutcome(`access ${key}`, load())
     this.forcedResources.set(key, forced)
     const clear = () => {
       if (this.forcedResources.get(key) === forced) this.forcedResources.delete(key)
@@ -373,11 +514,20 @@ export class GithubRestReader {
   }
 
   async cachedAggregate<T>(key: string, ttlMs: number, force: boolean, loader: () => Promise<T>): Promise<T> {
-    this.assertCircuitOpen()
+    this.counters.logicalRequests++
+    try {
+      this.assertCircuitOpen()
+    } catch (error) {
+      this.recordFailure(`access ${key}`, error)
+      throw error
+    }
     const cached = this.aggregates.get(key) as CachedValue<T> | undefined
-    if (!force && cached && cached.expiresAt > Date.now()) return cached.value
+    if (!force && cached && cached.expiresAt > Date.now()) {
+      this.counters.cacheHits++
+      return cached.value
+    }
     return this.deduplicate(`aggregate:${key}`, async () => {
-      const value = await loader()
+      const value = await this.withLoaderDepth(loader)()
       this.aggregates.set(key, { value, version: null, expiresAt: Date.now() + ttlMs })
       return value
     })
@@ -385,10 +535,25 @@ export class GithubRestReader {
 
   private async deduplicate<T>(key: string, loader: () => Promise<T>): Promise<T> {
     const pending = this.inFlight.get(key) as Promise<T> | undefined
-    if (pending) return pending
-    const created = loader().finally(() => this.inFlight.delete(key))
+    if (pending) {
+      this.counters.singleflightJoins++
+      return pending
+    }
+    const created = this.withOutcome(`access ${key}`, loader()).finally(() => this.inFlight.delete(key))
     this.inFlight.set(key, created)
     return created
+  }
+
+  /** Leader outcome lands in exactly one bucket; joiners are already counted. */
+  private async withOutcome<T>(operation: string, promise: Promise<T>): Promise<T> {
+    try {
+      const value = await promise
+      this.counters.executions++
+      return value
+    } catch (error) {
+      this.recordFailure(operation, error)
+      throw error
+    }
   }
 }
 

--- a/src/github/rest.ts
+++ b/src/github/rest.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises'
+import { AsyncLocalStorage } from 'node:async_hooks'
 import { logTaskDiagnostic } from '../infra/task-diagnostics.ts'
 
 interface ShellContext {
@@ -24,6 +25,33 @@ interface CachedValue<T> {
  * failure; upstream children, rate-limit budget snapshots, invalidations
  * and queue waits are recorded alongside as evidence.
  */
+/** One observed rate-limit bucket from response headers (#133 unit: per resource). */
+export interface RateLimitBucketSnapshot {
+  resource: string
+  limit: number | null
+  remaining: number | null
+  /** limit − remaining when both are known. */
+  used: number | null
+  reset: number | null
+  observedAt: number
+}
+
+/** One failure evidence row: the raw upstream operation and/or the access scope it failed. */
+export interface AccessFailureRecord {
+  level: 'upstream' | 'access'
+  operation: string
+  message: string
+  scope: string | null
+}
+
+/** One invalidation evidence row (#133 unit: object, reason, triggering action, sequence). */
+export interface InvalidationRecord {
+  seq: number
+  prefix: string
+  reason: string | null
+  trigger: string | null
+}
+
 export interface GithubAccessCounters {
   logicalRequests: number
   cacheHits: number
@@ -34,10 +62,10 @@ export interface GithubAccessCounters {
   invalidations: number
   waitCount: number
   waitMsTotal: number
-  /** Last observed account budget from response headers. */
-  rateLimit: { resource: string; limit: number | null; remaining: number | null; reset: number | null } | null
-  failureRecords: Array<{ operation: string; message: string }>
-  invalidationRecords: string[]
+  /** Per-resource budget snapshots; every observed bucket survives (#133). */
+  rateLimitBuckets: Record<string, RateLimitBucketSnapshot>
+  failureRecords: AccessFailureRecord[]
+  invalidationRecords: InvalidationRecord[]
 }
 
 const MAX_GATEWAY_EVIDENCE_RECORDS = 200
@@ -53,7 +81,7 @@ function emptyCounters(): GithubAccessCounters {
     invalidations: 0,
     waitCount: 0,
     waitMsTotal: 0,
-    rateLimit: null,
+    rateLimitBuckets: {},
     failureRecords: [],
     invalidationRecords: [],
   }
@@ -76,6 +104,15 @@ interface HostGithubRequestLane {
   tail: Promise<void>
   nextStartAt: number
 }
+
+/**
+ * Per-intent composition scope (review finding 1): marks upstream calls a
+ * cached loader composes for one already-counted access. Instance-level
+ * state leaked across concurrent accesses — a sibling direct request was
+ * misclassified and its logical intent vanished. Async context is isolated
+ * per access chain, including across awaits.
+ */
+const accessCompositionScope = new AsyncLocalStorage<{ composed: boolean }>()
 
 const HOST_GITHUB_MINIMUM_INTERVAL_MS = 250
 const hostGithubLaneSymbol = Symbol.for('clickvibe.github-request-lane')
@@ -206,8 +243,7 @@ export class GithubRestReader {
   private readonly minimumIntervalMs: number
   private readonly now: () => number
   readonly counters: GithubAccessCounters = emptyCounters()
-  /** >0 while a cached loader composes upstream calls for one already-counted intent. */
-  private loaderDepth = 0
+  private invalidationSeq = 0
   private readonly resources = new Map<string, CachedValue<unknown>>()
   private readonly aggregates = new Map<string, CachedValue<unknown>>()
   private readonly inFlight = new Map<string, Promise<unknown>>()
@@ -223,26 +259,47 @@ export class GithubRestReader {
     this.now = options.now ?? Date.now
   }
 
-  private recordFailure(operation: string, error: unknown): void {
+  private recordFailure(operation: string, error: unknown, scope: string | null = null): void {
     this.counters.failures++
-    this.counters.failureRecords.push({
+    this.pushFailureRecord({
+      level: 'access',
       operation,
+      scope,
       message: error instanceof Error ? error.message : String(error),
     })
+  }
+
+  /** Raw upstream evidence: retained even when the access layer already recorded the failure. */
+  private recordUpstreamFailure(operation: string, error: unknown): void {
+    this.pushFailureRecord({
+      level: 'upstream',
+      operation,
+      scope: null,
+      message: error instanceof Error ? error.message : String(error),
+    })
+  }
+
+  private pushFailureRecord(record: AccessFailureRecord): void {
+    this.counters.failureRecords.push(record)
     if (this.counters.failureRecords.length > MAX_GATEWAY_EVIDENCE_RECORDS) {
       this.counters.failureRecords.splice(0, this.counters.failureRecords.length - MAX_GATEWAY_EVIDENCE_RECORDS)
     }
+    // Production consumer + 错误不埋葬: failures land in the persisted
+    // diagnostics channel the panel can query.
+    logTaskDiagnostic('github-access-failure', {
+      level: record.level,
+      operation: record.operation,
+      scope: record.scope,
+      message: record.message,
+    })
   }
 
   private withLoaderDepth<T>(loader: () => Promise<T>): () => Promise<T> {
-    return async () => {
-      this.loaderDepth++
-      try {
-        return await loader()
-      } finally {
-        this.loaderDepth--
-      }
-    }
+    return () => accessCompositionScope.run({ composed: true }, loader)
+  }
+
+  private isComposed(): boolean {
+    return accessCompositionScope.getStore()?.composed === true
   }
 
   rateLimitError(now = Date.now()): GithubRateLimitError | null {
@@ -257,15 +314,18 @@ export class GithubRestReader {
     return this.versions.get(key) ?? null
   }
 
-  invalidate(prefix: string): void {
+  invalidate(prefix: string, reason: string | null = null, trigger: string | null = null): void {
     this.counters.invalidations++
-    this.counters.invalidationRecords.push(prefix)
+    this.invalidationSeq++
+    const record = { seq: this.invalidationSeq, prefix, reason, trigger }
+    this.counters.invalidationRecords.push(record)
     if (this.counters.invalidationRecords.length > MAX_GATEWAY_EVIDENCE_RECORDS) {
       this.counters.invalidationRecords.splice(
         0,
         this.counters.invalidationRecords.length - MAX_GATEWAY_EVIDENCE_RECORDS,
       )
     }
+    logTaskDiagnostic('github-rest-invalidation', { ...record })
     for (const key of this.resources.keys()) {
       if (key === prefix || key.startsWith(`${prefix}/`)) this.resources.delete(key)
     }
@@ -302,11 +362,16 @@ export class GithubRestReader {
     if (remainingRaw === undefined) return
     const resetSeconds = Number(headers.get('x-ratelimit-reset'))
     const limitRaw = Number(headers.get('x-ratelimit-limit'))
-    this.counters.rateLimit = {
-      resource: headers.get('x-ratelimit-resource') ?? 'core',
-      limit: Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : null,
-      remaining: Number.isFinite(Number(remainingRaw)) ? Number(remainingRaw) : null,
+    const resource = headers.get('x-ratelimit-resource') ?? 'core'
+    const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : null
+    const remaining = Number.isFinite(Number(remainingRaw)) ? Number(remainingRaw) : null
+    this.counters.rateLimitBuckets[resource] = {
+      resource,
+      limit,
+      remaining,
+      used: limit !== null && remaining !== null ? limit - remaining : null,
       reset: Number.isFinite(resetSeconds) && resetSeconds > 0 ? resetSeconds * 1000 : null,
+      observedAt: this.now(),
     }
   }
 
@@ -363,8 +428,10 @@ export class GithubRestReader {
         throw parseError
       }
       this.recordBudgetSnapshot(response.headers)
+      const requestOperation = `${mutation?.method ?? 'GET'} ${path}`
       const detail = [result.stderr?.text, response.body].filter(Boolean).join('\n')
       if (isRateLimited(response, detail)) {
+        this.recordUpstreamFailure(requestOperation, new GithubRateLimitError(resetFrom(response.headers, Date.now())))
         this.circuitUntil = resetFrom(response.headers, Date.now())
         const kind: GithubRateLimitKind =
           response.headers.get('x-ratelimit-remaining') === '0' ? 'primary' : 'secondary'
@@ -380,6 +447,10 @@ export class GithubRestReader {
         throw new GithubRateLimitError(this.circuitUntil, kind)
       }
       if (result.exitCode !== 0 || response.status < 200 || response.status >= 300) {
+        this.recordUpstreamFailure(
+          requestOperation,
+          new Error(`GitHub REST ${response.status}: ${response.body.trim() || result.stderr?.text || '请求失败'}`),
+        )
         let message = response.body.trim()
         try {
           const parsed = JSON.parse(response.body) as { message?: unknown }
@@ -394,7 +465,7 @@ export class GithubRestReader {
   }
 
   async json<T = unknown>(path: string, accept?: string, timeoutMs?: number): Promise<T> {
-    const direct = this.loaderDepth === 0
+    const direct = !this.isComposed()
     if (direct) this.counters.logicalRequests++
     try {
       const response = await this.request(path, accept, timeoutMs)
@@ -412,7 +483,7 @@ export class GithubRestReader {
   }
 
   async mutate<T = unknown>(path: string, method: 'POST' | 'PATCH', body: unknown, timeoutMs?: number): Promise<T> {
-    const direct = this.loaderDepth === 0
+    const direct = !this.isComposed()
     if (direct) this.counters.logicalRequests++
     try {
       const response = await this.request(path, undefined, timeoutMs, { method, body })
@@ -430,27 +501,28 @@ export class GithubRestReader {
   }
 
   async paginate<T>(path: string, accept?: string, timeoutMs?: number): Promise<T[]> {
-    const direct = this.loaderDepth === 0
+    const direct = !this.isComposed()
     if (direct) this.counters.logicalRequests++
-    this.loaderDepth++
-    try {
-      const values: T[] = []
-      for (let page = 1; ; page++) {
-        const separator = path.includes('?') ? '&' : '?'
-        const batch = await this.json<T[]>(`${path}${separator}per_page=100&page=${page}`, accept, timeoutMs)
-        if (!Array.isArray(batch)) throw new Error('GitHub REST 分页返回格式无效')
-        values.push(...batch)
-        if (batch.length < 100) {
-          if (direct) this.counters.executions++
-          return values
+    return accessCompositionScope.run({ composed: true }, async () => {
+      try {
+        const values: T[] = []
+        for (let page = 1; ; page++) {
+          const separator = path.includes('?') ? '&' : '?'
+          const batch = await this.json<T[]>(`${path}${separator}per_page=100&page=${page}`, accept, timeoutMs)
+          if (!Array.isArray(batch)) throw new Error('GitHub REST 分页返回格式无效')
+          values.push(...batch)
+          if (batch.length < 100) {
+            if (direct) this.counters.executions++
+            return values
+          }
         }
+      } catch (error) {
+        if (direct) this.recordFailure(`GET ${path} (paginate)`, error)
+        throw error
+      } finally {
+        // scope closed by the wrapping run
       }
-    } catch (error) {
-      if (direct) this.recordFailure(`GET ${path} (paginate)`, error)
-      throw error
-    } finally {
-      this.loaderDepth--
-    }
+    })
   }
 
   async cachedResource<T>(
@@ -504,7 +576,7 @@ export class GithubRestReader {
 
     // `force` means fresh from this invocation point. It must not coalesce
     // with an earlier force call whose GitHub fact may already be obsolete.
-    const forced = this.withOutcome(`access ${key}`, load())
+    const forced = this.withOutcome(key, load())
     this.forcedResources.set(key, forced)
     const clear = () => {
       if (this.forcedResources.get(key) === forced) this.forcedResources.delete(key)
@@ -539,19 +611,22 @@ export class GithubRestReader {
       this.counters.singleflightJoins++
       return pending
     }
-    const created = this.withOutcome(`access ${key}`, loader()).finally(() => this.inFlight.delete(key))
+    // `key` is an internal dedup handle (`resource:ordinary:…`); the scope
+    // carried in evidence is the access key without the handle prefix.
+    const scope = key.replace(/^(?:resource:ordinary:|aggregate:)/, '')
+    const created = this.withOutcome(scope, loader()).finally(() => this.inFlight.delete(key))
     this.inFlight.set(key, created)
     return created
   }
 
   /** Leader outcome lands in exactly one bucket; joiners are already counted. */
-  private async withOutcome<T>(operation: string, promise: Promise<T>): Promise<T> {
+  private async withOutcome<T>(scope: string, promise: Promise<T>): Promise<T> {
     try {
       const value = await promise
       this.counters.executions++
       return value
     } catch (error) {
-      this.recordFailure(operation, error)
+      this.recordFailure(`access ${scope}`, error, scope)
       throw error
     }
   }

--- a/src/github/rest.ts
+++ b/src/github/rest.ts
@@ -64,10 +64,6 @@ export interface InvalidationRecord {
 }
 
 export interface GithubAccessEvidence {
-  /** Append-only per-response series (capped); same-bucket responses never overwrite each other. */
-  rateLimitSamples: RateLimitSample[]
-  /** Latest snapshot per resource bucket; consumed by the circuit-trip diagnostic. */
-  rateLimitBuckets: Record<string, RateLimitSample>
   failureRecords: AccessFailureRecord[]
   invalidationRecords: InvalidationRecord[]
 }
@@ -76,8 +72,6 @@ const MAX_GATEWAY_EVIDENCE_RECORDS = 200
 
 function emptyEvidence(): GithubAccessEvidence {
   return {
-    rateLimitSamples: [],
-    rateLimitBuckets: {},
     failureRecords: [],
     invalidationRecords: [],
   }
@@ -392,7 +386,7 @@ export class GithubRestReader {
     const resetSeconds = Number(headers.get('x-ratelimit-reset'))
     const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : null
     const remaining = Number.isFinite(remainingRaw) ? Number(remainingRaw) : null
-    const sample: RateLimitSample = {
+    return {
       resource,
       limit,
       remaining,
@@ -400,12 +394,6 @@ export class GithubRestReader {
       reset: Number.isFinite(resetSeconds) && resetSeconds > 0 ? resetSeconds * 1000 : null,
       observedAt: this.now(),
     }
-    this.evidence.rateLimitSamples.push(sample)
-    if (this.evidence.rateLimitSamples.length > MAX_GATEWAY_EVIDENCE_RECORDS) {
-      this.evidence.rateLimitSamples.splice(0, this.evidence.rateLimitSamples.length - MAX_GATEWAY_EVIDENCE_RECORDS)
-    }
-    if (resource !== null) this.evidence.rateLimitBuckets[resource] = sample
-    return sample
   }
 
   private async request(

--- a/src/infra/diagnostic-log-store.ts
+++ b/src/infra/diagnostic-log-store.ts
@@ -86,8 +86,18 @@ export async function waitForDiagnosticLines(root: string, workflowKey: unknown)
  */
 export async function waitForAllDiagnosticLines(root: string): Promise<void> {
   const prefix = `${root}/`
-  for (const path of [...logQueues.keys()]) {
-    if (path === root || path.startsWith(prefix)) {
+  // Re-enumerate until a full pass finds no queue under this root: streams
+  // registered while an earlier pass was awaiting must be observed too
+  // (review round 9 — a single entry snapshot lets a late scoped write
+  // resurrect a deleted root).
+  // Re-enumerate until a full pass finds no queue under this root: streams
+  // registered while an earlier pass was awaiting must be observed too
+  // (review round 9 — a single entry snapshot lets a late scoped write
+  // resurrect a deleted root).
+  for (;;) {
+    const pending = [...logQueues.keys()].filter((path) => path === root || path.startsWith(prefix))
+    if (pending.length === 0) return
+    for (const path of pending) {
       while (logQueues.has(path)) {
         await logQueues.get(path)?.catch(() => undefined)
       }

--- a/src/infra/diagnostic-log-store.ts
+++ b/src/infra/diagnostic-log-store.ts
@@ -77,3 +77,20 @@ export async function waitForDiagnosticLines(root: string, workflowKey: unknown)
     await logQueues.get(path)?.catch(() => undefined)
   }
 }
+
+/**
+ * Drain every diagnostic stream under one root (review round 8): teardown
+ * must wait for global AND workflow-scoped writes — a root-scoped drain is
+ * the only caller-correct wait when a test removes the whole temp HOME.
+ * Streams registered under other roots are untouched.
+ */
+export async function waitForAllDiagnosticLines(root: string): Promise<void> {
+  const prefix = `${root}/`
+  for (const path of [...logQueues.keys()]) {
+    if (path === root || path.startsWith(prefix)) {
+      while (logQueues.has(path)) {
+        await logQueues.get(path)?.catch(() => undefined)
+      }
+    }
+  }
+}

--- a/src/infra/task-diagnostics.ts
+++ b/src/infra/task-diagnostics.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from 'node:crypto'
-import { appendDiagnosticLine, DEFAULT_DIAGNOSTIC_MAX_BYTES, waitForDiagnosticLines } from './diagnostic-log-store.ts'
+import {
+  appendDiagnosticLine,
+  DEFAULT_DIAGNOSTIC_MAX_BYTES,
+  waitForAllDiagnosticLines,
+  waitForDiagnosticLines,
+} from './diagnostic-log-store.ts'
 import { loadConfig } from './runtime.ts'
 import { stateDir } from './state.ts'
 
@@ -30,4 +35,9 @@ export function logTaskDiagnostic(event: string, fields: Record<string, unknown>
 /** Await best-effort writes before a task releases or deletes its persistence directory. */
 export function waitForTaskDiagnosticPersistence(workflowKey: unknown): Promise<void> {
   return waitForDiagnosticLines(stateDir(), workflowKey)
+}
+
+/** Await ALL writes under the current state root (global + workflow-scoped) before teardown. */
+export function waitForAllTaskDiagnostics(): Promise<void> {
+  return waitForAllDiagnosticLines(stateDir())
 }

--- a/src/workflow/delivery-publish.ts
+++ b/src/workflow/delivery-publish.ts
@@ -28,8 +28,14 @@ export async function publishDeliveryComment(
       ...(commentUrl ? { url: commentUrl } : {}),
     }
     const number = workflow.prNumber ?? parseUrl(workflow.url)?.number
-    if (number) githubRest(ctx).invalidate(`${workflow.repoKey}/${target === 'pr' ? 'pulls' : 'issues'}/${number}`)
-    githubRest(ctx).invalidate(`repo:${workflow.repoKey}`)
+    if (number) {
+      githubRest(ctx).invalidate(
+        `${workflow.repoKey}/${target === 'pr' ? 'pulls' : 'issues'}/${number}`,
+        'comment-published',
+        'publishDeliveryComment',
+      )
+    }
+    githubRest(ctx).invalidate(`repo:${workflow.repoKey}`, 'comment-published', 'publishDeliveryComment')
     await appendLog(
       workflow.key,
       event.kind === 'review' ? 'review' : 'dev',

--- a/src/workflow/merge.ts
+++ b/src/workflow/merge.ts
@@ -386,8 +386,8 @@ export async function mergeAndCleanupUnlocked(ctx: Context, payload: unknown): P
       ].join(' ')
       try {
         await runCommand(ctx, command, { timeoutMs: 120_000 })
-        githubRest(ctx).invalidate(`${repoKey}/pulls/${pr.number}`)
-        githubRest(ctx).invalidate(`repo:${repoKey}`)
+        githubRest(ctx).invalidate(`${repoKey}/pulls/${pr.number}`, 'pr-merged', 'mergeAndCleanup')
+        githubRest(ctx).invalidate(`repo:${repoKey}`, 'pr-merged', 'mergeAndCleanup')
       } catch (error) {
         return { ok: false, error: `PR 合并失败: ${String(error instanceof Error ? error.message : error)}` }
       }
@@ -509,8 +509,8 @@ export async function mergeAndCleanupUnlocked(ctx: Context, payload: unknown): P
           `gh issue close ${shellQuote(parsed.number)} --repo ${shellQuote(repoKey)} --comment ${shellQuote(`由 PR #${pr.number} 以 merge commit 合并交付。`)}`,
           { timeoutMs: 30_000 },
         )
-        githubRest(ctx).invalidate(`${repoKey}/issues/${parsed.number}`)
-        githubRest(ctx).invalidate(`repo:${repoKey}`)
+        githubRest(ctx).invalidate(`${repoKey}/issues/${parsed.number}`, 'issue-closed', 'mergeAndCleanup')
+        githubRest(ctx).invalidate(`repo:${repoKey}`, 'issue-closed', 'mergeAndCleanup')
       }
       workflow.issueState = 'CLOSED'
       delivery.cleanup.issue = true

--- a/src/workflow/repository-state.ts
+++ b/src/workflow/repository-state.ts
@@ -266,8 +266,8 @@ export async function maintainCompletedDependencyLedger(
       return { issue, updated: false }
     }
     const updated = await rest.mutate<RepositoryIssueRest>(`repos/${repoKey}/issues/${issue.number}`, 'PATCH', { body })
-    rest.invalidate(`repo:${repoKey}`)
-    rest.invalidate(`${repoKey}/issues/${issue.number}`)
+    rest.invalidate(`repo:${repoKey}`, 'dependency-unlocked', 'maintainCompletedDependencyLedger')
+    rest.invalidate(`${repoKey}/issues/${issue.number}`, 'dependency-unlocked', 'maintainCompletedDependencyLedger')
     dependencyLedgerRetryGate.succeed(retryKey)
     return {
       issue: {

--- a/tests/develop-baseline-preview.test.ts
+++ b/tests/develop-baseline-preview.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { waitForTaskDiagnosticPersistence } from '../src/infra/task-diagnostics.ts'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -50,6 +51,7 @@ test('baseline preview validates URLs and degrades an unconfigured repository on
       /无法在未配置的本地仓库中验证/,
     )
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(home, { recursive: true, force: true })
@@ -82,6 +84,7 @@ test('baseline preview exposes fetch failure for the default but rejects an unve
       /offline/,
     )
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(home, { recursive: true, force: true })
@@ -138,6 +141,7 @@ test('baseline preview excludes and rejects the current issue development branch
       /默认分支指向当前 Issue 开发分支/,
     )
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(home, { recursive: true, force: true })
@@ -186,6 +190,7 @@ test('frozen issue-branch preview skips self-dependencies and ignores a closed p
     const warning = await developBaselinePreview(rateLimited as never, workflow('7', '').url, undefined)
     assert.match(warning.baselineWarning ?? '', /无法确认基线关联 Issue #5.*GitHub 额度已用完/)
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(home, { recursive: true, force: true })

--- a/tests/develop-baseline-preview.test.ts
+++ b/tests/develop-baseline-preview.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { waitForTaskDiagnosticPersistence } from '../src/infra/task-diagnostics.ts'
+import { waitForAllTaskDiagnostics } from '../src/infra/task-diagnostics.ts'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -51,7 +51,7 @@ test('baseline preview validates URLs and degrades an unconfigured repository on
       /无法在未配置的本地仓库中验证/,
     )
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(home, { recursive: true, force: true })
@@ -84,7 +84,7 @@ test('baseline preview exposes fetch failure for the default but rejects an unve
       /offline/,
     )
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(home, { recursive: true, force: true })
@@ -141,7 +141,7 @@ test('baseline preview excludes and rejects the current issue development branch
       /默认分支指向当前 Issue 开发分支/,
     )
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(home, { recursive: true, force: true })
@@ -190,7 +190,7 @@ test('frozen issue-branch preview skips self-dependencies and ignores a closed p
     const warning = await developBaselinePreview(rateLimited as never, workflow('7', '').url, undefined)
     assert.match(warning.baselineWarning ?? '', /无法确认基线关联 Issue #5.*GitHub 额度已用完/)
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(home, { recursive: true, force: true })

--- a/tests/diagnostic-teardown.test.ts
+++ b/tests/diagnostic-teardown.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Deterministic teardown interactions (issue #131 slice A, review round 8):
+ * a root-scoped drain must cover every stream under the temp HOME — global
+ * and workflow-scoped — including writes queued behind a record the test
+ * already saw. Both regressions gate production queue ordering, not timing.
+ */
+import assert from 'node:assert/strict'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import {
+  appendDiagnosticLine,
+  DEFAULT_DIAGNOSTIC_MAX_BYTES,
+  waitForAllDiagnosticLines,
+  waitForDiagnosticLines,
+} from '../src/infra/diagnostic-log-store.ts'
+import { parseIssueKey } from '../src/infra/state-layout.ts'
+
+function issueRoot(root: string, key: string): string {
+  const coordinates = parseIssueKey(key)
+  assert.ok(coordinates, 'fixture key must be a workflow key')
+  return join(root, coordinates.owner, coordinates.repo, `issue-${coordinates.issue}`)
+}
+
+test('trailing write queued behind a visible record cannot resurrect a drained root', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'clickvibe-drain-trail-'))
+  const previousHome = process.env.HOME
+  process.env.HOME = home
+  try {
+    let releaseMiddle!: () => void
+    const middleGate = new Promise<void>((resolve) => {
+      releaseMiddle = resolve
+    })
+
+    // A first completed write, then a gated middle write, then a trailing
+    // write queued behind it (the access-level failure after the trip).
+    await appendDiagnosticLine(home, undefined, 'first', Promise.resolve(DEFAULT_DIAGNOSTIC_MAX_BYTES))
+    const middle = appendDiagnosticLine(home, undefined, 'middle', Promise.resolve(DEFAULT_DIAGNOSTIC_MAX_BYTES)).then(
+      () => middleGate,
+    )
+    void middle.then(
+      () => undefined,
+      () => undefined,
+    )
+    const trailing = appendDiagnosticLine(home, undefined, 'trailing', Promise.resolve(DEFAULT_DIAGNOSTIC_MAX_BYTES))
+    void trailing.then(
+      () => undefined,
+      () => undefined,
+    )
+
+    // The middle record becomes visible; the test would return here and tear
+    // down — but the trailing write is still queued behind the gate.
+    void middle.then(() => releaseMiddle())
+    await waitForDiagnosticLines(home, undefined)
+      .then(() => undefined)
+      .catch(() => undefined)
+    // Gate stays closed: simulate the teardown path BEFORE the trailing write
+    // completes would race — so prove the drain waits for it.
+    const drained = waitForAllDiagnosticLines(home)
+    releaseMiddle()
+    await drained
+
+    await waitForAllTaskDiagnosticsSafe()
+    rmSync(home, { recursive: true, force: true })
+    assert.equal(existsSync(home), false, 'the root must stay deleted — no trailing resurrection')
+  } finally {
+    process.env.HOME = previousHome
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('root drain also waits for workflow-scoped writes under the same root', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'clickvibe-drain-scoped-'))
+  const previousHome = process.env.HOME
+  process.env.HOME = home
+  const workflowKey = 'issue-YWktZGFtaW5nL2NsaWNrdmliZQ-77' // ai-daming/clickvibe#77
+  try {
+    let releaseScoped!: () => void
+    const scopedGate = new Promise<void>((resolve) => {
+      releaseScoped = resolve
+    })
+
+    // Global write completes; the workflow-scoped write is still queued.
+    await appendDiagnosticLine(home, undefined, 'global', Promise.resolve(DEFAULT_DIAGNOSTIC_MAX_BYTES))
+    const scoped = appendDiagnosticLine(
+      issueRoot(home, workflowKey),
+      workflowKey,
+      'scoped',
+      Promise.resolve(DEFAULT_DIAGNOSTIC_MAX_BYTES),
+    ).then(() => scopedGate)
+    void scoped.then(
+      () => undefined,
+      () => undefined,
+    )
+
+    // waitForDiagnosticLines(root, undefined) resolves while the scoped write
+    // is pending — exactly the old drain's blind spot.
+    const globalOnly = waitForDiagnosticLines(home, undefined)
+      .then(() => undefined)
+      .catch(() => undefined)
+    const drained = waitForAllDiagnosticLines(home)
+    releaseScoped()
+    await Promise.all([globalOnly, drained])
+
+    await waitForAllTaskDiagnosticsSafe()
+    rmSync(home, { recursive: true, force: true })
+    assert.equal(existsSync(home), false, 'the root must stay deleted — no scoped resurrection')
+  } finally {
+    process.env.HOME = previousHome
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+async function waitForAllTaskDiagnosticsSafe(): Promise<void> {
+  const { waitForAllTaskDiagnostics } = await import('../src/infra/task-diagnostics.ts')
+  await waitForAllTaskDiagnostics().catch(() => undefined)
+}

--- a/tests/diagnostic-teardown.test.ts
+++ b/tests/diagnostic-teardown.test.ts
@@ -1,11 +1,13 @@
 /**
- * Deterministic teardown interactions (issue #131 slice A, review round 8):
- * a root-scoped drain must cover every stream under the temp HOME — global
- * and workflow-scoped — including writes queued behind a record the test
- * already saw. Both regressions gate production queue ordering, not timing.
+ * Deterministic teardown interactions (issue #131 slice A, reviews 8-9):
+ * a root-scoped drain must reach a fixed point over every stream under the
+ * temp HOME — including streams registered while the drain is already
+ * waiting — and all gating happens INSIDE the production queue via the
+ * pending `maxBytes` promise (gates chained after the returned promise are
+ * outside the queue and prove nothing).
  */
 import assert from 'node:assert/strict'
-import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { test } from 'node:test'
@@ -13,106 +15,149 @@ import {
   appendDiagnosticLine,
   DEFAULT_DIAGNOSTIC_MAX_BYTES,
   waitForAllDiagnosticLines,
-  waitForDiagnosticLines,
 } from '../src/infra/diagnostic-log-store.ts'
-import { parseIssueKey } from '../src/infra/state-layout.ts'
+import { diagnosticLogPath } from '../src/infra/state-layout.ts'
 
-function issueRoot(root: string, key: string): string {
-  const coordinates = parseIssueKey(key)
-  assert.ok(coordinates, 'fixture key must be a workflow key')
-  return join(root, coordinates.owner, coordinates.repo, `issue-${coordinates.issue}`)
+const WORKFLOW_KEY = 'issue-YWktZGFtaW5nL2NsaWNrdmliZQ-77' // ai-daming/clickvibe#77
+
+/** Gate INSIDE the production queue: the append's operation cannot start until the gate opens. */
+function gatedAppend(root: string, workflowKey: unknown, line: string, gate: Promise<void>): Promise<void> {
+  return appendDiagnosticLine(
+    root,
+    workflowKey,
+    line,
+    gate.then(() => DEFAULT_DIAGNOSTIC_MAX_BYTES),
+  )
 }
 
-test('trailing write queued behind a visible record cannot resurrect a drained root', async () => {
+function assertNoLine(root: string, workflowKey: unknown, needle: string): void {
+  const path = diagnosticLogPath(root, workflowKey)
+  const text = existsSync(path) ? readFileSync(path, 'utf8') : ''
+  assert.ok(!text.includes(needle), `line "${needle}" must still be queued, not on disk`)
+}
+
+test('same-path trailing write stays inside the queue until the drain observes it', async () => {
   const home = mkdtempSync(join(tmpdir(), 'clickvibe-drain-trail-'))
   const previousHome = process.env.HOME
   process.env.HOME = home
   try {
+    await appendDiagnosticLine(home, undefined, 'first', DEFAULT_DIAGNOSTIC_MAX_BYTES)
+
     let releaseMiddle!: () => void
     const middleGate = new Promise<void>((resolve) => {
       releaseMiddle = resolve
     })
+    const middle = gatedAppend(home, undefined, 'middle', middleGate)
 
-    // A first completed write, then a gated middle write, then a trailing
-    // write queued behind it (the access-level failure after the trip).
-    await appendDiagnosticLine(home, undefined, 'first', Promise.resolve(DEFAULT_DIAGNOSTIC_MAX_BYTES))
-    const middle = appendDiagnosticLine(home, undefined, 'middle', Promise.resolve(DEFAULT_DIAGNOSTIC_MAX_BYTES)).then(
-      () => middleGate,
-    )
-    void middle.then(
-      () => undefined,
-      () => undefined,
-    )
-    const trailing = appendDiagnosticLine(home, undefined, 'trailing', Promise.resolve(DEFAULT_DIAGNOSTIC_MAX_BYTES))
-    void trailing.then(
-      () => undefined,
-      () => undefined,
-    )
+    let releaseTrailing!: () => void
+    const trailingGate = new Promise<void>((resolve) => {
+      releaseTrailing = resolve
+    })
+    // The trailing write queues behind the gated middle one — same path, so
+    // it cannot touch disk before middle completes (production queue order).
+    const trailing = gatedAppend(home, undefined, 'trailing', trailingGate)
 
-    // The middle record becomes visible; the test would return here and tear
-    // down — but the trailing write is still queued behind the gate.
-    void middle.then(() => releaseMiddle())
-    await waitForDiagnosticLines(home, undefined)
-      .then(() => undefined)
-      .catch(() => undefined)
-    // Gate stays closed: simulate the teardown path BEFORE the trailing write
-    // completes would race — so prove the drain waits for it.
+    await new Promise((resolve) => setImmediate(resolve))
+    assertNoLine(home, undefined, 'trailing')
+
     const drained = waitForAllDiagnosticLines(home)
+    await new Promise((resolve) => setImmediate(resolve))
+    assertNoLine(home, undefined, 'trailing', 'still queued while the middle gate holds the stream')
     releaseMiddle()
-    await drained
+    await new Promise((resolve) => setImmediate(resolve))
+    assertNoLine(home, undefined, 'trailing', 'still queued behind its own gate')
+    releaseTrailing()
+    await Promise.all([middle, trailing, drained])
 
-    await waitForAllTaskDiagnosticsSafe()
     rmSync(home, { recursive: true, force: true })
-    assert.equal(existsSync(home), false, 'the root must stay deleted — no trailing resurrection')
+    assert.equal(existsSync(home), false, 'no trailing resurrection after the drain')
   } finally {
     process.env.HOME = previousHome
     rmSync(home, { recursive: true, force: true })
   }
 })
 
-test('root drain also waits for workflow-scoped writes under the same root', async () => {
+test('pre-existing workflow-scoped stream under the same root is drained', async () => {
   const home = mkdtempSync(join(tmpdir(), 'clickvibe-drain-scoped-'))
   const previousHome = process.env.HOME
   process.env.HOME = home
-  const workflowKey = 'issue-YWktZGFtaW5nL2NsaWNrdmliZQ-77' // ai-daming/clickvibe#77
   try {
+    await appendDiagnosticLine(home, undefined, 'global', DEFAULT_DIAGNOSTIC_MAX_BYTES)
+
     let releaseScoped!: () => void
     const scopedGate = new Promise<void>((resolve) => {
       releaseScoped = resolve
     })
+    const scopedPath = diagnosticLogPath(home, WORKFLOW_KEY)
+    assert.ok(scopedPath.startsWith(join(home, '')), 'production shape: state root + workflowKey')
+    const scoped = gatedAppend(home, WORKFLOW_KEY, 'scoped', scopedGate)
+    await new Promise((resolve) => setImmediate(resolve))
+    assertNoLine(home, WORKFLOW_KEY, 'scoped')
 
-    // Global write completes; the workflow-scoped write is still queued.
-    await appendDiagnosticLine(home, undefined, 'global', Promise.resolve(DEFAULT_DIAGNOSTIC_MAX_BYTES))
-    const scoped = appendDiagnosticLine(
-      issueRoot(home, workflowKey),
-      workflowKey,
-      'scoped',
-      Promise.resolve(DEFAULT_DIAGNOSTIC_MAX_BYTES),
-    ).then(() => scopedGate)
-    void scoped.then(
-      () => undefined,
-      () => undefined,
-    )
-
-    // waitForDiagnosticLines(root, undefined) resolves while the scoped write
-    // is pending — exactly the old drain's blind spot.
-    const globalOnly = waitForDiagnosticLines(home, undefined)
-      .then(() => undefined)
-      .catch(() => undefined)
     const drained = waitForAllDiagnosticLines(home)
     releaseScoped()
-    await Promise.all([globalOnly, drained])
+    await Promise.all([scoped, drained])
 
-    await waitForAllTaskDiagnosticsSafe()
+    assert.ok(readFileSync(scopedPath, 'utf8').includes('scoped'))
     rmSync(home, { recursive: true, force: true })
-    assert.equal(existsSync(home), false, 'the root must stay deleted — no scoped resurrection')
+    assert.equal(existsSync(home), false)
   } finally {
     process.env.HOME = previousHome
     rmSync(home, { recursive: true, force: true })
   }
 })
 
-async function waitForAllTaskDiagnosticsSafe(): Promise<void> {
-  const { waitForAllTaskDiagnostics } = await import('../src/infra/task-diagnostics.ts')
-  await waitForAllTaskDiagnostics().catch(() => undefined)
-}
+test('a scoped stream registered while the drain is waiting is observed (fixed point)', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'clickvibe-drain-late-'))
+  const previousHome = process.env.HOME
+  process.env.HOME = home
+  try {
+    // 1. Global stream gated so the drain starts waiting on it.
+    let releaseGlobal!: () => void
+    const globalGate = new Promise<void>((resolve) => {
+      releaseGlobal = resolve
+    })
+    const global = gatedAppend(home, undefined, 'global', globalGate)
+    await new Promise((resolve) => setImmediate(resolve))
+    assertNoLine(home, undefined, 'global')
+
+    // 2. Drain begins (entry snapshot would capture only the global path).
+    const drained = waitForAllDiagnosticLines(home)
+    await new Promise((resolve) => setImmediate(resolve))
+
+    // 3. A workflow-scoped stream registers under the same root mid-drain.
+    let releaseScoped!: () => void
+    const scopedGate = new Promise<void>((resolve) => {
+      releaseScoped = resolve
+    })
+    const scoped = gatedAppend(home, WORKFLOW_KEY, 'scoped', scopedGate)
+    await new Promise((resolve) => setImmediate(resolve))
+    assertNoLine(home, WORKFLOW_KEY, 'scoped')
+
+    // 4. Freeing global alone must NOT complete the drain: the late scoped
+    // stream was not in any entry snapshot. If the drain returned here, the
+    // teardown would delete the root while the scoped write is still queued.
+    releaseGlobal()
+    await global
+    await new Promise((resolve) => setImmediate(resolve))
+    assertNoLine(home, WORKFLOW_KEY, 'scoped', 'the scoped write is still queued')
+
+    let drainSettled = false
+    void drained.then(() => {
+      drainSettled = true
+    })
+    await new Promise((resolve) => setImmediate(resolve))
+    assert.equal(drainSettled, false, 'the drain must keep waiting for the late-registered stream')
+
+    // 5. Release the scoped write: now the drain reaches its fixed point.
+    releaseScoped()
+    await Promise.all([scoped, drained])
+    assert.ok(readFileSync(diagnosticLogPath(home, WORKFLOW_KEY), 'utf8').includes('scoped'))
+
+    rmSync(home, { recursive: true, force: true })
+    assert.equal(existsSync(home), false, 'no resurrection by the late scoped write')
+  } finally {
+    process.env.HOME = previousHome
+    rmSync(home, { recursive: true, force: true })
+  }
+})

--- a/tests/github-gateway.test.ts
+++ b/tests/github-gateway.test.ts
@@ -53,35 +53,6 @@ function okShell(result: ShellResult) {
   }
 }
 
-test('same-bucket responses append samples instead of overwriting', async () => {
-  const responses = [
-    { exitCode: 0, stdout: { text: included(200, '1', rateHeaders('4999')) } },
-    { exitCode: 0, stdout: { text: included(200, '2', rateHeaders('4998')) } },
-  ]
-  let index = 0
-  const ctx = {
-    shell: {
-      resolve: (spec: unknown) => spec,
-      run: async () => {
-        const next = responses[Math.min(index, responses.length - 1)]
-        index++
-        return next
-      },
-    },
-  }
-  const reader = new GithubRestReader(ctx as never)
-  await reader.json('repos/o/r/first')
-  await reader.json('repos/o/r/second')
-  // Every response is recoverable from the append-only series (review gap 1).
-  assert.deepEqual(
-    reader.evidence.rateLimitSamples.map((sample) => sample.used),
-    [1, 2],
-  )
-  // The bucket view keeps the latest observation for the trip diagnostic.
-  assert.equal(reader.evidence.rateLimitBuckets.core?.used, 2)
-  assert.equal(reader.evidence.rateLimitBuckets.core?.remaining, 4998)
-})
-
 test('non-HTTP CLI failure keeps the upstream level with the raw operation', async () => {
   const { ctx } = okShell({ exitCode: 1, stdout: { text: 'gh: some CLI failure' } })
   const reader = new GithubRestReader(ctx as never)
@@ -202,8 +173,6 @@ test('rate exhaustion trips the circuit carrying the bucket snapshot', async () 
   const { ctx } = okShell({ exitCode: 0, stdout: { text: exhausted } })
   const reader = new GithubRestReader(ctx as never)
   await assert.rejects(reader.json('repos/o/r'), /额度已用完/)
-  assert.equal(reader.evidence.rateLimitBuckets.core?.remaining, 0)
-  assert.equal(reader.evidence.rateLimitBuckets.core?.used, 5000)
   await assert.rejects(
     reader.cachedResource('k', null, () => Promise.resolve('x')),
     /额度已用完/,
@@ -284,57 +253,6 @@ test('spill read failure keeps the upstream level (dispatched child, unreadable 
   assert.equal(reader.evidence.failureRecords[0].operation, 'GET repos/o/r/pulls')
 })
 
-test('a response with partial rate headers still leaves an observation', async () => {
-  // Review round 4: a response carrying resource/limit/reset but missing
-  // remaining must not vanish from the series — present fields survive,
-  // missing ones are explicitly null (unknown, not absence).
-  const partial = included(200, '"ok"', {
-    'x-ratelimit-resource': 'search',
-    'x-ratelimit-limit': '30',
-    'x-ratelimit-reset': '1893456100',
-  })
-  const responses = [
-    { exitCode: 0, stdout: { text: partial } },
-    { exitCode: 0, stdout: { text: included(200, '1', rateHeaders('4998')) } },
-  ]
-  let index = 0
-  const ctx = {
-    shell: {
-      resolve: (spec: unknown) => spec,
-      run: async () => {
-        const next = responses[Math.min(index, responses.length - 1)]
-        index++
-        return next
-      },
-    },
-  }
-  const reader = new GithubRestReader(ctx as never)
-  await reader.json('search/code')
-  await reader.json('repos/o/r')
-  const [searchSample, coreSample] = reader.evidence.rateLimitSamples
-  assert.equal(searchSample.resource, 'search', 'partial-header responses are still observations')
-  assert.equal(searchSample.limit, 30)
-  assert.equal(searchSample.reset, 1_893_456_100_000)
-  assert.equal(searchSample.remaining, null, 'missing field is unknown, not zero')
-  assert.equal(searchSample.used, null)
-  assert.equal(coreSample.resource, 'core', 'the following full response records normally')
-  assert.equal(reader.evidence.rateLimitBuckets.search?.remaining, null)
-})
-
-test('a response with no rate headers at all still counts as an observation with nulls', async () => {
-  const bare = included(200, '"ok"', {})
-  const { ctx } = okShell({ exitCode: 0, stdout: { text: bare } })
-  const reader = new GithubRestReader(ctx as never)
-  await reader.json('repos/o/r/meta')
-  // Every response leaves an observation; with no headers present the
-  // resource is unknown (null-marked core-less row), distinguishable from
-  // "no response happened".
-  assert.equal(reader.evidence.rateLimitSamples.length, 1)
-  assert.equal(reader.evidence.rateLimitSamples[0].limit, null)
-  assert.equal(reader.evidence.rateLimitSamples[0].remaining, null)
-  assert.equal(reader.evidence.rateLimitSamples[0].reset, null)
-})
-
 test('pagination shape failure keeps the upstream operation and the access scope', async () => {
   // Review round 4: HTTP 200 + valid JSON + wrong shape ({"items":[]}) must
   // record the upstream GET with the real page path; a composed aggregate
@@ -364,23 +282,6 @@ test('direct pagination shape failure records its own access level', async () =>
       (record) => record.level === 'access' && record.operation.includes('milestones'),
     ),
   )
-})
-
-test('rate headers without a resource stay unknown and never fabricate a core bucket', async () => {
-  // Review round 5: limit/remaining/reset present, resource absent — the
-  // sample must keep resource=null and must not update any named bucket.
-  const noResource = included(200, '"ok"', {
-    'x-ratelimit-limit': '5000',
-    'x-ratelimit-remaining': '4997',
-    'x-ratelimit-reset': '1893456000',
-  })
-  const { ctx } = okShell({ exitCode: 0, stdout: { text: noResource } })
-  const reader = new GithubRestReader(ctx as never)
-  await reader.json('repos/o/r')
-  assert.equal(reader.evidence.rateLimitSamples[0].resource, null, 'unknown resource stays unknown')
-  assert.equal(reader.evidence.rateLimitSamples[0].limit, 5000)
-  assert.equal(reader.evidence.rateLimitSamples[0].remaining, 4997)
-  assert.deepEqual(reader.evidence.rateLimitBuckets, {}, 'no named bucket is fabricated')
 })
 
 test('a headerless 429 trip never carries a prior response bucket', async () => {
@@ -451,10 +352,6 @@ test('a rate-limited response with numeric headers but no resource keeps its bud
     const { ctx } = okShell({ exitCode: 0, stdout: { text: noResource429 } })
     const reader = new GithubRestReader(ctx as never)
     await assert.rejects(reader.json('repos/o/r'), /额度已用完|限流/)
-    const sample = reader.evidence.rateLimitSamples[0]
-    assert.equal(sample.resource, null)
-    assert.equal(sample.remaining, 0)
-    assert.equal(sample.used, 5000)
     const globalDiag = join(home, '.clickvibe', 'state', 'diagnostics.jsonl')
     for (let spin = 0; spin < 100; spin++) {
       try {

--- a/tests/github-gateway.test.ts
+++ b/tests/github-gateway.test.ts
@@ -122,9 +122,10 @@ test('rate-limit headers become a budget snapshot; exhaustion trips the circuit 
   const reader = new GithubRestReader(ctx as never)
   await assert.rejects(reader.json('repos/o/r'), /额度已用完/)
   assert.equal(reader.counters.failures, 1)
-  assert.equal(reader.counters.rateLimit?.resource, 'core')
-  assert.equal(reader.counters.rateLimit?.remaining, 0)
-  assert.equal(reader.counters.rateLimit?.reset, 1_893_456_000_000)
+  assert.equal(reader.counters.rateLimitBuckets.core?.resource, 'core')
+  assert.equal(reader.counters.rateLimitBuckets.core?.remaining, 0)
+  assert.equal(reader.counters.rateLimitBuckets.core?.used, 5000)
+  assert.equal(reader.counters.rateLimitBuckets.core?.reset, 1_893_456_000_000)
   // The circuit is open: the next access intent fails closed and still lands
   // in exactly one bucket.
   await assert.rejects(
@@ -139,9 +140,15 @@ test('failures keep the operation and raw message as evidence', async () => {
   const { ctx } = okShell({ exitCode: 0, stdout: { text: included(500, '{"message":"boom"}', RATE_HEADERS) } })
   const reader = new GithubRestReader(ctx as never)
   await assert.rejects(reader.json('repos/o/r/pulls'), /GitHub REST 500: boom/)
-  assert.equal(reader.counters.failureRecords.length, 1)
+  // Both evidence levels are retained: the raw upstream operation and the
+  // direct access intent that surfaced it.
+  assert.deepEqual(
+    reader.counters.failureRecords.map((record) => record.level),
+    ['upstream', 'access'],
+  )
   assert.equal(reader.counters.failureRecords[0].operation, 'GET repos/o/r/pulls')
   assert.match(reader.counters.failureRecords[0].message, /boom/)
+  assert.equal(reader.counters.failureRecords[1].operation, 'GET repos/o/r/pulls')
 })
 
 test('invalidations are counted with their scope prefix', () => {
@@ -149,7 +156,13 @@ test('invalidations are counted with their scope prefix', () => {
   reader.invalidate('repo:o/r')
   reader.invalidate('repo:o/r')
   assert.equal(reader.counters.invalidations, 2)
-  assert.deepEqual(reader.counters.invalidationRecords, ['repo:o/r', 'repo:o/r'])
+  assert.deepEqual(
+    reader.counters.invalidationRecords.map((record) => [record.seq, record.prefix]),
+    [
+      [1, 'repo:o/r'],
+      [2, 'repo:o/r'],
+    ],
+  )
 })
 
 test('lane queue waits are measured from access entry to dispatch', async () => {
@@ -192,4 +205,112 @@ test('lane queue waits are measured from access entry to dispatch', async () => 
   assert.equal(reader.counters.upstreamRequests, 2)
   assert.equal(reader.counters.waitCount, 1, 'only the second request queued behind the first')
   assert.equal(reader.counters.waitMsTotal, 500)
+})
+
+test('concurrent cross-access counting: a composing loader never hides a sibling direct request', async () => {
+  // Review finding 1: the instance-level loader guard leaked across
+  // concurrent accesses — while access A's loader was composing upstream
+  // calls, a sibling direct json was misclassified as composed and its
+  // logical intent vanished, letting multi-work-item metrics pass falsely.
+  let releaseA!: () => void
+  const gate = new Promise<void>((resolve) => {
+    releaseA = resolve
+  })
+  const commands: string[] = []
+  let call = 0
+  const ctx = {
+    shell: {
+      resolve: (spec: unknown) => spec,
+      run: async (spec: { command: string }) => {
+        commands.push(spec.command)
+        call += 1
+        return { exitCode: 0, stdout: { text: included(200, `"v${call}"`, RATE_HEADERS) } }
+      },
+    },
+  }
+  const reader = new GithubRestReader(ctx as never)
+  const accessA = reader.cachedResource('A', null, async () => {
+    const inner = await reader.json<string>('repos/o/r/inner')
+    await gate
+    return `a:${inner}`
+  })
+  for (let spin = 0; spin < 100 && reader.counters.upstreamRequests < 1; spin++) {
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+  assert.equal(reader.counters.upstreamRequests, 1, 'access A composed one upstream call')
+  const direct = reader.json<string>('repos/o/r/direct')
+  releaseA()
+  assert.deepEqual(await Promise.all([accessA, direct]), ['a:v1', 'v2'])
+  assert.equal(reader.counters.logicalRequests, 2, 'the sibling direct request is its own logical intent')
+  assert.equal(reader.counters.executions, 2)
+  assert.equal(reader.counters.upstreamRequests, 2)
+  assert.equal(
+    reader.counters.logicalRequests,
+    reader.counters.cacheHits +
+      reader.counters.singleflightJoins +
+      reader.counters.executions +
+      reader.counters.failures,
+  )
+})
+
+test('rate-limit buckets keep per-resource state including used', async () => {
+  const secondary = included(200, 'null', {
+    'x-ratelimit-resource': 'search',
+    'x-ratelimit-limit': '30',
+    'x-ratelimit-remaining': '27',
+    'x-ratelimit-reset': '1893456100',
+  })
+  const core = included(200, 'null', RATE_HEADERS)
+  const results = [core, secondary, core]
+  let index = 0
+  const ctx = {
+    shell: {
+      resolve: (spec: unknown) => spec,
+      run: async () => {
+        const next = results[Math.min(index, results.length - 1)]
+        index++
+        return { exitCode: 0, stdout: { text: next } }
+      },
+    },
+  }
+  const reader = new GithubRestReader(ctx as never)
+  await reader.json('repos/o/r')
+  await reader.json('search/code')
+  await reader.json('repos/o/r/again')
+  const buckets = reader.counters.rateLimitBuckets
+  assert.equal(buckets.core?.resource, 'core', 'both buckets survive, not just the last response')
+  assert.equal(buckets.core?.remaining, 4998)
+  assert.equal(buckets.core?.used, 2)
+  assert.equal(buckets.search?.resource, 'search')
+  assert.equal(buckets.search?.used, 3)
+})
+
+test('invalidations carry scope, reason, trigger and a monotonic sequence', () => {
+  const reader = new GithubRestReader({} as never)
+  reader.invalidate('repo:o/r', 'pr-merged', 'mergeAndCleanup')
+  reader.invalidate('repo:o/r/pulls/9', 'pr-merged', 'mergeAndCleanup')
+  assert.equal(reader.counters.invalidations, 2)
+  assert.deepEqual(
+    reader.counters.invalidationRecords.map((record) => [record.seq, record.prefix, record.reason, record.trigger]),
+    [
+      [1, 'repo:o/r', 'pr-merged', 'mergeAndCleanup'],
+      [2, 'repo:o/r/pulls/9', 'pr-merged', 'mergeAndCleanup'],
+    ],
+  )
+})
+
+test('failure evidence keeps both levels: the upstream operation and the access scope', async () => {
+  const { ctx } = okShell({ exitCode: 0, stdout: { text: included(500, '{"message":"boom"}', RATE_HEADERS) } })
+  const reader = new GithubRestReader(ctx as never)
+  await assert.rejects(
+    reader.cachedResource('detail:o/r/1', null, () => reader.json('repos/o/r/issues/1')),
+    /boom/,
+  )
+  const levels = reader.counters.failureRecords.map((record) => record.level)
+  assert.ok(levels.includes('upstream'), 'the raw gh operation failure is retained')
+  assert.ok(levels.includes('access'), 'the access-scope failure is retained')
+  const upstream = reader.counters.failureRecords.find((record) => record.level === 'upstream')
+  assert.equal(upstream?.operation, 'GET repos/o/r/issues/1')
+  const access = reader.counters.failureRecords.find((record) => record.level === 'access')
+  assert.equal(access?.scope, 'detail:o/r/1')
 })

--- a/tests/github-gateway.test.ts
+++ b/tests/github-gateway.test.ts
@@ -9,6 +9,7 @@
  * assertions, scheduling).
  */
 import assert from 'node:assert/strict'
+import { waitForAllTaskDiagnostics } from '../src/infra/task-diagnostics.ts'
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -158,6 +159,7 @@ test('failures and invalidations persist into the diagnostics channel (readback 
     }
     assert.fail('diagnostics readback did not observe the gateway evidence lines')
   } finally {
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     process.env.HOME = previousHome
     rmSync(home, { recursive: true, force: true })
   }
@@ -237,6 +239,7 @@ test('subsequent observation persists to diagnostics and survives readback', asy
     }
     assert.fail('observed invalidation event never reached diagnostics.jsonl')
   } finally {
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     process.env.HOME = previousHome
     rmSync(home, { recursive: true, force: true })
   }
@@ -331,6 +334,7 @@ test('a headerless 429 trip never carries a prior response bucket', async () => 
     }
     assert.fail('circuit trip never reached diagnostics.jsonl')
   } finally {
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     process.env.HOME = previousHome
     rmSync(home, { recursive: true, force: true })
   }
@@ -372,6 +376,7 @@ test('a rate-limited response with numeric headers but no resource keeps its bud
     }
     assert.fail('circuit trip never reached diagnostics.jsonl')
   } finally {
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     process.env.HOME = previousHome
     rmSync(home, { recursive: true, force: true })
   }

--- a/tests/github-gateway.test.ts
+++ b/tests/github-gateway.test.ts
@@ -209,3 +209,77 @@ test('rate exhaustion trips the circuit carrying the bucket snapshot', async () 
     /额度已用完/,
   )
 })
+
+test('composed JSON parse failure keeps the upstream level naming the garbage child', async () => {
+  // Review round 3: HTTP 200 + valid rate headers + body=not-json must not
+  // lose the upstream row — the child that returned the unparseable body is
+  // the evidence (#133 failures retain the upstream operation).
+  const { ctx } = okShell({ exitCode: 0, stdout: { text: included(200, 'not-json', rateHeaders('4998')) } })
+  const reader = new GithubRestReader(ctx as never)
+  await assert.rejects(
+    reader.cachedResource('detail:o/r/1', null, () => reader.json('repos/o/r/issues/1')),
+    /返回了无效 JSON/,
+  )
+  const upstream = reader.evidence.failureRecords.find((record) => record.level === 'upstream')
+  assert.equal(upstream?.operation, 'GET repos/o/r/issues/1')
+  assert.match(upstream?.message ?? '', /not-json|无效 JSON/)
+  const access = reader.evidence.failureRecords.find((record) => record.level === 'access')
+  assert.equal(access?.scope, 'detail:o/r/1')
+})
+
+test('secondary rate-limit upstream evidence carries the secondary classification', async () => {
+  // Review round 3: a 403 secondary limit must not be persisted as 额度已用完
+  // (primary) at the upstream level while the circuit records secondary.
+  const secondary = included(403, '{"message":"You have exceeded a secondary rate limit"}', {
+    ...rateHeaders('4990'),
+    'retry-after': '60',
+  })
+  const { ctx } = okShell({ exitCode: 0, stdout: { text: secondary } })
+  const reader = new GithubRestReader(ctx as never)
+  await assert.rejects(reader.json('repos/o/r'), /二级限流/)
+  const upstream = reader.evidence.failureRecords.find((record) => record.level === 'upstream')
+  assert.match(upstream?.message ?? '', /二级限流/, 'upstream evidence must match the actual kind')
+  assert.doesNotMatch(upstream?.message ?? '', /额度已用完/)
+})
+
+test('subsequent observation persists to diagnostics and survives readback', async () => {
+  const previousHome = process.env.HOME
+  const home = mkdtempSync(join(tmpdir(), 'clickvibe-gateway-inv-'))
+  process.env.HOME = home
+  try {
+    const { ctx } = okShell({ exitCode: 0, stdout: { text: included(200, '"v"', rateHeaders('4998')) } })
+    const reader = new GithubRestReader(ctx as never)
+    reader.invalidate('repo:o/r', 'comment-published', 'publishDeliveryComment')
+    await reader.cachedAggregate('repo:o/r', 30_000, false, () => Promise.resolve(['i']))
+    assert.equal(reader.evidence.invalidationRecords[0].status, 'observed')
+    const globalDiag = join(home, '.clickvibe', 'state', 'diagnostics.jsonl')
+    for (let spin = 0; spin < 100; spin++) {
+      try {
+        const lines = readFileSync(globalDiag, 'utf8')
+        if (lines.includes('github-rest-invalidation-observed')) {
+          assert.match(lines, /"prefix":"repo:o\/r"/)
+          assert.match(lines, /"observedKey":"repo:o\/r"/)
+          return
+        }
+      } catch {
+        /* not yet flushed */
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    assert.fail('observed invalidation event never reached diagnostics.jsonl')
+  } finally {
+    process.env.HOME = previousHome
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('spill read failure keeps the upstream level (dispatched child, unreadable output)', async () => {
+  const { ctx } = okShell({
+    exitCode: 0,
+    stdout: { text: '', truncated: true, spillPath: '/nonexistent/clickvibe-spill' },
+  })
+  const reader = new GithubRestReader(ctx as never)
+  await assert.rejects(reader.json('repos/o/r/pulls'), /spill|ENOENT|失败/)
+  assert.equal(reader.evidence.failureRecords[0].level, 'upstream')
+  assert.equal(reader.evidence.failureRecords[0].operation, 'GET repos/o/r/pulls')
+})

--- a/tests/github-gateway.test.ts
+++ b/tests/github-gateway.test.ts
@@ -283,3 +283,85 @@ test('spill read failure keeps the upstream level (dispatched child, unreadable 
   assert.equal(reader.evidence.failureRecords[0].level, 'upstream')
   assert.equal(reader.evidence.failureRecords[0].operation, 'GET repos/o/r/pulls')
 })
+
+test('a response with partial rate headers still leaves an observation', async () => {
+  // Review round 4: a response carrying resource/limit/reset but missing
+  // remaining must not vanish from the series — present fields survive,
+  // missing ones are explicitly null (unknown, not absence).
+  const partial = included(200, '"ok"', {
+    'x-ratelimit-resource': 'search',
+    'x-ratelimit-limit': '30',
+    'x-ratelimit-reset': '1893456100',
+  })
+  const responses = [
+    { exitCode: 0, stdout: { text: partial } },
+    { exitCode: 0, stdout: { text: included(200, '1', rateHeaders('4998')) } },
+  ]
+  let index = 0
+  const ctx = {
+    shell: {
+      resolve: (spec: unknown) => spec,
+      run: async () => {
+        const next = responses[Math.min(index, responses.length - 1)]
+        index++
+        return next
+      },
+    },
+  }
+  const reader = new GithubRestReader(ctx as never)
+  await reader.json('search/code')
+  await reader.json('repos/o/r')
+  const [searchSample, coreSample] = reader.evidence.rateLimitSamples
+  assert.equal(searchSample.resource, 'search', 'partial-header responses are still observations')
+  assert.equal(searchSample.limit, 30)
+  assert.equal(searchSample.reset, 1_893_456_100_000)
+  assert.equal(searchSample.remaining, null, 'missing field is unknown, not zero')
+  assert.equal(searchSample.used, null)
+  assert.equal(coreSample.resource, 'core', 'the following full response records normally')
+  assert.equal(reader.evidence.rateLimitBuckets.search?.remaining, null)
+})
+
+test('a response with no rate headers at all still counts as an observation with nulls', async () => {
+  const bare = included(200, '"ok"', {})
+  const { ctx } = okShell({ exitCode: 0, stdout: { text: bare } })
+  const reader = new GithubRestReader(ctx as never)
+  await reader.json('repos/o/r/meta')
+  // Every response leaves an observation; with no headers present the
+  // resource is unknown (null-marked core-less row), distinguishable from
+  // "no response happened".
+  assert.equal(reader.evidence.rateLimitSamples.length, 1)
+  assert.equal(reader.evidence.rateLimitSamples[0].limit, null)
+  assert.equal(reader.evidence.rateLimitSamples[0].remaining, null)
+  assert.equal(reader.evidence.rateLimitSamples[0].reset, null)
+})
+
+test('pagination shape failure keeps the upstream operation and the access scope', async () => {
+  // Review round 4: HTTP 200 + valid JSON + wrong shape ({"items":[]}) must
+  // record the upstream GET with the real page path; a composed aggregate
+  // access keeps its scope alongside.
+  const wrongShape = included(200, '{"items":[]}', rateHeaders('4998'))
+  const { ctx } = okShell({ exitCode: 0, stdout: { text: wrongShape } })
+  const reader = new GithubRestReader(ctx as never)
+  await assert.rejects(
+    reader.cachedAggregate('repo:o/r/aggregated', 30_000, false, () => reader.paginate('repos/o/r/contributors')),
+    /分页返回格式无效/,
+  )
+  const upstream = reader.evidence.failureRecords.find((record) => record.level === 'upstream')
+  assert.equal(upstream?.operation, 'GET repos/o/r/contributors?per_page=100&page=1')
+  assert.match(upstream?.message ?? '', /items|格式无效|Array/)
+  const access = reader.evidence.failureRecords.find((record) => record.level === 'access')
+  assert.equal(access?.scope, 'repo:o/r/aggregated')
+})
+
+test('direct pagination shape failure records its own access level', async () => {
+  const wrongShape = included(200, '{"total": 3}', rateHeaders('4998'))
+  const { ctx } = okShell({ exitCode: 0, stdout: { text: wrongShape } })
+  const reader = new GithubRestReader(ctx as never)
+  await assert.rejects(reader.paginate('repos/o/r/milestones'), /分页返回格式无效/)
+  assert.ok(reader.evidence.failureRecords.some((record) => record.level === 'upstream'))
+  assert.ok(
+    reader.evidence.failureRecords.some(
+      (record) => record.level === 'access' && record.operation.includes('milestones'),
+    ),
+  )
+})

--- a/tests/github-gateway.test.ts
+++ b/tests/github-gateway.test.ts
@@ -417,7 +417,55 @@ test('a headerless 429 trip never carries a prior response bucket', async () => 
         const tripLine = lines.split('\n').find((line) => line.includes('github-rate-circuit-trip'))
         if (tripLine) {
           assert.match(tripLine, /"resource":null/, 'the trip names the current observation, not a fallback')
-          assert.match(tripLine, /"bucket":null/, 'a prior response bucket must not leak onto this trip')
+          // The current (headerless) sample is persisted with null numerics;
+          // the prior core response's quota must not leak onto this trip.
+          assert.match(tripLine, /"bucket":\{"resource":null/)
+          assert.doesNotMatch(tripLine, /"remaining":4999/)
+          return
+        }
+      } catch {
+        /* not yet flushed */
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    assert.fail('circuit trip never reached diagnostics.jsonl')
+  } finally {
+    process.env.HOME = previousHome
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('a rate-limited response with numeric headers but no resource keeps its budget evidence on disk', async () => {
+  // Review round 6: 429 carrying limit/remaining/reset without
+  // x-ratelimit-resource — resource stays unknown, but the present numeric
+  // budget fields must survive into the persisted trip event.
+  const previousHome = process.env.HOME
+  const home = mkdtempSync(join(tmpdir(), 'clickvibe-gateway-trip6-'))
+  process.env.HOME = home
+  try {
+    const noResource429 = included(429, '{"message":"too many"}', {
+      'x-ratelimit-limit': '5000',
+      'x-ratelimit-remaining': '0',
+      'x-ratelimit-reset': '1893456000',
+    })
+    const { ctx } = okShell({ exitCode: 0, stdout: { text: noResource429 } })
+    const reader = new GithubRestReader(ctx as never)
+    await assert.rejects(reader.json('repos/o/r'), /额度已用完|限流/)
+    const sample = reader.evidence.rateLimitSamples[0]
+    assert.equal(sample.resource, null)
+    assert.equal(sample.remaining, 0)
+    assert.equal(sample.used, 5000)
+    const globalDiag = join(home, '.clickvibe', 'state', 'diagnostics.jsonl')
+    for (let spin = 0; spin < 100; spin++) {
+      try {
+        const lines = readFileSync(globalDiag, 'utf8')
+        const tripLine = lines.split('\n').find((line) => line.includes('github-rate-circuit-trip'))
+        if (tripLine) {
+          assert.match(tripLine, /"resource":null/, 'resource stays unknown')
+          assert.match(tripLine, /"bucket":\{/, 'the current sample is persisted, not dropped')
+          assert.match(tripLine, /"remaining":0/)
+          assert.match(tripLine, /"used":5000/)
+          assert.match(tripLine, /"limit":5000/)
           return
         }
       } catch {

--- a/tests/github-gateway.test.ts
+++ b/tests/github-gateway.test.ts
@@ -1,11 +1,17 @@
 /**
- * Gateway access metrics (issue #131 slice A, ledger Q5): the frozen #133
- * units measured at the existing REST reader — every logical request must
- * land in exactly one of hit / singleflight-join / execution / failure, and
- * upstream children, rate-limit snapshots, invalidations and queue waits are
- * recorded alongside. Pure observation: no behavior changes in this slice.
+ * Gateway evidence (issue #131 slice A, review closure round 2): the frozen
+ * #133 evidence classes that already have production consumers — failures
+ * (both levels, including pre-parse and transport failures), per-response
+ * rate-limit samples (same-bucket responses never overwrite), and
+ * invalidations (generation, reason/trigger, subsequent observation vs
+ * unknown) — plus persisted-diagnostics readback proof. Numeric access
+ * counters are deferred to the slice that consumes them (threshold
+ * assertions, scheduling).
  */
 import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { test } from 'node:test'
 import { GithubRestReader } from '../src/github/rest.ts'
 
@@ -22,11 +28,13 @@ function included(status = 200, body = 'null', headers: Record<string, string> =
   return `HTTP/1.1 ${status} OK\n${headerLines}\n\n${body}`
 }
 
-const RATE_HEADERS = {
-  'x-ratelimit-resource': 'core',
-  'x-ratelimit-limit': '5000',
-  'x-ratelimit-remaining': '4998',
-  'x-ratelimit-reset': '1893456000',
+function rateHeaders(remaining: string): Record<string, string> {
+  return {
+    'x-ratelimit-resource': 'core',
+    'x-ratelimit-limit': '5000',
+    'x-ratelimit-remaining': remaining,
+    'x-ratelimit-reset': '1893456000',
+  }
 }
 
 function okShell(result: ShellResult) {
@@ -45,73 +53,146 @@ function okShell(result: ShellResult) {
   }
 }
 
-test('frozen identity: logical = hit + join + execution + failure across the cache lifecycle', async () => {
-  const { ctx } = okShell({ exitCode: 0, stdout: { text: included(200, '{"n":1}', RATE_HEADERS) } })
-  const reader = new GithubRestReader(ctx as never)
-  const value = await reader.cachedResource('k', null, async () =>
-    JSON.stringify(await reader.json<{ n: number }>('repos/o/r')),
-  )
-  assert.equal(value, '{"n":1}')
-  const cached = await reader.cachedResource('k', null, () => Promise.resolve('never'))
-  assert.equal(cached, '{"n":1}')
-  const { logicalRequests, cacheHits, singleflightJoins, executions, failures } = reader.counters
-  assert.equal(logicalRequests, 2)
-  assert.equal(cacheHits, 1)
-  assert.equal(executions, 1)
-  assert.equal(singleflightJoins, 0)
-  assert.equal(failures, 0)
-  assert.equal(logicalRequests, cacheHits + singleflightJoins + executions + failures)
-  assert.equal(reader.counters.upstreamRequests, 1, 'only the first access touched the wire')
-})
-
-test('concurrent identical access singleflights: one execution, one join, one upstream', async () => {
-  const { ctx } = okShell({ exitCode: 0, stdout: { text: included(200, '[]', RATE_HEADERS) } })
-  const reader = new GithubRestReader(ctx as never)
-  const loader = async () => JSON.stringify(await reader.json<unknown[]>('repos/o/r'))
-  const first = reader.cachedResource('k', null, loader)
-  const second = reader.cachedResource('k', null, loader)
-  await Promise.all([first, second])
-  assert.equal(reader.counters.singleflightJoins, 1)
-  assert.equal(reader.counters.executions, 1)
-  assert.equal(reader.counters.logicalRequests, 2)
-  assert.equal(reader.counters.upstreamRequests, 1)
-  assert.equal(
-    reader.counters.logicalRequests,
-    reader.counters.cacheHits +
-      reader.counters.singleflightJoins +
-      reader.counters.executions +
-      reader.counters.failures,
-  )
-})
-
-test('loader-composed pagination counts one logical intent and every upstream child', async () => {
-  const full = included(200, JSON.stringify(Array.from({ length: 100 }, (_, i) => `a${i}`)), RATE_HEADERS)
-  const tail = included(200, '["tail"]', RATE_HEADERS)
-  const commands: string[] = []
+test('same-bucket responses append samples instead of overwriting', async () => {
+  const responses = [
+    { exitCode: 0, stdout: { text: included(200, '1', rateHeaders('4999')) } },
+    { exitCode: 0, stdout: { text: included(200, '2', rateHeaders('4998')) } },
+  ]
   let index = 0
-  const results = [full, tail]
   const ctx = {
     shell: {
       resolve: (spec: unknown) => spec,
-      run: async (spec: { command: string }) => {
-        commands.push(spec.command)
-        const next = results[Math.min(index, results.length - 1)]
+      run: async () => {
+        const next = responses[Math.min(index, responses.length - 1)]
         index++
-        return { exitCode: 0, stdout: { text: next } }
+        return next
       },
     },
   }
   const reader = new GithubRestReader(ctx as never)
-  const values = await reader.cachedAggregate('repo:o/r', 30_000, false, () =>
-    reader.paginate<string>('repos/o/r/issues'),
+  await reader.json('repos/o/r/first')
+  await reader.json('repos/o/r/second')
+  // Every response is recoverable from the append-only series (review gap 1).
+  assert.deepEqual(
+    reader.evidence.rateLimitSamples.map((sample) => sample.used),
+    [1, 2],
   )
-  assert.equal(values.length, 101)
-  assert.equal(reader.counters.logicalRequests, 1, 'the aggregate is the access intent')
-  assert.equal(reader.counters.upstreamRequests, 2, 'each page is one upstream child')
-  assert.equal(reader.counters.executions, 1)
+  // The bucket view keeps the latest observation for the trip diagnostic.
+  assert.equal(reader.evidence.rateLimitBuckets.core?.used, 2)
+  assert.equal(reader.evidence.rateLimitBuckets.core?.remaining, 4998)
 })
 
-test('rate-limit headers become a budget snapshot; exhaustion trips the circuit and counts failures', async () => {
+test('non-HTTP CLI failure keeps the upstream level with the raw operation', async () => {
+  const { ctx } = okShell({ exitCode: 1, stdout: { text: 'gh: some CLI failure' } })
+  const reader = new GithubRestReader(ctx as never)
+  await assert.rejects(
+    reader.cachedResource('detail:o/r/1', null, () => reader.json('repos/o/r/issues/1')),
+    /CLI failure/,
+  )
+  const upstream = reader.evidence.failureRecords.find((record) => record.level === 'upstream')
+  assert.equal(upstream?.operation, 'GET repos/o/r/issues/1', 'the child that failed is named before any parse')
+  const access = reader.evidence.failureRecords.find((record) => record.level === 'access')
+  assert.equal(access?.scope, 'detail:o/r/1')
+})
+
+test('shell rejection keeps the upstream level (transport dispatched, transport failed)', async () => {
+  const ctx = {
+    shell: {
+      resolve: (spec: unknown) => spec,
+      run: async () => {
+        throw new Error('shell exploded')
+      },
+    },
+  }
+  const reader = new GithubRestReader(ctx as never)
+  await assert.rejects(reader.json('repos/o/r'), /shell exploded/)
+  assert.equal(reader.evidence.failureRecords[0].level, 'upstream')
+  assert.equal(reader.evidence.failureRecords[0].operation, 'GET repos/o/r')
+})
+
+test('parseable HTTP failures keep both levels', async () => {
+  const { ctx } = okShell({ exitCode: 0, stdout: { text: included(500, '{"message":"boom"}', rateHeaders('4998')) } })
+  const reader = new GithubRestReader(ctx as never)
+  await assert.rejects(reader.json('repos/o/r/pulls'), /GitHub REST 500: boom/)
+  assert.deepEqual(
+    reader.evidence.failureRecords.map((record) => record.level),
+    ['upstream', 'access'],
+  )
+  assert.equal(reader.evidence.failureRecords[0].operation, 'GET repos/o/r/pulls')
+})
+
+test('invalidations carry generation, reason/trigger and complete on subsequent observation', async () => {
+  const { ctx } = okShell({ exitCode: 0, stdout: { text: included(200, '"v"', rateHeaders('4998')) } })
+  const reader = new GithubRestReader(ctx as never)
+  reader.invalidate('repo:o/r', 'comment-published', 'publishDeliveryComment')
+  reader.invalidate('repo:o/r', 'pr-merged', 'mergeAndCleanup')
+  reader.invalidate('repo:o/r/pulls/9', 'pr-merged', 'mergeAndCleanup')
+  // Same-prefix repeats advance the generation; sibling prefixes keep their own.
+  assert.deepEqual(
+    reader.evidence.invalidationRecords.map((record) => [
+      record.generation,
+      record.prefix,
+      record.reason,
+      record.status,
+    ]),
+    [
+      [1, 'repo:o/r', 'comment-published', 'pending'],
+      [2, 'repo:o/r', 'pr-merged', 'pending'],
+      [1, 'repo:o/r/pulls/9', 'pr-merged', 'pending'],
+    ],
+  )
+
+  // A subsequent cached load under a matching prefix completes every pending
+  // record it satisfies; an unrelated prefix stays unknown.
+  const aggregate = await reader.cachedAggregate('repo:o/r', 30_000, false, () => Promise.resolve(['i']))
+  assert.equal(aggregate[0], 'i')
+  assert.deepEqual(
+    reader.evidence.invalidationRecords.map((record) => [record.prefix, record.status, record.observedKey]),
+    [
+      ['repo:o/r', 'observed', 'repo:o/r'],
+      ['repo:o/r', 'observed', 'repo:o/r'],
+      ['repo:o/r/pulls/9', 'pending', null],
+    ],
+  )
+
+  // Repopulating the deeper key completes the remaining record.
+  await reader.cachedResource('repo:o/r/pulls/9', null, () => Promise.resolve(9))
+  assert.equal(reader.evidence.invalidationRecords[2].status, 'observed')
+  assert.equal(reader.evidence.invalidationRecords[2].observedKey, 'repo:o/r/pulls/9')
+})
+
+test('failures and invalidations persist into the diagnostics channel (readback proof)', async () => {
+  const previousHome = process.env.HOME
+  const home = mkdtempSync(join(tmpdir(), 'clickvibe-gateway-diag-'))
+  process.env.HOME = home
+  try {
+    const { ctx } = okShell({ exitCode: 0, stdout: { text: included(500, '{"message":"boom"}', rateHeaders('4998')) } })
+    const reader = new GithubRestReader(ctx as never)
+    await assert.rejects(reader.json('repos/o/r'), /boom/)
+    reader.invalidate('repo:o/r', 'comment-published', 'publishDeliveryComment')
+    const globalDiag = join(home, '.clickvibe', 'state', 'diagnostics.jsonl')
+    // The best-effort writer is async; drain briefly.
+    for (let spin = 0; spin < 100; spin++) {
+      try {
+        const lines = readFileSync(globalDiag, 'utf8')
+        if (lines.includes('github-access-failure') && lines.includes('github-rest-invalidation')) {
+          assert.match(lines, /"level":"upstream"/)
+          assert.match(lines, /"reason":"comment-published"/)
+          return
+        }
+      } catch {
+        /* not yet flushed */
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    assert.fail('diagnostics readback did not observe the gateway evidence lines')
+  } finally {
+    process.env.HOME = previousHome
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('rate exhaustion trips the circuit carrying the bucket snapshot', async () => {
   const exhausted = included(429, '{"message":"API rate limit exceeded"}', {
     'x-ratelimit-resource': 'core',
     'x-ratelimit-limit': '5000',
@@ -121,196 +202,10 @@ test('rate-limit headers become a budget snapshot; exhaustion trips the circuit 
   const { ctx } = okShell({ exitCode: 0, stdout: { text: exhausted } })
   const reader = new GithubRestReader(ctx as never)
   await assert.rejects(reader.json('repos/o/r'), /额度已用完/)
-  assert.equal(reader.counters.failures, 1)
-  assert.equal(reader.counters.rateLimitBuckets.core?.resource, 'core')
-  assert.equal(reader.counters.rateLimitBuckets.core?.remaining, 0)
-  assert.equal(reader.counters.rateLimitBuckets.core?.used, 5000)
-  assert.equal(reader.counters.rateLimitBuckets.core?.reset, 1_893_456_000_000)
-  // The circuit is open: the next access intent fails closed and still lands
-  // in exactly one bucket.
+  assert.equal(reader.evidence.rateLimitBuckets.core?.remaining, 0)
+  assert.equal(reader.evidence.rateLimitBuckets.core?.used, 5000)
   await assert.rejects(
-    reader.cachedResource('k2', null, () => Promise.resolve('x')),
+    reader.cachedResource('k', null, () => Promise.resolve('x')),
     /额度已用完/,
   )
-  assert.equal(reader.counters.logicalRequests, 2)
-  assert.equal(reader.counters.failures, 2)
-})
-
-test('failures keep the operation and raw message as evidence', async () => {
-  const { ctx } = okShell({ exitCode: 0, stdout: { text: included(500, '{"message":"boom"}', RATE_HEADERS) } })
-  const reader = new GithubRestReader(ctx as never)
-  await assert.rejects(reader.json('repos/o/r/pulls'), /GitHub REST 500: boom/)
-  // Both evidence levels are retained: the raw upstream operation and the
-  // direct access intent that surfaced it.
-  assert.deepEqual(
-    reader.counters.failureRecords.map((record) => record.level),
-    ['upstream', 'access'],
-  )
-  assert.equal(reader.counters.failureRecords[0].operation, 'GET repos/o/r/pulls')
-  assert.match(reader.counters.failureRecords[0].message, /boom/)
-  assert.equal(reader.counters.failureRecords[1].operation, 'GET repos/o/r/pulls')
-})
-
-test('invalidations are counted with their scope prefix', () => {
-  const reader = new GithubRestReader({} as never)
-  reader.invalidate('repo:o/r')
-  reader.invalidate('repo:o/r')
-  assert.equal(reader.counters.invalidations, 2)
-  assert.deepEqual(
-    reader.counters.invalidationRecords.map((record) => [record.seq, record.prefix]),
-    [
-      [1, 'repo:o/r'],
-      [2, 'repo:o/r'],
-    ],
-  )
-})
-
-test('lane queue waits are measured from access entry to dispatch', async () => {
-  const clock = { now: 1000 }
-  let releaseFirst!: () => void
-  const firstGate = new Promise<void>((resolve) => {
-    releaseFirst = resolve
-  })
-  const commands: string[] = []
-  let call = 0
-  const ctx = {
-    shell: {
-      resolve: (spec: unknown) => spec,
-      run: async (spec: { command: string }) => {
-        commands.push(spec.command)
-        call += 1
-        if (call === 1) {
-          await firstGate
-          return { exitCode: 0, stdout: { text: included(200, '1', RATE_HEADERS) } }
-        }
-        return { exitCode: 0, stdout: { text: included(200, '2', RATE_HEADERS) } }
-      },
-    },
-  }
-  const reader = new GithubRestReader(ctx as never, { now: () => clock.now, minimumIntervalMs: 0 })
-  const first = reader.json<number>('repos/o/r/first')
-  const second = reader.json<number>('repos/o/r/second')
-  // The request lane is process-global; residue from earlier tests can pace
-  // the first request behind their interval. Wait until it has actually
-  // dispatched (and recorded its zero wait under the unmoved clock) — it
-  // then blocks inside the shell — before the clock moves.
-  for (let spin = 0; spin < 100 && reader.counters.upstreamRequests < 1; spin++) {
-    await new Promise((resolve) => setTimeout(resolve, 10))
-  }
-  assert.equal(reader.counters.upstreamRequests, 1, 'the first request must dispatch before the clock moves')
-  assert.equal(reader.counters.waitCount, 0)
-  clock.now = 1500
-  releaseFirst()
-  assert.deepEqual(await Promise.all([first, second]), [1, 2])
-  assert.equal(reader.counters.upstreamRequests, 2)
-  assert.equal(reader.counters.waitCount, 1, 'only the second request queued behind the first')
-  assert.equal(reader.counters.waitMsTotal, 500)
-})
-
-test('concurrent cross-access counting: a composing loader never hides a sibling direct request', async () => {
-  // Review finding 1: the instance-level loader guard leaked across
-  // concurrent accesses — while access A's loader was composing upstream
-  // calls, a sibling direct json was misclassified as composed and its
-  // logical intent vanished, letting multi-work-item metrics pass falsely.
-  let releaseA!: () => void
-  const gate = new Promise<void>((resolve) => {
-    releaseA = resolve
-  })
-  const commands: string[] = []
-  let call = 0
-  const ctx = {
-    shell: {
-      resolve: (spec: unknown) => spec,
-      run: async (spec: { command: string }) => {
-        commands.push(spec.command)
-        call += 1
-        return { exitCode: 0, stdout: { text: included(200, `"v${call}"`, RATE_HEADERS) } }
-      },
-    },
-  }
-  const reader = new GithubRestReader(ctx as never)
-  const accessA = reader.cachedResource('A', null, async () => {
-    const inner = await reader.json<string>('repos/o/r/inner')
-    await gate
-    return `a:${inner}`
-  })
-  for (let spin = 0; spin < 100 && reader.counters.upstreamRequests < 1; spin++) {
-    await new Promise((resolve) => setTimeout(resolve, 5))
-  }
-  assert.equal(reader.counters.upstreamRequests, 1, 'access A composed one upstream call')
-  const direct = reader.json<string>('repos/o/r/direct')
-  releaseA()
-  assert.deepEqual(await Promise.all([accessA, direct]), ['a:v1', 'v2'])
-  assert.equal(reader.counters.logicalRequests, 2, 'the sibling direct request is its own logical intent')
-  assert.equal(reader.counters.executions, 2)
-  assert.equal(reader.counters.upstreamRequests, 2)
-  assert.equal(
-    reader.counters.logicalRequests,
-    reader.counters.cacheHits +
-      reader.counters.singleflightJoins +
-      reader.counters.executions +
-      reader.counters.failures,
-  )
-})
-
-test('rate-limit buckets keep per-resource state including used', async () => {
-  const secondary = included(200, 'null', {
-    'x-ratelimit-resource': 'search',
-    'x-ratelimit-limit': '30',
-    'x-ratelimit-remaining': '27',
-    'x-ratelimit-reset': '1893456100',
-  })
-  const core = included(200, 'null', RATE_HEADERS)
-  const results = [core, secondary, core]
-  let index = 0
-  const ctx = {
-    shell: {
-      resolve: (spec: unknown) => spec,
-      run: async () => {
-        const next = results[Math.min(index, results.length - 1)]
-        index++
-        return { exitCode: 0, stdout: { text: next } }
-      },
-    },
-  }
-  const reader = new GithubRestReader(ctx as never)
-  await reader.json('repos/o/r')
-  await reader.json('search/code')
-  await reader.json('repos/o/r/again')
-  const buckets = reader.counters.rateLimitBuckets
-  assert.equal(buckets.core?.resource, 'core', 'both buckets survive, not just the last response')
-  assert.equal(buckets.core?.remaining, 4998)
-  assert.equal(buckets.core?.used, 2)
-  assert.equal(buckets.search?.resource, 'search')
-  assert.equal(buckets.search?.used, 3)
-})
-
-test('invalidations carry scope, reason, trigger and a monotonic sequence', () => {
-  const reader = new GithubRestReader({} as never)
-  reader.invalidate('repo:o/r', 'pr-merged', 'mergeAndCleanup')
-  reader.invalidate('repo:o/r/pulls/9', 'pr-merged', 'mergeAndCleanup')
-  assert.equal(reader.counters.invalidations, 2)
-  assert.deepEqual(
-    reader.counters.invalidationRecords.map((record) => [record.seq, record.prefix, record.reason, record.trigger]),
-    [
-      [1, 'repo:o/r', 'pr-merged', 'mergeAndCleanup'],
-      [2, 'repo:o/r/pulls/9', 'pr-merged', 'mergeAndCleanup'],
-    ],
-  )
-})
-
-test('failure evidence keeps both levels: the upstream operation and the access scope', async () => {
-  const { ctx } = okShell({ exitCode: 0, stdout: { text: included(500, '{"message":"boom"}', RATE_HEADERS) } })
-  const reader = new GithubRestReader(ctx as never)
-  await assert.rejects(
-    reader.cachedResource('detail:o/r/1', null, () => reader.json('repos/o/r/issues/1')),
-    /boom/,
-  )
-  const levels = reader.counters.failureRecords.map((record) => record.level)
-  assert.ok(levels.includes('upstream'), 'the raw gh operation failure is retained')
-  assert.ok(levels.includes('access'), 'the access-scope failure is retained')
-  const upstream = reader.counters.failureRecords.find((record) => record.level === 'upstream')
-  assert.equal(upstream?.operation, 'GET repos/o/r/issues/1')
-  const access = reader.counters.failureRecords.find((record) => record.level === 'access')
-  assert.equal(access?.scope, 'detail:o/r/1')
 })

--- a/tests/github-gateway.test.ts
+++ b/tests/github-gateway.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Gateway access metrics (issue #131 slice A, ledger Q5): the frozen #133
+ * units measured at the existing REST reader — every logical request must
+ * land in exactly one of hit / singleflight-join / execution / failure, and
+ * upstream children, rate-limit snapshots, invalidations and queue waits are
+ * recorded alongside. Pure observation: no behavior changes in this slice.
+ */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { GithubRestReader } from '../src/github/rest.ts'
+
+interface ShellResult {
+  exitCode: number | null
+  stdout: { text: string; truncated?: boolean; spillPath?: string }
+  stderr?: { text?: string }
+}
+
+function included(status = 200, body = 'null', headers: Record<string, string> = {}): string {
+  const headerLines = Object.entries(headers)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join('\n')
+  return `HTTP/1.1 ${status} OK\n${headerLines}\n\n${body}`
+}
+
+const RATE_HEADERS = {
+  'x-ratelimit-resource': 'core',
+  'x-ratelimit-limit': '5000',
+  'x-ratelimit-remaining': '4998',
+  'x-ratelimit-reset': '1893456000',
+}
+
+function okShell(result: ShellResult) {
+  const commands: string[] = []
+  return {
+    commands,
+    ctx: {
+      shell: {
+        resolve: (spec: unknown) => spec,
+        run: async (spec: { command: string }) => {
+          commands.push(spec.command)
+          return result
+        },
+      },
+    },
+  }
+}
+
+test('frozen identity: logical = hit + join + execution + failure across the cache lifecycle', async () => {
+  const { ctx } = okShell({ exitCode: 0, stdout: { text: included(200, '{"n":1}', RATE_HEADERS) } })
+  const reader = new GithubRestReader(ctx as never)
+  const value = await reader.cachedResource('k', null, async () =>
+    JSON.stringify(await reader.json<{ n: number }>('repos/o/r')),
+  )
+  assert.equal(value, '{"n":1}')
+  const cached = await reader.cachedResource('k', null, () => Promise.resolve('never'))
+  assert.equal(cached, '{"n":1}')
+  const { logicalRequests, cacheHits, singleflightJoins, executions, failures } = reader.counters
+  assert.equal(logicalRequests, 2)
+  assert.equal(cacheHits, 1)
+  assert.equal(executions, 1)
+  assert.equal(singleflightJoins, 0)
+  assert.equal(failures, 0)
+  assert.equal(logicalRequests, cacheHits + singleflightJoins + executions + failures)
+  assert.equal(reader.counters.upstreamRequests, 1, 'only the first access touched the wire')
+})
+
+test('concurrent identical access singleflights: one execution, one join, one upstream', async () => {
+  const { ctx } = okShell({ exitCode: 0, stdout: { text: included(200, '[]', RATE_HEADERS) } })
+  const reader = new GithubRestReader(ctx as never)
+  const loader = async () => JSON.stringify(await reader.json<unknown[]>('repos/o/r'))
+  const first = reader.cachedResource('k', null, loader)
+  const second = reader.cachedResource('k', null, loader)
+  await Promise.all([first, second])
+  assert.equal(reader.counters.singleflightJoins, 1)
+  assert.equal(reader.counters.executions, 1)
+  assert.equal(reader.counters.logicalRequests, 2)
+  assert.equal(reader.counters.upstreamRequests, 1)
+  assert.equal(
+    reader.counters.logicalRequests,
+    reader.counters.cacheHits +
+      reader.counters.singleflightJoins +
+      reader.counters.executions +
+      reader.counters.failures,
+  )
+})
+
+test('loader-composed pagination counts one logical intent and every upstream child', async () => {
+  const full = included(200, JSON.stringify(Array.from({ length: 100 }, (_, i) => `a${i}`)), RATE_HEADERS)
+  const tail = included(200, '["tail"]', RATE_HEADERS)
+  const commands: string[] = []
+  let index = 0
+  const results = [full, tail]
+  const ctx = {
+    shell: {
+      resolve: (spec: unknown) => spec,
+      run: async (spec: { command: string }) => {
+        commands.push(spec.command)
+        const next = results[Math.min(index, results.length - 1)]
+        index++
+        return { exitCode: 0, stdout: { text: next } }
+      },
+    },
+  }
+  const reader = new GithubRestReader(ctx as never)
+  const values = await reader.cachedAggregate('repo:o/r', 30_000, false, () =>
+    reader.paginate<string>('repos/o/r/issues'),
+  )
+  assert.equal(values.length, 101)
+  assert.equal(reader.counters.logicalRequests, 1, 'the aggregate is the access intent')
+  assert.equal(reader.counters.upstreamRequests, 2, 'each page is one upstream child')
+  assert.equal(reader.counters.executions, 1)
+})
+
+test('rate-limit headers become a budget snapshot; exhaustion trips the circuit and counts failures', async () => {
+  const exhausted = included(429, '{"message":"API rate limit exceeded"}', {
+    'x-ratelimit-resource': 'core',
+    'x-ratelimit-limit': '5000',
+    'x-ratelimit-remaining': '0',
+    'x-ratelimit-reset': '1893456000',
+  })
+  const { ctx } = okShell({ exitCode: 0, stdout: { text: exhausted } })
+  const reader = new GithubRestReader(ctx as never)
+  await assert.rejects(reader.json('repos/o/r'), /额度已用完/)
+  assert.equal(reader.counters.failures, 1)
+  assert.equal(reader.counters.rateLimit?.resource, 'core')
+  assert.equal(reader.counters.rateLimit?.remaining, 0)
+  assert.equal(reader.counters.rateLimit?.reset, 1_893_456_000_000)
+  // The circuit is open: the next access intent fails closed and still lands
+  // in exactly one bucket.
+  await assert.rejects(
+    reader.cachedResource('k2', null, () => Promise.resolve('x')),
+    /额度已用完/,
+  )
+  assert.equal(reader.counters.logicalRequests, 2)
+  assert.equal(reader.counters.failures, 2)
+})
+
+test('failures keep the operation and raw message as evidence', async () => {
+  const { ctx } = okShell({ exitCode: 0, stdout: { text: included(500, '{"message":"boom"}', RATE_HEADERS) } })
+  const reader = new GithubRestReader(ctx as never)
+  await assert.rejects(reader.json('repos/o/r/pulls'), /GitHub REST 500: boom/)
+  assert.equal(reader.counters.failureRecords.length, 1)
+  assert.equal(reader.counters.failureRecords[0].operation, 'GET repos/o/r/pulls')
+  assert.match(reader.counters.failureRecords[0].message, /boom/)
+})
+
+test('invalidations are counted with their scope prefix', () => {
+  const reader = new GithubRestReader({} as never)
+  reader.invalidate('repo:o/r')
+  reader.invalidate('repo:o/r')
+  assert.equal(reader.counters.invalidations, 2)
+  assert.deepEqual(reader.counters.invalidationRecords, ['repo:o/r', 'repo:o/r'])
+})
+
+test('lane queue waits are measured from access entry to dispatch', async () => {
+  const clock = { now: 1000 }
+  let releaseFirst!: () => void
+  const firstGate = new Promise<void>((resolve) => {
+    releaseFirst = resolve
+  })
+  const commands: string[] = []
+  let call = 0
+  const ctx = {
+    shell: {
+      resolve: (spec: unknown) => spec,
+      run: async (spec: { command: string }) => {
+        commands.push(spec.command)
+        call += 1
+        if (call === 1) {
+          await firstGate
+          return { exitCode: 0, stdout: { text: included(200, '1', RATE_HEADERS) } }
+        }
+        return { exitCode: 0, stdout: { text: included(200, '2', RATE_HEADERS) } }
+      },
+    },
+  }
+  const reader = new GithubRestReader(ctx as never, { now: () => clock.now, minimumIntervalMs: 0 })
+  const first = reader.json<number>('repos/o/r/first')
+  const second = reader.json<number>('repos/o/r/second')
+  // The request lane is process-global; residue from earlier tests can pace
+  // the first request behind their interval. Wait until it has actually
+  // dispatched (and recorded its zero wait under the unmoved clock) — it
+  // then blocks inside the shell — before the clock moves.
+  for (let spin = 0; spin < 100 && reader.counters.upstreamRequests < 1; spin++) {
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  assert.equal(reader.counters.upstreamRequests, 1, 'the first request must dispatch before the clock moves')
+  assert.equal(reader.counters.waitCount, 0)
+  clock.now = 1500
+  releaseFirst()
+  assert.deepEqual(await Promise.all([first, second]), [1, 2])
+  assert.equal(reader.counters.upstreamRequests, 2)
+  assert.equal(reader.counters.waitCount, 1, 'only the second request queued behind the first')
+  assert.equal(reader.counters.waitMsTotal, 500)
+})

--- a/tests/github-gateway.test.ts
+++ b/tests/github-gateway.test.ts
@@ -365,3 +365,69 @@ test('direct pagination shape failure records its own access level', async () =>
     ),
   )
 })
+
+test('rate headers without a resource stay unknown and never fabricate a core bucket', async () => {
+  // Review round 5: limit/remaining/reset present, resource absent — the
+  // sample must keep resource=null and must not update any named bucket.
+  const noResource = included(200, '"ok"', {
+    'x-ratelimit-limit': '5000',
+    'x-ratelimit-remaining': '4997',
+    'x-ratelimit-reset': '1893456000',
+  })
+  const { ctx } = okShell({ exitCode: 0, stdout: { text: noResource } })
+  const reader = new GithubRestReader(ctx as never)
+  await reader.json('repos/o/r')
+  assert.equal(reader.evidence.rateLimitSamples[0].resource, null, 'unknown resource stays unknown')
+  assert.equal(reader.evidence.rateLimitSamples[0].limit, 5000)
+  assert.equal(reader.evidence.rateLimitSamples[0].remaining, 4997)
+  assert.deepEqual(reader.evidence.rateLimitBuckets, {}, 'no named bucket is fabricated')
+})
+
+test('a headerless 429 trip never carries a prior response bucket', async () => {
+  const previousHome = process.env.HOME
+  const home = mkdtempSync(join(tmpdir(), 'clickvibe-gateway-trip-'))
+  process.env.HOME = home
+  try {
+    const realCore = included(200, '1', rateHeaders('4999'))
+    const bare429 = included(429, '{"message":"too many"}', { 'retry-after': '60' })
+    const responses = [
+      { exitCode: 0, stdout: { text: realCore } },
+      { exitCode: 0, stdout: { text: bare429 } },
+    ]
+    let index = 0
+    const ctx = {
+      shell: {
+        resolve: (spec: unknown) => spec,
+        run: async () => {
+          const next = responses[Math.min(index, responses.length - 1)]
+          index++
+          return next
+        },
+      },
+    }
+    const reader = new GithubRestReader(ctx as never)
+    await reader.json('repos/o/r')
+    await assert.rejects(reader.json('repos/o/r'), /限流/)
+    // The persisted trip event must bind to THIS response's observation —
+    // resource unknown, no bucket — not the earlier core response's.
+    const globalDiag = join(home, '.clickvibe', 'state', 'diagnostics.jsonl')
+    for (let spin = 0; spin < 100; spin++) {
+      try {
+        const lines = readFileSync(globalDiag, 'utf8')
+        const tripLine = lines.split('\n').find((line) => line.includes('github-rate-circuit-trip'))
+        if (tripLine) {
+          assert.match(tripLine, /"resource":null/, 'the trip names the current observation, not a fallback')
+          assert.match(tripLine, /"bucket":null/, 'a prior response bucket must not leak onto this trip')
+          return
+        }
+      } catch {
+        /* not yet flushed */
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    assert.fail('circuit trip never reached diagnostics.jsonl')
+  } finally {
+    process.env.HOME = previousHome
+    rmSync(home, { recursive: true, force: true })
+  }
+})

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { waitForTaskDiagnosticPersistence } from '../src/infra/task-diagnostics.ts'
 import { commitWorkflowFixture } from './workflow-fixture.ts'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { createServer, request, type RequestListener } from 'node:http'
@@ -368,6 +369,7 @@ test('/create-pr uses a one-use privileged authorization before the shared handl
     )
     assert.equal(replay.status, 403)
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -572,6 +574,7 @@ test('develop authorization previews fetched baselines and binds a custom select
     assert.equal(replaceFrozen.status, 400)
     assert.match(String(replaceFrozen.body.error), /基线已定格/)
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -699,6 +702,7 @@ test('concurrent first-development authorizations freeze exactly one baseline an
     assert.match(frozen?.baseRef ?? '', /^origin\/(?:main|release\/2\.0) @ (?:1111111|2222222)$/)
     await new Promise((resolve) => setTimeout(resolve, 120))
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -892,6 +896,7 @@ test('missing baseline restoration requires and consumes an exact one-use author
     )
     assert.equal(replay.status, 403)
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(home, { recursive: true, force: true })
@@ -1098,6 +1103,7 @@ test('/merge requires one-use authorization, exact reviewed HEAD, merge commit, 
     )
     assert.equal(replay.status, 403)
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1158,6 +1164,7 @@ test('/merge rejects a stale review hash before invoking gh pr merge', async () 
     )
     assert.equal((await loadWorkflow(workflow.key))?.delivery, undefined)
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1228,6 +1235,7 @@ test('/merge authorization rejects a changed acceptance contract with the same P
       false,
     )
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1401,6 +1409,7 @@ test('/merge gate rejection offers manual override that merges once and audits t
     )
     assert.equal(replay.status, 403)
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1516,6 +1525,7 @@ test('/merge manual override refuses gate failures not covered by the confirmati
     )
     assert.equal(persisted?.delivery, undefined)
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1642,6 +1652,7 @@ test('cleanup failure keeps merged terminal state and retries without merging ag
     assert.equal(commands.filter((command) => command.startsWith('gh pr merge')).length, 1)
     assert.equal((await loadAllArchivedWorkflows())[0]?.delivery?.status, 'archived')
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1683,6 +1694,7 @@ test('/state uses the live GitHub issue state instead of the stored issueState',
     assert.equal(response.body.workflows?.[0].issueState, 'CLOSED')
     assert.equal(response.body.workflows?.[0].derived.nextAction.kind, 'none')
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1752,6 +1764,7 @@ test('/state and repo/issues share one repository fetch TTL while manual refresh
     assert.equal((list.body as { freshness?: { refreshed: boolean } }).freshness?.refreshed, false)
     assert.equal((forced.body as { freshness?: { refreshed: boolean } }).freshness?.refreshed, true)
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1779,6 +1792,7 @@ test('/state keeps local-ref state readable and marks freshness stale when fetch
     assert.deepEqual((result.body as { workflows?: unknown[] }).workflows, [])
     assert.equal((result.body as { freshness?: { stale: boolean } }).freshness?.stale, true)
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1804,6 +1818,7 @@ test('/state schedules dependency refreshes for a remote-only configured reposit
     assert.equal((second.body as { dependenciesRefreshDue?: boolean }).dependenciesRefreshDue, false)
     assert.equal((first.body as { freshness?: unknown }).freshness, null)
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1833,6 +1848,7 @@ test('/state returns stale local facts within a bounded wait when git fetch hang
     assert.equal((result.body as { freshness?: { stale: boolean; refreshing: boolean } }).freshness?.refreshing, true)
     assert.ok(elapsedMs < 3_000, `state response took ${elapsedMs}ms`)
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1893,6 +1909,7 @@ test('a rejected dry-run worktree attempt preserves the previous durable dev his
     assert.equal(history[0], 'previous completed task history')
     assert.ok(history.some((line) => line.includes('worktree 冲突')))
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1974,6 +1991,7 @@ test('dryrun uses the default baseline, reports command output and closes succes
     assert.equal(failure.polled.status, 'failed')
     assert.match(failure.polled.delta?.join('\n') ?? '', /dry-run 失败/)
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1998,6 +2016,7 @@ test('/history restores the complete disk log by task id after Host restart', as
     assert.equal(result.body.active, false)
     assert.equal(result.body.kind, 'dev')
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -2030,6 +2049,7 @@ test('/history queries an older round by project and issue while binding the rou
     )
     assert.equal(wrongIssue.status, 404)
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -2063,6 +2083,7 @@ test('/history restores structured agent records and keeps legacy lines compatib
       { source: 'system', kind: 'system', text: '[clickvibe] legacy system line' },
     ])
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -2088,6 +2109,7 @@ test('/history accepts a safe workflow key and rejects unknown or traversal targ
     const missing = await get(handler, '/clickvibe/api/history?taskId=missing')
     assert.equal(missing.status, 404)
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -2305,6 +2327,7 @@ test('invalid exact dev session falls back once to a fresh session on the same t
     assert.equal(delivery?.publication?.status, 'posted')
     assert.equal(delivery?.publication?.target, 'pr')
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -2438,6 +2461,7 @@ test('lossy agent output recovers the missing head from the host spill file into
     assert.ok(historyEvents.some((event) => event.text.includes('lost in the host buffer')))
     assert.ok(historyEvents.some((event) => event.text.includes('已从宿主 spill 文件恢复 2 行')))
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -2533,6 +2557,7 @@ test('completed development without a PR appends its Dev Meta comment to the iss
     assert.equal(reloaded?.events.at(-1)?.publication?.target, 'issue')
     assert.equal(reloaded?.events.at(-1)?.publication?.status, 'posted')
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -2632,6 +2657,7 @@ test('concurrent resume requests reserve one workflow task before refreshing the
     assert.ok(first.body.taskId)
     await waitForTask(handler, first.body.taskId)
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -2713,6 +2739,7 @@ test('comment publication failure keeps the delivery event and stores a bounded 
     assert.equal(reloaded?.events[0].publication?.error?.length, 500)
     assert.match(reloaded?.events[0].publication?.error ?? '', /offline-/)
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -2891,6 +2918,7 @@ test('invalid exact review session clears the stale id and falls back to a fresh
       "gh pr review 'https://github.com/o/r/pull/29' --approve --body '**身份：Review Agent**\n\nLGTM'",
     ])
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -3008,6 +3036,7 @@ test('duplicate review requests reuse the reserved task before fetching the Issu
     assert.ok(first.body.taskId)
     await waitForTask(handler, first.body.taskId)
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -3107,6 +3136,7 @@ test('cross-agent review starts fresh and an empty failed verdict requires re-re
     assert.equal(reloaded?.reviewResult, null)
     assert.equal(reloaded?.stage, 'review-ready')
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -3267,6 +3297,7 @@ test('/develop automatic mode rejects a branch with commits when workflow histor
     assert.ok(commands.some((command) => command.startsWith('git rev-list --count')))
     assert.ok(commands.every((command) => !command.startsWith('git worktree add')))
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -3384,6 +3415,7 @@ test('rate-limit response opens a circuit and returns the friendly recovery time
     assert.equal(second.body.error, first.body.error)
     assert.equal(githubRequests, 1, 'open circuit must reject without another GitHub request')
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -4219,6 +4251,7 @@ test('develop with user context stays a first development and records the note i
     assert.equal(reloaded?.events.at(-1)?.userContext, secondContext)
     assert.equal(typeof reloaded?.events.at(-1)?.durationMs, 'number')
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -4314,6 +4347,7 @@ test('resume (rework) carries the user context next to the review feedback and a
     assert.equal(reloaded?.events.at(-1)?.userContext, userContext)
     assert.equal(typeof reloaded?.events.at(-1)?.durationMs, 'number')
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -4428,6 +4462,7 @@ test('review with user context appends it to the prompt and audits it in the rev
       false,
     )
   } finally {
+    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { waitForTaskDiagnosticPersistence } from '../src/infra/task-diagnostics.ts'
+import { waitForAllTaskDiagnostics } from '../src/infra/task-diagnostics.ts'
 import { commitWorkflowFixture } from './workflow-fixture.ts'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { createServer, request, type RequestListener } from 'node:http'
@@ -369,7 +369,7 @@ test('/create-pr uses a one-use privileged authorization before the shared handl
     )
     assert.equal(replay.status, 403)
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -574,7 +574,7 @@ test('develop authorization previews fetched baselines and binds a custom select
     assert.equal(replaceFrozen.status, 400)
     assert.match(String(replaceFrozen.body.error), /基线已定格/)
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -702,7 +702,7 @@ test('concurrent first-development authorizations freeze exactly one baseline an
     assert.match(frozen?.baseRef ?? '', /^origin\/(?:main|release\/2\.0) @ (?:1111111|2222222)$/)
     await new Promise((resolve) => setTimeout(resolve, 120))
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -896,7 +896,7 @@ test('missing baseline restoration requires and consumes an exact one-use author
     )
     assert.equal(replay.status, 403)
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(home, { recursive: true, force: true })
@@ -1103,7 +1103,7 @@ test('/merge requires one-use authorization, exact reviewed HEAD, merge commit, 
     )
     assert.equal(replay.status, 403)
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1164,7 +1164,7 @@ test('/merge rejects a stale review hash before invoking gh pr merge', async () 
     )
     assert.equal((await loadWorkflow(workflow.key))?.delivery, undefined)
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1235,7 +1235,7 @@ test('/merge authorization rejects a changed acceptance contract with the same P
       false,
     )
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1409,7 +1409,7 @@ test('/merge gate rejection offers manual override that merges once and audits t
     )
     assert.equal(replay.status, 403)
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1525,7 +1525,7 @@ test('/merge manual override refuses gate failures not covered by the confirmati
     )
     assert.equal(persisted?.delivery, undefined)
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1652,7 +1652,7 @@ test('cleanup failure keeps merged terminal state and retries without merging ag
     assert.equal(commands.filter((command) => command.startsWith('gh pr merge')).length, 1)
     assert.equal((await loadAllArchivedWorkflows())[0]?.delivery?.status, 'archived')
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1694,7 +1694,7 @@ test('/state uses the live GitHub issue state instead of the stored issueState',
     assert.equal(response.body.workflows?.[0].issueState, 'CLOSED')
     assert.equal(response.body.workflows?.[0].derived.nextAction.kind, 'none')
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1764,7 +1764,7 @@ test('/state and repo/issues share one repository fetch TTL while manual refresh
     assert.equal((list.body as { freshness?: { refreshed: boolean } }).freshness?.refreshed, false)
     assert.equal((forced.body as { freshness?: { refreshed: boolean } }).freshness?.refreshed, true)
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1792,7 +1792,7 @@ test('/state keeps local-ref state readable and marks freshness stale when fetch
     assert.deepEqual((result.body as { workflows?: unknown[] }).workflows, [])
     assert.equal((result.body as { freshness?: { stale: boolean } }).freshness?.stale, true)
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1818,7 +1818,7 @@ test('/state schedules dependency refreshes for a remote-only configured reposit
     assert.equal((second.body as { dependenciesRefreshDue?: boolean }).dependenciesRefreshDue, false)
     assert.equal((first.body as { freshness?: unknown }).freshness, null)
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1848,7 +1848,7 @@ test('/state returns stale local facts within a bounded wait when git fetch hang
     assert.equal((result.body as { freshness?: { stale: boolean; refreshing: boolean } }).freshness?.refreshing, true)
     assert.ok(elapsedMs < 3_000, `state response took ${elapsedMs}ms`)
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1909,7 +1909,7 @@ test('a rejected dry-run worktree attempt preserves the previous durable dev his
     assert.equal(history[0], 'previous completed task history')
     assert.ok(history.some((line) => line.includes('worktree 冲突')))
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1991,7 +1991,7 @@ test('dryrun uses the default baseline, reports command output and closes succes
     assert.equal(failure.polled.status, 'failed')
     assert.match(failure.polled.delta?.join('\n') ?? '', /dry-run 失败/)
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -2016,7 +2016,7 @@ test('/history restores the complete disk log by task id after Host restart', as
     assert.equal(result.body.active, false)
     assert.equal(result.body.kind, 'dev')
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -2049,7 +2049,7 @@ test('/history queries an older round by project and issue while binding the rou
     )
     assert.equal(wrongIssue.status, 404)
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -2083,7 +2083,7 @@ test('/history restores structured agent records and keeps legacy lines compatib
       { source: 'system', kind: 'system', text: '[clickvibe] legacy system line' },
     ])
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -2109,7 +2109,7 @@ test('/history accepts a safe workflow key and rejects unknown or traversal targ
     const missing = await get(handler, '/clickvibe/api/history?taskId=missing')
     assert.equal(missing.status, 404)
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -2327,7 +2327,7 @@ test('invalid exact dev session falls back once to a fresh session on the same t
     assert.equal(delivery?.publication?.status, 'posted')
     assert.equal(delivery?.publication?.target, 'pr')
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -2461,7 +2461,7 @@ test('lossy agent output recovers the missing head from the host spill file into
     assert.ok(historyEvents.some((event) => event.text.includes('lost in the host buffer')))
     assert.ok(historyEvents.some((event) => event.text.includes('已从宿主 spill 文件恢复 2 行')))
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -2557,7 +2557,7 @@ test('completed development without a PR appends its Dev Meta comment to the iss
     assert.equal(reloaded?.events.at(-1)?.publication?.target, 'issue')
     assert.equal(reloaded?.events.at(-1)?.publication?.status, 'posted')
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -2657,7 +2657,7 @@ test('concurrent resume requests reserve one workflow task before refreshing the
     assert.ok(first.body.taskId)
     await waitForTask(handler, first.body.taskId)
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -2739,7 +2739,7 @@ test('comment publication failure keeps the delivery event and stores a bounded 
     assert.equal(reloaded?.events[0].publication?.error?.length, 500)
     assert.match(reloaded?.events[0].publication?.error ?? '', /offline-/)
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -2918,7 +2918,7 @@ test('invalid exact review session clears the stale id and falls back to a fresh
       "gh pr review 'https://github.com/o/r/pull/29' --approve --body '**身份：Review Agent**\n\nLGTM'",
     ])
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -3036,7 +3036,7 @@ test('duplicate review requests reuse the reserved task before fetching the Issu
     assert.ok(first.body.taskId)
     await waitForTask(handler, first.body.taskId)
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -3136,7 +3136,7 @@ test('cross-agent review starts fresh and an empty failed verdict requires re-re
     assert.equal(reloaded?.reviewResult, null)
     assert.equal(reloaded?.stage, 'review-ready')
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -3297,7 +3297,7 @@ test('/develop automatic mode rejects a branch with commits when workflow histor
     assert.ok(commands.some((command) => command.startsWith('git rev-list --count')))
     assert.ok(commands.every((command) => !command.startsWith('git worktree add')))
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -3415,7 +3415,7 @@ test('rate-limit response opens a circuit and returns the friendly recovery time
     assert.equal(second.body.error, first.body.error)
     assert.equal(githubRequests, 1, 'open circuit must reject without another GitHub request')
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -4251,7 +4251,7 @@ test('develop with user context stays a first development and records the note i
     assert.equal(reloaded?.events.at(-1)?.userContext, secondContext)
     assert.equal(typeof reloaded?.events.at(-1)?.durationMs, 'number')
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -4347,7 +4347,7 @@ test('resume (rework) carries the user context next to the review feedback and a
     assert.equal(reloaded?.events.at(-1)?.userContext, userContext)
     assert.equal(typeof reloaded?.events.at(-1)?.durationMs, 'number')
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -4462,7 +4462,7 @@ test('review with user context appends it to the prompt and audits it in the rev
       false,
     )
   } finally {
-    await waitForTaskDiagnosticPersistence(undefined).catch(() => undefined)
+    await waitForAllTaskDiagnostics().catch(() => undefined)
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })


### PR DESCRIPTION
Toward #131，按 [grill 台账](https://github.com/ai-daming/clickvibe/issues/131#issuecomment-5463878043) 片一内部顺序的第一步。Baseline：`b580c31`。经八轮 review 收敛后的**当前交付面**如下（历史叙述已按实际 head 校正）：

## 交付内容（八轮收敛后）

**盘点结论**：全部 Controller 读调用点本已流经 `GithubRestReader`，片一铺路增量收敛为**证据层**，不新建模块/包装层/并行缓存。

**有生产消费者的证据**（每项均通过磁盘 readback 回归证明持久化）：
- **双层失败证据**：upstream 层（原始 GET/POST 操作 + 原始错误，覆盖 HTTP 错误、JSON 解析失败、分页 shape 错误、CLI 非 HTTP 失败、shell 拒绝、spill 读取失败六类路径）+ access 层（失败访问的真实 scope，ALS 组合标记做证据路由：直连自记、组合由 wrapper 记）；secondary/primary 限流分类三层一致；全部落 `github-access-failure` 持久诊断。
- **失效证据**：`{seq, generation(按前缀), prefix, reason, trigger}`，签名必填；匹配前缀的后续缓存装载翻转为 observed 并落 `github-rest-invalidation-observed` 事件，未重采停留 pending（unknown）。6 处生产调用点传入语义化 reason/trigger。
- **限流观察**：熔断事件携带**当前响应**的 rate observation——resource 未知保持 null（无 core 伪造、无旧桶泄漏），已存在的 limit/remaining/used/reset 全部持久化。
- **teardown 稳定性**：`waitForAllDiagnosticLines(root)` root 级 drain 原语（覆盖 global + workflow-scoped 队列）；42 处临时 HOME 测试在恢复前 drain；两个确定性交互回归（trailing write / scoped write）用生产队列原语钉死。

**按概念预算推迟到 B 片**（与真实消费者同批交付）：数值 access counters（logical/hit/join/execution/wait）、in-memory rate series 容器、ALS 计数用途（保留证据路由用途）。

## 门禁

typecheck ✓ build ✓ test **664/664** ✓（含 16 例 gateway 证据回归 + 2 例 teardown 交互回归）✓ coverage/CI 原始终态为准 ✓ lint ✓ format ✓ size/layers/style-tokens/state-writes/local-git-writes ✓

## 概念预算清单

| 概念 | 消费者 |
|---|---|
| `AccessFailureRecord`/`InvalidationRecord`/`RateLimitSample`（局部） | 持久诊断管线 + 磁盘 readback 回归 |
| `waitForAllDiagnosticLines` | 42 处 teardown + 2 交互回归 |
| ALS 组合标记（证据路由用途） | 失败双层路由 + 回归 |

已删除（消费者不存在）：数值 counters、rateLimitSamples/rateLimitBuckets 容器及仅验证容器的 4 个测试。