### PR TITLE
feat: finish Remote Git Coordinator Slice C (#135)

### DIFF
--- a/src/infra/remote-git-contracts.ts
+++ b/src/infra/remote-git-contracts.ts
@@ -1,0 +1,22 @@
+import type { RemoteGitScope, RemoteGitTerminalOutcome } from './remote-git-lifecycle.ts'
+
+export interface RemoteGitWriteAttempt {
+  attemptId: string
+  scope: RemoteGitScope
+  operationKind: 'push' | 'push-set-upstream' | 'force-with-lease' | 'delete'
+  destinationRef: string
+  expectedOid: string | null
+  expectedRemoteOid: string | null
+  status: 'prepared' | 'confirmed' | 'failed' | 'unknown'
+  preparedAt: string
+  diagnosticRef?: string
+}
+
+export interface RemoteGitOutcome {
+  outcome: RemoteGitTerminalOutcome
+  flightId: string
+  attemptId?: string
+  output?: string
+  readback?: string
+  error?: string
+}

--- a/src/infra/remote-git-coordinator.ts
+++ b/src/infra/remote-git-coordinator.ts
@@ -13,29 +13,12 @@ import {
   type RemoteGitFreshness,
   type RemoteGitFreshnessEntry,
 } from './remote-git-freshness.ts'
+import type { RemoteGitOutcome, RemoteGitWriteAttempt } from './remote-git-contracts.ts'
+import { type RemoteGitDeleteInput, runDeleteRemoteBranchIfPresent } from './remote-git-delete.ts'
 
 export { deriveRemoteGitMetrics }
 export type { RemoteGitLifecycleEvent, RemoteGitMetrics, RemoteGitScope } from './remote-git-lifecycle.ts'
-
-export interface RemoteGitWriteAttempt {
-  attemptId: string
-  scope: RemoteGitScope
-  operationKind: 'push' | 'push-set-upstream' | 'force-with-lease' | 'delete'
-  destinationRef: string
-  expectedOid: string | null
-  expectedRemoteOid: string | null
-  status: 'prepared' | 'confirmed' | 'failed' | 'unknown'
-  preparedAt: string
-  diagnosticRef?: string
-}
-
-export interface RemoteGitOutcome {
-  outcome: RemoteGitTerminalOutcome
-  flightId: string
-  output?: string
-  readback?: string
-  error?: string
-}
+export type { RemoteGitOutcome, RemoteGitWriteAttempt } from './remote-git-contracts.ts'
 
 export type { RemoteGitFreshness } from './remote-git-freshness.ts'
 
@@ -166,8 +149,21 @@ export function createRemoteGitCoordinator(
     })
   }
 
-  const terminal = (requestId: string, flightId: string, outcome: RemoteGitTerminalOutcome, error?: unknown) => {
-    const event = { requestId, flightId, outcome, error: error === undefined ? null : errorText(error), at: now() }
+  const terminal = (
+    requestId: string,
+    flightId: string,
+    outcome: RemoteGitTerminalOutcome,
+    error?: unknown,
+    attemptId?: string,
+  ) => {
+    const event = {
+      requestId,
+      flightId,
+      ...(attemptId ? { attemptId } : {}),
+      outcome,
+      error: error === undefined ? null : errorText(error),
+      at: now(),
+    }
     if (terminalRequests.has(requestId)) {
       emit({ kind: 'late-result', ...event })
       return
@@ -180,15 +176,17 @@ export function createRemoteGitCoordinator(
   const noteSubprocess = (
     requestId: string,
     flightId: string,
-    phase: 'fetch' | 'push' | 'readback',
+    phase: 'fetch' | 'pre-read' | 'push' | 'readback',
     startedAt: number,
     error?: unknown,
+    attemptId?: string,
   ) => {
     emit({
       kind: 'subprocess-settled',
       requestId,
       flightId,
       phase,
+      ...(attemptId ? { attemptId } : {}),
       upstream: true,
       ok: error === undefined,
       serviceMs: Math.max(0, now() - startedAt),
@@ -318,7 +316,15 @@ export function createRemoteGitCoordinator(
       } catch (error) {
         return { outcome: 'failed', flightId, error: errorText(error) }
       }
-      emit({ kind: 'dispatched', requestId, flightId, operation: 'push', waitedMs: now() - queuedAt, at: now() })
+      emit({
+        kind: 'dispatched',
+        requestId,
+        flightId,
+        operation: 'push',
+        attemptId: attempt.attemptId,
+        waitedMs: now() - queuedAt,
+        at: now(),
+      })
       const pushStartedAt = now()
       let output: string | undefined
       let commandError: unknown
@@ -327,9 +333,16 @@ export function createRemoteGitCoordinator(
       } catch (error) {
         commandError = error
       }
-      noteSubprocess(requestId, flightId, 'push', pushStartedAt, commandError)
+      noteSubprocess(requestId, flightId, 'push', pushStartedAt, commandError, attempt.attemptId)
       input.invalidate()
-      emit({ kind: 'invalidated', requestId, flightId, repoKey: input.scope.repoKey, at: now() })
+      emit({
+        kind: 'invalidated',
+        requestId,
+        flightId,
+        attemptId: attempt.attemptId,
+        repoKey: input.scope.repoKey,
+        at: now(),
+      })
       let readback: string | null = null
       let readbackError: unknown
       const readbackStartedAt = now()
@@ -338,9 +351,9 @@ export function createRemoteGitCoordinator(
       } catch (error) {
         readbackError = error
       }
-      noteSubprocess(requestId, flightId, 'readback', readbackStartedAt, readbackError)
+      noteSubprocess(requestId, flightId, 'readback', readbackStartedAt, readbackError, attempt.attemptId)
       const confirmed = readbackError === undefined && readback === attempt.expectedOid
-      emit({ kind: 'readback-settled', requestId, flightId, confirmed, at: now() })
+      emit({ kind: 'readback-settled', requestId, flightId, attemptId: attempt.attemptId, confirmed, at: now() })
       const settled: RemoteGitWriteAttempt = {
         ...attempt,
         status: confirmed ? 'confirmed' : 'unknown',
@@ -356,6 +369,7 @@ export function createRemoteGitCoordinator(
       return {
         outcome: confirmed ? 'confirmed' : 'unknown',
         flightId,
+        attemptId: attempt.attemptId,
         output,
         readback: readback ?? undefined,
         ...(confirmed ? {} : { error: settled.diagnosticRef }),
@@ -367,7 +381,7 @@ export function createRemoteGitCoordinator(
         error: errorText(error),
       }),
     )
-    terminal(requestId, flightId, outcome.outcome, outcome.error)
+    terminal(requestId, flightId, outcome.outcome, outcome.error, outcome.attemptId)
     return outcome
   }
 
@@ -405,9 +419,16 @@ export function createRemoteGitCoordinator(
       } catch (error) {
         readbackError = error
       }
-      noteSubprocess(requestId, flightId, 'readback', startedAt, readbackError)
+      noteSubprocess(requestId, flightId, 'readback', startedAt, readbackError, input.attempt.attemptId)
       const confirmed = readbackError === undefined && readback === input.attempt.expectedOid
-      emit({ kind: 'readback-settled', requestId, flightId, confirmed, at: now() })
+      emit({
+        kind: 'readback-settled',
+        requestId,
+        flightId,
+        attemptId: input.attempt.attemptId,
+        confirmed,
+        at: now(),
+      })
       const settled: RemoteGitWriteAttempt = {
         ...input.attempt,
         status: confirmed ? 'confirmed' : 'unknown',
@@ -417,13 +438,26 @@ export function createRemoteGitCoordinator(
       return {
         outcome: confirmed ? 'confirmed' : 'unknown',
         flightId,
+        attemptId: input.attempt.attemptId,
         readback: readback ?? undefined,
         ...(confirmed ? {} : { error: settled.diagnosticRef }),
       }
     }).catch((error): RemoteGitOutcome => ({ outcome: 'unknown', flightId, error: errorText(error) }))
-    terminal(requestId, flightId, outcome.outcome, outcome.error)
+    terminal(requestId, flightId, outcome.outcome, outcome.error, input.attempt.attemptId)
     return outcome
   }
+
+  const deleteRemoteBranchIfPresent = (input: RemoteGitDeleteInput): Promise<RemoteGitOutcome> =>
+    runDeleteRemoteBranchIfPresent(input, {
+      assertOpen,
+      now,
+      newId: randomUUID,
+      enqueue,
+      emit,
+      noteSubprocess,
+      terminal,
+      errorText,
+    })
 
   const close = async (): Promise<void> => {
     if (closed) return
@@ -454,6 +488,7 @@ export function createRemoteGitCoordinator(
     lsRemote,
     push,
     recoverPush,
+    deleteRemoteBranchIfPresent,
     ensureFresh,
     clearFreshness,
     lifecycleEvents: (): RemoteGitLifecycleEvent[] => [...events],

--- a/src/infra/remote-git-delete.ts
+++ b/src/infra/remote-git-delete.ts
@@ -1,0 +1,186 @@
+/** ADR-0011 Slice C: one serialized, nullable remote-branch delete operation. */
+
+import type { RemoteGitOutcome, RemoteGitWriteAttempt } from './remote-git-contracts.ts'
+import type { RemoteGitLifecycleEvent, RemoteGitScope, RemoteGitTerminalOutcome } from './remote-git-lifecycle.ts'
+
+export interface RemoteGitDeletePreparation {
+  destinationRef: string
+  expectedRemoteOid: string
+}
+
+export interface RemoteGitDeleteInput {
+  scope: RemoteGitScope
+  validate(): Promise<RemoteGitDeletePreparation>
+  preRead(plan: RemoteGitDeletePreparation): Promise<string | null>
+  persistAttempt(attempt: RemoteGitWriteAttempt): Promise<void>
+  execute(attempt: RemoteGitWriteAttempt): Promise<string>
+  invalidate(): void
+  readback(attempt: RemoteGitWriteAttempt): Promise<string | null>
+  settleAttempt(attempt: RemoteGitWriteAttempt): Promise<void>
+}
+
+interface DeleteRuntime {
+  assertOpen(): void
+  now(): number
+  newId(): string
+  enqueue(
+    scope: RemoteGitScope,
+    requestId: string,
+    flightId: string,
+    run: () => Promise<RemoteGitOutcome>,
+  ): Promise<RemoteGitOutcome>
+  emit(event: RemoteGitLifecycleEvent): void
+  noteSubprocess(
+    requestId: string,
+    flightId: string,
+    phase: 'pre-read' | 'push' | 'readback',
+    startedAt: number,
+    error?: unknown,
+    attemptId?: string,
+  ): void
+  terminal(
+    requestId: string,
+    flightId: string,
+    outcome: RemoteGitTerminalOutcome,
+    error?: unknown,
+    attemptId?: string,
+  ): void
+  errorText(error: unknown): string
+}
+
+export async function runDeleteRemoteBranchIfPresent(
+  input: RemoteGitDeleteInput,
+  runtime: DeleteRuntime,
+): Promise<RemoteGitOutcome> {
+  runtime.assertOpen()
+  const requestId = runtime.newId()
+  const flightId = runtime.newId()
+  const queuedAt = runtime.now()
+  runtime.emit({
+    kind: 'declared',
+    requestId,
+    scope: input.scope,
+    operation: 'delete-remote-branch-if-present',
+    at: runtime.now(),
+  })
+  const outcome = await runtime
+    .enqueue(input.scope, requestId, flightId, async () => {
+      let plan: RemoteGitDeletePreparation
+      try {
+        plan = await input.validate()
+      } catch (error) {
+        return { outcome: 'failed', flightId, error: runtime.errorText(error) }
+      }
+      runtime.emit({
+        kind: 'dispatched',
+        requestId,
+        flightId,
+        operation: 'delete-remote-branch-if-present',
+        waitedMs: runtime.now() - queuedAt,
+        at: runtime.now(),
+      })
+      let observedOid: string | null = null
+      const preReadStartedAt = runtime.now()
+      try {
+        observedOid = await input.preRead(plan)
+        runtime.noteSubprocess(requestId, flightId, 'pre-read', preReadStartedAt)
+      } catch (error) {
+        runtime.noteSubprocess(requestId, flightId, 'pre-read', preReadStartedAt, error)
+        return { outcome: 'unknown', flightId, error: runtime.errorText(error) }
+      }
+      if (observedOid === null) return { outcome: 'confirmed', flightId }
+      if (observedOid !== plan.expectedRemoteOid) {
+        return {
+          outcome: 'failed',
+          flightId,
+          error: `远端 ref 已变化: expected ${plan.expectedRemoteOid}, observed ${observedOid}`,
+        }
+      }
+
+      const attempt: RemoteGitWriteAttempt = {
+        attemptId: runtime.newId(),
+        scope: input.scope,
+        operationKind: 'delete',
+        destinationRef: plan.destinationRef,
+        expectedOid: null,
+        expectedRemoteOid: observedOid,
+        status: 'prepared',
+        preparedAt: new Date(runtime.now()).toISOString(),
+      }
+      try {
+        await input.persistAttempt(attempt)
+      } catch (error) {
+        return { outcome: 'failed', flightId, attemptId: attempt.attemptId, error: runtime.errorText(error) }
+      }
+
+      let output: string | undefined
+      let commandError: unknown
+      const pushStartedAt = runtime.now()
+      try {
+        output = await input.execute(attempt)
+      } catch (error) {
+        commandError = error
+      }
+      runtime.noteSubprocess(requestId, flightId, 'push', pushStartedAt, commandError, attempt.attemptId)
+      input.invalidate()
+      runtime.emit({
+        kind: 'invalidated',
+        requestId,
+        flightId,
+        attemptId: attempt.attemptId,
+        repoKey: input.scope.repoKey,
+        at: runtime.now(),
+      })
+
+      let readback: string | null = null
+      let readbackError: unknown
+      const readbackStartedAt = runtime.now()
+      try {
+        readback = await input.readback(attempt)
+      } catch (error) {
+        readbackError = error
+      }
+      runtime.noteSubprocess(requestId, flightId, 'readback', readbackStartedAt, readbackError, attempt.attemptId)
+      const confirmed = readbackError === undefined && readback === null
+      runtime.emit({
+        kind: 'readback-settled',
+        requestId,
+        flightId,
+        attemptId: attempt.attemptId,
+        confirmed,
+        at: runtime.now(),
+      })
+      const settled: RemoteGitWriteAttempt = {
+        ...attempt,
+        status: confirmed ? 'confirmed' : 'unknown',
+        ...(confirmed
+          ? {}
+          : {
+              diagnosticRef: runtime.errorText(readbackError ?? commandError ?? `readback=${readback ?? '<missing>'}`),
+            }),
+      }
+      try {
+        await input.settleAttempt(settled)
+      } catch (error) {
+        return {
+          outcome: 'unknown',
+          flightId,
+          attemptId: attempt.attemptId,
+          output,
+          readback: readback ?? undefined,
+          error: runtime.errorText(error),
+        }
+      }
+      return {
+        outcome: confirmed ? 'confirmed' : 'unknown',
+        flightId,
+        attemptId: attempt.attemptId,
+        output,
+        readback: readback ?? undefined,
+        ...(confirmed ? {} : { error: settled.diagnosticRef }),
+      }
+    })
+    .catch((error): RemoteGitOutcome => ({ outcome: 'unknown', flightId, error: runtime.errorText(error) }))
+  runtime.terminal(requestId, flightId, outcome.outcome, outcome.error, outcome.attemptId)
+  return outcome
+}

--- a/src/infra/remote-git-lifecycle.ts
+++ b/src/infra/remote-git-lifecycle.ts
@@ -6,7 +6,7 @@ export interface RemoteGitScope {
   remote: string
 }
 
-export type RemoteGitOperation = 'fetch' | 'push' | 'push-recovery' | 'ls-remote'
+export type RemoteGitOperation = 'fetch' | 'push' | 'push-recovery' | 'ls-remote' | 'delete-remote-branch-if-present'
 export type RemoteGitTerminalOutcome = 'confirmed' | 'failed' | 'unknown' | 'interrupted'
 
 export type RemoteGitLifecycleEvent =
@@ -17,7 +17,8 @@ export type RemoteGitLifecycleEvent =
       kind: 'dispatched'
       requestId: string
       flightId: string
-      operation: 'fetch' | 'push' | 'ls-remote'
+      operation: 'fetch' | 'push' | 'ls-remote' | 'delete-remote-branch-if-present'
+      attemptId?: string
       waitedMs: number
       at: number
     }
@@ -25,19 +26,28 @@ export type RemoteGitLifecycleEvent =
       kind: 'subprocess-settled'
       requestId: string
       flightId: string
-      phase: 'fetch' | 'push' | 'readback'
+      phase: 'fetch' | 'pre-read' | 'push' | 'readback'
+      attemptId?: string
       upstream: boolean
       ok: boolean
       serviceMs: number
       error: string | null
       at: number
     }
-  | { kind: 'invalidated'; requestId: string; flightId: string; repoKey: string; at: number }
-  | { kind: 'readback-settled'; requestId: string; flightId: string; confirmed: boolean; at: number }
+  | { kind: 'invalidated'; requestId: string; flightId: string; attemptId?: string; repoKey: string; at: number }
+  | {
+      kind: 'readback-settled'
+      requestId: string
+      flightId: string
+      attemptId?: string
+      confirmed: boolean
+      at: number
+    }
   | {
       kind: 'terminal'
       requestId: string
       flightId: string
+      attemptId?: string
       outcome: RemoteGitTerminalOutcome
       error: string | null
       at: number
@@ -46,6 +56,7 @@ export type RemoteGitLifecycleEvent =
       kind: 'late-result'
       requestId: string
       flightId: string
+      attemptId?: string
       outcome: RemoteGitTerminalOutcome
       error: string | null
       at: number

--- a/src/infra/remote-git.ts
+++ b/src/infra/remote-git.ts
@@ -1,13 +1,4 @@
-/**
- * Shared entry points for Controller-owned remote Git operations (issue #135
- * slice A). Thin, zero-behavior extraction: the command strings, timeouts and
- * sandbox policies match the call sites verbatim, and non-zero exits keep the
- * shared runCommand semantics. The Remote Git Coordinator (slice B) will own
- * these entry points — singleflight, the per-repository critical section, the
- * authoritative post-push readback and the snapshot invalidation broadcast
- * all wrap here for every migrated call site (the two compound flows pending
- * in slice C still go direct).
- */
+/** Controller-owned Remote Git entry points governed by ADR-0011. */
 
 import { randomUUID } from 'node:crypto'
 import type { Context } from '@deepseek-ai/cordis'
@@ -17,6 +8,7 @@ import {
   type RemoteGitFreshness,
   type RemoteGitWriteAttempt,
 } from './remote-git-coordinator.ts'
+import type { RemoteGitDeletePreparation } from './remote-git-delete.ts'
 import { createRemoteGitEvidenceSink } from './remote-git-evidence.ts'
 import { notifyLocalGitMutation } from './local-git-invalidate.ts'
 import { runCommand } from './runtime.ts'
@@ -91,6 +83,20 @@ function assertDestinationRef(value: string): void {
   if (!/^refs\/heads\/[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(value) || value.includes('..') || value.includes('@{')) {
     throw new Error(`非法远端目标 ref: ${value}`)
   }
+}
+
+async function readRemoteHead(
+  ctx: Context,
+  remote: string,
+  destinationRef: string,
+  options: RemoteGitCommandOptions,
+): Promise<string | null> {
+  const output = await runCommand(ctx, `git ls-remote --heads ${remote} ${quoted(destinationRef)}`, {
+    workdir: options.workdir,
+    timeoutMs: 30_000,
+    sandboxPolicy: options.sandboxPolicy,
+  })
+  return output.trim().split(/\s+/)[0] || null
 }
 
 export interface RemotePushPreparation {
@@ -214,20 +220,50 @@ export function remotePush(
         })
       },
       invalidate: () => notifyLocalGitMutation({ repoKey: options.repoKey }, 'remote-push', 'RemoteGitCoordinator'),
-      readback: async (attempt) => {
-        const output = await runCommand(ctx, `git ls-remote --heads ${remote} ${quoted(attempt.destinationRef)}`, {
-          workdir: options.workdir,
-          timeoutMs: 30_000,
-          sandboxPolicy: options.sandboxPolicy,
-        })
-        return output.trim().split(/\s+/)[0] || null
-      },
+      readback: (attempt) => readRemoteHead(ctx, remote, attempt.destinationRef, options),
       settleAttempt: options.settleAttempt,
     })
     .then((outcome) => {
       if (outcome.outcome !== 'confirmed') throw outcomeError('git push', outcome)
       return outcome.output ?? ''
     })
+}
+
+export async function remoteDeleteBranchIfPresent(
+  ctx: Context,
+  options: RemoteGitCommandOptions & {
+    prepare(): Promise<RemoteGitDeletePreparation>
+    persistAttempt(attempt: RemoteGitWriteAttempt): Promise<void>
+    settleAttempt(attempt: RemoteGitWriteAttempt): Promise<void>
+  },
+): Promise<string> {
+  const remote = normalizedRemote(options.remote)
+  const outcome = await remoteGitCoordinator().deleteRemoteBranchIfPresent({
+    scope: { repoKey: options.repoKey, repositoryId: options.repositoryId, remote },
+    validate: async () => {
+      const plan = await options.prepare()
+      assertDestinationRef(plan.destinationRef)
+      assertOid(plan.expectedRemoteOid, 'expectedRemoteOid')
+      return plan
+    },
+    preRead: (plan) => readRemoteHead(ctx, remote, plan.destinationRef, options),
+    persistAttempt: options.persistAttempt,
+    execute: (attempt) =>
+      runCommand(
+        ctx,
+        `git push --force-with-lease=${quoted(`${attempt.destinationRef}:${attempt.expectedRemoteOid}`)} ${remote} ${quoted(`:${attempt.destinationRef}`)}`,
+        {
+          workdir: options.workdir,
+          timeoutMs: options.timeoutMs ?? 120_000,
+          sandboxPolicy: options.sandboxPolicy,
+        },
+      ),
+    invalidate: () => notifyLocalGitMutation({ repoKey: options.repoKey }, 'remote-delete', 'RemoteGitCoordinator'),
+    readback: (attempt) => readRemoteHead(ctx, remote, attempt.destinationRef, options),
+    settleAttempt: options.settleAttempt,
+  })
+  if (outcome.outcome !== 'confirmed') throw outcomeError('git push --delete', outcome)
+  return outcome.output ?? ''
 }
 
 export async function recoverRemotePush(
@@ -240,14 +276,7 @@ export async function recoverRemotePush(
   const remote = normalizedRemote(options.remote ?? options.attempt.scope.remote)
   const outcome = await remoteGitCoordinator().recoverPush({
     attempt: options.attempt,
-    readback: async (attempt) => {
-      const output = await runCommand(ctx, `git ls-remote --heads ${remote} ${quoted(attempt.destinationRef)}`, {
-        workdir: options.workdir,
-        timeoutMs: 30_000,
-        sandboxPolicy: options.sandboxPolicy,
-      })
-      return output.trim().split(/\s+/)[0] || null
-    },
+    readback: (attempt) => readRemoteHead(ctx, remote, attempt.destinationRef, options),
     settleAttempt: options.settleAttempt,
   })
   if (outcome.outcome !== 'confirmed') throw outcomeError('git push recovery', outcome)

--- a/src/infra/state.ts
+++ b/src/infra/state.ts
@@ -42,6 +42,8 @@ export interface DeliveryCleanup {
   worktree: boolean
   localBranch: boolean
   remoteBranch: boolean
+  /** Merge-cleanup-owned delete marker; prepared recovery is readback-only. */
+  remoteBranchAttempt?: RemoteGitWriteAttempt
   issue: boolean
   /** 关闭评论写事务的 attempt marker(merge 清理步骤账本):'pending' 表示已准备派发,重启恢复只回读;'confirmed' 表示已发布。 */
   issueComment?: 'pending' | 'confirmed'

--- a/src/workflow/merge-remote-cleanup.ts
+++ b/src/workflow/merge-remote-cleanup.ts
@@ -1,0 +1,73 @@
+/** Remote branch cleanup settlement for ADR-0011 Slice C. */
+
+import type { Context } from '@deepseek-ai/cordis'
+import { recoverRemotePush, remoteDeleteBranchIfPresent } from '../infra/remote-git.ts'
+import { type IssueWorkflow, loadWorkflow } from '../infra/state.ts'
+
+interface CleanupOptions {
+  repoPath: string
+  sandboxPolicy: { mode: 'danger-full-access'; workspaceRoot: string }
+  persist(): Promise<void>
+}
+
+export async function cleanupRemoteBranch(
+  ctx: Context,
+  workflow: IssueWorkflow,
+  options: CleanupOptions,
+): Promise<void> {
+  const delivery = () => {
+    if (!workflow.delivery) throw new Error('delivery 状态丢失,拒绝清理')
+    return workflow.delivery
+  }
+  const persistAttempt = async (
+    attempt: NonNullable<ReturnType<typeof delivery>['cleanup']['remoteBranchAttempt']>,
+  ) => {
+    delivery().cleanup.remoteBranchAttempt = attempt
+    await options.persist()
+  }
+  const existing = delivery().cleanup.remoteBranchAttempt
+  if (existing?.status === 'confirmed') {
+    delivery().cleanup.remoteBranch = true
+    await options.persist()
+    return
+  }
+  if (existing?.status === 'prepared') {
+    await recoverRemotePush(ctx, {
+      repoKey: workflow.repoKey,
+      repositoryId: existing.scope.repositoryId,
+      remote: existing.scope.remote,
+      workdir: options.repoPath,
+      sandboxPolicy: options.sandboxPolicy,
+      attempt: existing,
+      settleAttempt: persistAttempt,
+    })
+    delivery().cleanup.remoteBranch = true
+    await options.persist()
+    return
+  }
+
+  await remoteDeleteBranchIfPresent(ctx, {
+    repoKey: workflow.repoKey,
+    workdir: options.repoPath,
+    sandboxPolicy: options.sandboxPolicy,
+    prepare: async () => {
+      const current = await loadWorkflow(workflow.key)
+      const currentDelivery = current?.delivery
+      if (!current || !currentDelivery || currentDelivery.status === 'archived') {
+        throw new Error('merge delivery 已失效,拒绝删除远端分支')
+      }
+      if (current.branch !== workflow.branch || currentDelivery.prHead !== delivery().prHead) {
+        throw new Error('merge cleanup 凭证已变化,拒绝删除远端分支')
+      }
+      if (currentDelivery.cleanup.remoteBranch) throw new Error('远端分支清理步骤已由其他执行者完成')
+      return {
+        destinationRef: `refs/heads/${current.branch}`,
+        expectedRemoteOid: currentDelivery.prHead,
+      }
+    },
+    persistAttempt,
+    settleAttempt: persistAttempt,
+  })
+  delivery().cleanup.remoteBranch = true
+  await options.persist()
+}

--- a/src/workflow/merge.ts
+++ b/src/workflow/merge.ts
@@ -40,6 +40,7 @@ import { collectMergeGateFailures, type MergeGateFailure, mergeGateRejection } f
 import { workflowBaseBranch } from './state-view.ts'
 import { baselineRestorePreview } from './baseline-restore.ts'
 import { type DevelopBaselinePreview, developBaselinePreview } from './develop-baseline-preview.ts'
+import { cleanupRemoteBranch } from './merge-remote-cleanup.ts'
 import { withWorkflowLock } from '../infra/workflow-lock.ts'
 
 export type MergeAuthorizationPreview =
@@ -489,13 +490,7 @@ export async function mergeAndCleanupUnlocked(ctx: Context, payload: unknown): P
 
   if (!delivery.cleanup.remoteBranch) {
     try {
-      await runCommand(
-        ctx,
-        `if git ls-remote --exit-code --heads origin ${shellQuote(`refs/heads/${workflow.branch}`)} >/dev/null 2>&1; then git push origin --delete ${shellQuote(workflow.branch)}; fi`,
-        { workdir: repoPath, timeoutMs: 60_000, sandboxPolicy: policy },
-      )
-      delivery.cleanup.remoteBranch = true
-      await persistStep()
+      await cleanupRemoteBranch(ctx, workflow, { repoPath, sandboxPolicy: policy, persist: persistStep })
     } catch (error) {
       return failCleanup('删除远端分支', error)
     }

--- a/tests/merge-edge.test.ts
+++ b/tests/merge-edge.test.ts
@@ -174,13 +174,18 @@ test('merge execution rejects an authorization whose exact PR base changed', asy
     await writeFile(join(home, '.clickvibe', 'config.yaml'), `repos:\n  o/r: ${repo}\nworktreeRoot: ${worktreeRoot}\n`)
     const stored = workflow('8', { worktree: worktreePath, branch: 'repo-issue-8', prNumber: '8' })
     await saveWorkflow(stored)
-    const ctx = prCtx({ head: stored.branch, sha: 'abcdef1234567890', base: 'release/2.0', baseSha: 'bbb2222' })
+    const ctx = prCtx({
+      head: stored.branch,
+      sha: 'abcdef1234567890abcdef1234567890abcdef12',
+      base: 'release/2.0',
+      baseSha: 'bbb2222',
+    })
     const result = await mergeAndCleanupUnlocked(ctx as never, {
       url: stored.url,
       target: {
         prNumber: '8',
         branch: stored.branch,
-        head: 'abcdef1234567890',
+        head: 'abcdef1234567890abcdef1234567890abcdef12',
         baseRef: 'release/2.0',
         baseSha: 'aaa1111',
         mergeFlag: '--merge',

--- a/tests/merge-remote-cleanup.test.ts
+++ b/tests/merge-remote-cleanup.test.ts
@@ -1,0 +1,332 @@
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import test from 'node:test'
+import {
+  closeRemoteGitCoordinator,
+  remoteGitCoordinator,
+  resetRemoteGitCoordinatorForTests,
+} from '../src/infra/remote-git.ts'
+import { deriveRemoteGitMetrics } from '../src/infra/remote-git-coordinator.ts'
+import type { RemoteGitWriteAttempt } from '../src/infra/remote-git-contracts.ts'
+import {
+  commitWorkflowMetadata,
+  issueKey,
+  type IssueWorkflow,
+  loadWorkflow,
+  workflowRevision,
+} from '../src/infra/state.ts'
+import { cleanupRemoteBranch } from '../src/workflow/merge-remote-cleanup.ts'
+import { commitWorkflowFixture } from './workflow-fixture.ts'
+
+const execFileAsync = promisify(execFile)
+
+function cleanupWorkflow(number: string): IssueWorkflow {
+  return {
+    key: issueKey('o/r', number),
+    url: `https://github.com/o/r/issues/${number}`,
+    repoKey: 'o/r',
+    worktree: '/tmp/clickvibe-cleanup',
+    branch: `clickvibe-issue-${number}`,
+    stage: 'passed',
+    devAgent: 'codex',
+    devTaskId: null,
+    devSessionId: null,
+    devSessionAgent: null,
+    devInterrupted: false,
+    reviewAgent: 'codex',
+    reviewTaskId: null,
+    reviewSessionId: null,
+    reviewSessionAgent: null,
+    reviewResult: { passed: true, issues: [] },
+    prNumber: number,
+    issueState: 'OPEN',
+    baseRef: 'origin/main',
+    delivery: {
+      status: 'cleanup-pending',
+      mergedAt: '2026-09-02T00:00:00Z',
+      prHead: 'a'.repeat(40),
+      mergeStrategy: 'merge',
+      cleanup: { worktree: true, localBranch: true, remoteBranch: false, issue: false },
+    },
+    updatedAt: Date.now(),
+    events: [],
+  }
+}
+
+test('merge cleanup persists one exact delete attempt and confirms the absent remote ref', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'clickvibe-merge-remote-cleanup-'))
+  const previousHome = process.env.HOME
+  const home = join(root, 'home')
+  process.env.HOME = home
+  const remote = join(root, 'remote.git')
+  const repo = join(root, 'repo')
+  resetRemoteGitCoordinatorForTests()
+  try {
+    await mkdir(home, { recursive: true })
+    await execFileAsync('git', ['init', '--bare', remote])
+    await execFileAsync('git', ['clone', remote, repo])
+    const git = (...args: string[]) => execFileAsync('git', ['-C', repo, ...args])
+    await git('config', 'user.name', 'clickvibe-test')
+    await git('config', 'user.email', 'clickvibe-test@example.invalid')
+    await git('commit', '--allow-empty', '-m', 'base')
+    await git('branch', '-M', 'main')
+    await git('push', '-u', 'origin', 'main')
+    const branch = 'clickvibe-issue-135'
+    await git('switch', '-c', branch)
+    await git('commit', '--allow-empty', '-m', 'delivery')
+    const prHead = (await git('rev-parse', 'HEAD')).stdout.trim()
+    await git('push', 'origin', `${prHead}:refs/heads/${branch}`)
+
+    const workflow = {
+      key: issueKey('o/r', '135'),
+      url: 'https://github.com/o/r/issues/135',
+      repoKey: 'o/r',
+      worktree: repo,
+      branch,
+      stage: 'passed',
+      devAgent: 'codex',
+      devTaskId: null,
+      devSessionId: null,
+      devSessionAgent: null,
+      devInterrupted: false,
+      reviewAgent: 'codex',
+      reviewTaskId: null,
+      reviewSessionId: null,
+      reviewSessionAgent: null,
+      reviewResult: { passed: true, issues: [] },
+      prNumber: '155',
+      issueState: 'OPEN',
+      baseRef: 'origin/main',
+      delivery: {
+        status: 'cleanup-pending',
+        mergedAt: new Date().toISOString(),
+        prHead,
+        mergeStrategy: 'merge',
+        cleanup: { worktree: true, localBranch: true, remoteBranch: false, issue: false },
+      },
+      updatedAt: Date.now(),
+      events: [],
+    } satisfies IssueWorkflow
+    await commitWorkflowFixture(workflow, null)
+    const active = await loadWorkflow(workflow.key)
+    assert.ok(active)
+    const ctx = {
+      shell: {
+        resolve(spec: unknown) {
+          return spec
+        },
+        async run(spec: { command: string; workdir?: string }) {
+          try {
+            const output = await execFileAsync('/bin/sh', ['-c', spec.command], {
+              cwd: spec.workdir,
+              encoding: 'utf8',
+            })
+            return { exitCode: 0, stdout: { text: output.stdout }, stderr: { text: output.stderr } }
+          } catch (error) {
+            const detail = error as { code?: number; stdout?: string; stderr?: string }
+            return {
+              exitCode: detail.code ?? 1,
+              stdout: { text: detail.stdout ?? '' },
+              stderr: { text: detail.stderr ?? '' },
+            }
+          }
+        },
+      },
+    }
+    await cleanupRemoteBranch(ctx as never, active, {
+      repoPath: repo,
+      sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: repo },
+      persist: async () => {
+        const current = await loadWorkflow(active.key)
+        if (!current) throw new Error('workflow disappeared during cleanup test')
+        Object.assign(
+          active,
+          await commitWorkflowMetadata(current, workflowRevision(current), { delivery: active.delivery }),
+        )
+      },
+    })
+
+    const persisted = await loadWorkflow(active.key)
+    assert.equal(persisted?.delivery?.cleanup.remoteBranch, true)
+    assert.equal(persisted?.delivery?.cleanup.remoteBranchAttempt?.status, 'confirmed')
+    assert.equal(persisted?.delivery?.cleanup.remoteBranchAttempt?.expectedRemoteOid, prHead)
+    assert.equal((await git('ls-remote', '--heads', 'origin', `refs/heads/${branch}`)).stdout.trim(), '')
+    const events = remoteGitCoordinator().lifecycleEvents()
+    const metrics = deriveRemoteGitMetrics(events)
+    assert.equal(events.filter((event) => event.kind === 'declared').length, 1)
+    assert.deepEqual(
+      events
+        .filter((event) => event.kind === 'subprocess-settled')
+        .map((event) => (event.kind === 'subprocess-settled' ? event.phase : '')),
+      ['pre-read', 'push', 'readback'],
+    )
+    assert.equal(metrics.upstreamRequests, 3)
+    assert.equal(metrics.invalidations, 1)
+    assert.equal(metrics.writeReadbacks, 1)
+  } finally {
+    await closeRemoteGitCoordinator()
+    resetRemoteGitCoordinatorForTests()
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('confirmed and prepared delete markers converge without redispatching a delete', async (t) => {
+  await t.test('confirmed marker only advances the cleanup ledger', async () => {
+    const workflow = cleanupWorkflow('136')
+    const attempt: RemoteGitWriteAttempt = {
+      attemptId: 'confirmed-delete',
+      scope: { repoKey: workflow.repoKey, remote: 'origin' },
+      operationKind: 'delete',
+      destinationRef: `refs/heads/${workflow.branch}`,
+      expectedOid: null,
+      expectedRemoteOid: workflow.delivery?.prHead ?? null,
+      status: 'confirmed',
+      preparedAt: '2026-09-02T00:00:00Z',
+    }
+    if (!workflow.delivery) throw new Error('test workflow delivery missing')
+    workflow.delivery.cleanup.remoteBranchAttempt = attempt
+    let persists = 0
+    await cleanupRemoteBranch({} as never, workflow, {
+      repoPath: workflow.worktree,
+      sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: workflow.worktree },
+      persist: async () => {
+        persists += 1
+      },
+    })
+    assert.equal(workflow.delivery.cleanup.remoteBranch, true)
+    assert.equal(persists, 1)
+  })
+
+  await t.test('prepared marker performs one readback and zero push', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'clickvibe-prepared-delete-'))
+    const previousHome = process.env.HOME
+    process.env.HOME = root
+    resetRemoteGitCoordinatorForTests()
+    const workflow = cleanupWorkflow('137')
+    if (!workflow.delivery) throw new Error('test workflow delivery missing')
+    workflow.delivery.cleanup.remoteBranchAttempt = {
+      attemptId: 'prepared-delete',
+      scope: { repoKey: workflow.repoKey, remote: 'origin' },
+      operationKind: 'delete',
+      destinationRef: `refs/heads/${workflow.branch}`,
+      expectedOid: null,
+      expectedRemoteOid: workflow.delivery.prHead,
+      status: 'prepared',
+      preparedAt: '2026-09-02T00:00:00Z',
+    }
+    const commands: string[] = []
+    let persists = 0
+    const ctx = {
+      shell: {
+        resolve(spec: unknown) {
+          return spec
+        },
+        async run(spec: { command: string }) {
+          commands.push(spec.command)
+          return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
+        },
+      },
+    }
+    try {
+      await cleanupRemoteBranch(ctx as never, workflow, {
+        repoPath: workflow.worktree,
+        sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: workflow.worktree },
+        persist: async () => {
+          persists += 1
+        },
+      })
+      assert.equal(workflow.delivery.cleanup.remoteBranch, true)
+      assert.equal(workflow.delivery.cleanup.remoteBranchAttempt?.status, 'confirmed')
+      assert.equal(persists, 2)
+      assert.deepEqual(commands, [`git ls-remote --heads origin 'refs/heads/${workflow.branch}'`])
+      assert.equal(
+        commands.some((command) => command.startsWith('git push')),
+        false,
+      )
+    } finally {
+      await closeRemoteGitCoordinator()
+      resetRemoteGitCoordinatorForTests()
+      if (previousHome === undefined) delete process.env.HOME
+      else process.env.HOME = previousHome
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})
+
+test('merge cleanup revalidates every delivery credential inside the coordinator lease', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'clickvibe-cleanup-validation-'))
+  const previousHome = process.env.HOME
+  process.env.HOME = root
+  resetRemoteGitCoordinatorForTests()
+  const ctx = {
+    shell: {
+      resolve(spec: unknown) {
+        return spec
+      },
+      async run(spec: { command: string }) {
+        throw new Error(`unexpected remote command: ${spec.command}`)
+      },
+    },
+  }
+  const run = (workflow: IssueWorkflow) =>
+    cleanupRemoteBranch(ctx as never, workflow, {
+      repoPath: workflow.worktree,
+      sandboxPolicy: { mode: 'danger-full-access', workspaceRoot: workflow.worktree },
+      persist: async () => {
+        throw new Error('validation rejection must not persist')
+      },
+    })
+  try {
+    const missingDelivery = cleanupWorkflow('140')
+    delete missingDelivery.delivery
+    await assert.rejects(run(missingDelivery), /delivery 状态丢失/)
+
+    const missingCurrent = cleanupWorkflow('141')
+    await assert.rejects(run(missingCurrent), /merge delivery 已失效/)
+
+    const currentWithoutDelivery = cleanupWorkflow('142')
+    const claimantWithoutDelivery = structuredClone(currentWithoutDelivery)
+    delete currentWithoutDelivery.delivery
+    await commitWorkflowFixture(currentWithoutDelivery, null)
+    await assert.rejects(run(claimantWithoutDelivery), /merge delivery 已失效/)
+
+    const archived = cleanupWorkflow('143')
+    const archivedClaimant = structuredClone(archived)
+    if (!archived.delivery) throw new Error('test workflow delivery missing')
+    archived.delivery.status = 'archived'
+    await commitWorkflowFixture(archived, null)
+    await assert.rejects(run(archivedClaimant), /merge delivery 已失效/)
+
+    const changedBranch = cleanupWorkflow('144')
+    const branchClaimant = structuredClone(changedBranch)
+    changedBranch.branch = 'competitor-branch'
+    await commitWorkflowFixture(changedBranch, null)
+    await assert.rejects(run(branchClaimant), /merge cleanup 凭证已变化/)
+
+    const changedHead = cleanupWorkflow('145')
+    const headClaimant = structuredClone(changedHead)
+    if (!changedHead.delivery) throw new Error('test workflow delivery missing')
+    changedHead.delivery.prHead = 'b'.repeat(40)
+    await commitWorkflowFixture(changedHead, null)
+    await assert.rejects(run(headClaimant), /merge cleanup 凭证已变化/)
+
+    const alreadyComplete = cleanupWorkflow('146')
+    const completeClaimant = structuredClone(alreadyComplete)
+    if (!alreadyComplete.delivery) throw new Error('test workflow delivery missing')
+    alreadyComplete.delivery.cleanup.remoteBranch = true
+    await commitWorkflowFixture(alreadyComplete, null)
+    await assert.rejects(run(completeClaimant), /远端分支清理步骤已由其他执行者完成/)
+  } finally {
+    await closeRemoteGitCoordinator()
+    resetRemoteGitCoordinatorForTests()
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/tests/remote-git-delete.test.ts
+++ b/tests/remote-git-delete.test.ts
@@ -1,0 +1,430 @@
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import test from 'node:test'
+import {
+  createRemoteGitCoordinator,
+  deriveRemoteGitMetrics,
+  type RemoteGitWriteAttempt,
+} from '../src/infra/remote-git-coordinator.ts'
+
+const execFileAsync = promisify(execFile)
+
+interface RepositoryFixture {
+  remote: string
+  repo: string
+  cleanup(): Promise<void>
+}
+
+async function repositoryFixture(label: string): Promise<RepositoryFixture> {
+  const root = await mkdtemp(join(tmpdir(), `clickvibe-remote-delete-${label}-`))
+  const remote = join(root, 'remote.git')
+  const repo = join(root, 'repo')
+  await execFileAsync('git', ['init', '--bare', remote])
+  await execFileAsync('git', ['clone', remote, repo])
+  await execFileAsync('git', ['-C', repo, 'config', 'user.name', 'clickvibe-test'])
+  await execFileAsync('git', ['-C', repo, 'config', 'user.email', 'clickvibe-test@example.invalid'])
+  await execFileAsync('git', ['-C', repo, 'commit', '--allow-empty', '-m', 'base'])
+  await execFileAsync('git', ['-C', repo, 'branch', '-M', 'main'])
+  await execFileAsync('git', ['-C', repo, 'push', '-u', 'origin', 'main'])
+  return { remote, repo, cleanup: () => rm(root, { recursive: true, force: true }) }
+}
+
+function deferred(): { promise: Promise<void>; resolve(): void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+async function commit(repo: string, message: string): Promise<string> {
+  await execFileAsync('git', ['-C', repo, 'commit', '--allow-empty', '-m', message])
+  return (await execFileAsync('git', ['-C', repo, 'rev-parse', 'HEAD'])).stdout.trim()
+}
+
+async function updateRemote(remote: string, ref: string, oid: string | null): Promise<void> {
+  await execFileAsync('git', [`--git-dir=${remote}`, 'update-ref', ...(oid === null ? ['-d', ref] : [ref, oid])])
+}
+
+async function seedRemoteObject(repo: string, oid: string): Promise<void> {
+  await execFileAsync('git', ['-C', repo, 'push', 'origin', `${oid}:refs/heads/object-seed`])
+}
+
+async function remoteOid(repo: string, ref: string): Promise<string | null> {
+  const result = await execFileAsync('git', ['-C', repo, 'ls-remote', '--heads', 'origin', ref])
+  return result.stdout.trim().split(/\s+/)[0] || null
+}
+
+async function deleteWithLease(repo: string, attempt: RemoteGitWriteAttempt): Promise<string> {
+  const lease = `--force-with-lease=${attempt.destinationRef}:${attempt.expectedRemoteOid}`
+  const result = await execFileAsync('git', ['-C', repo, 'push', lease, 'origin', `:${attempt.destinationRef}`])
+  return result.stdout
+}
+
+test('initially absent cleanup ref is confirmed by one pre-read with zero marker, push and invalidation', async () => {
+  const fixture = await repositoryFixture('absent')
+  const coordinator = createRemoteGitCoordinator()
+  const destinationRef = 'refs/heads/cleanup'
+  const candidateOid = (await execFileAsync('git', ['-C', fixture.repo, 'rev-parse', 'HEAD'])).stdout.trim()
+  let markers = 0
+  let pushes = 0
+  let invalidations = 0
+  let settlements = 0
+  try {
+    const outcome = await coordinator.deleteRemoteBranchIfPresent({
+      scope: { repoKey: 'o/absent', remote: 'origin' },
+      validate: async () => ({ destinationRef, expectedRemoteOid: candidateOid }),
+      preRead: () => remoteOid(fixture.repo, destinationRef),
+      persistAttempt: async () => {
+        markers += 1
+      },
+      execute: async (attempt) => {
+        pushes += 1
+        return deleteWithLease(fixture.repo, attempt)
+      },
+      invalidate: () => {
+        invalidations += 1
+      },
+      readback: (attempt) => remoteOid(fixture.repo, attempt.destinationRef),
+      settleAttempt: async () => {
+        settlements += 1
+      },
+    })
+
+    assert.equal(outcome.outcome, 'confirmed')
+    assert.equal(markers, 0)
+    assert.equal(pushes, 0)
+    assert.equal(invalidations, 0)
+    assert.equal(settlements, 0)
+    const metrics = deriveRemoteGitMetrics(coordinator.lifecycleEvents())
+    assert.equal(metrics.logicalRequests, 1)
+    assert.equal(metrics.executions, 1)
+    assert.equal(metrics.upstreamRequests, 1)
+    assert.equal(metrics.writeReadbacks, 0)
+    const phases = coordinator
+      .lifecycleEvents()
+      .filter((event) => event.kind === 'subprocess-settled')
+      .map((event) => (event.kind === 'subprocess-settled' ? event.phase : ''))
+    assert.deepEqual(phases, ['pre-read'])
+    const terminal = coordinator.lifecycleEvents().find((event) => event.kind === 'terminal')
+    assert.equal(terminal?.kind === 'terminal' ? terminal.attemptId : 'missing', undefined)
+  } finally {
+    await coordinator.close()
+    await fixture.cleanup()
+  }
+})
+
+test('different-OID rebuild between pre-read and delete is preserved by the exact lease', async () => {
+  const fixture = await repositoryFixture('different-oid')
+  const coordinator = createRemoteGitCoordinator()
+  const destinationRef = 'refs/heads/cleanup'
+  const candidateOid = await commit(fixture.repo, 'candidate')
+  const competingOid = await commit(fixture.repo, 'competitor')
+  await seedRemoteObject(fixture.repo, competingOid)
+  await updateRemote(fixture.remote, destinationRef, candidateOid)
+  const enteredPush = deferred()
+  const releasePush = deferred()
+  const persisted: RemoteGitWriteAttempt[] = []
+  const settled: RemoteGitWriteAttempt[] = []
+  let invalidations = 0
+  try {
+    const deletion = coordinator.deleteRemoteBranchIfPresent({
+      scope: { repoKey: 'o/different', remote: 'origin' },
+      validate: async () => ({ destinationRef, expectedRemoteOid: candidateOid }),
+      preRead: () => remoteOid(fixture.repo, destinationRef),
+      persistAttempt: async (attempt) => {
+        persisted.push(attempt)
+      },
+      execute: async (attempt) => {
+        enteredPush.resolve()
+        await releasePush.promise
+        return deleteWithLease(fixture.repo, attempt)
+      },
+      invalidate: () => {
+        invalidations += 1
+      },
+      readback: (attempt) => remoteOid(fixture.repo, attempt.destinationRef),
+      settleAttempt: async (attempt) => {
+        settled.push(attempt)
+      },
+    })
+
+    await enteredPush.promise
+    await updateRemote(fixture.remote, destinationRef, competingOid)
+    releasePush.resolve()
+    const outcome = await deletion
+
+    assert.equal(outcome.outcome, 'unknown')
+    assert.equal(await remoteOid(fixture.repo, destinationRef), competingOid)
+    assert.equal(persisted.length, 1)
+    assert.equal(persisted[0].status, 'prepared')
+    assert.equal(settled[0].status, 'unknown')
+    assert.equal(invalidations, 1)
+    const terminal = coordinator.lifecycleEvents().find((event) => event.kind === 'terminal')
+    assert.equal(terminal?.kind === 'terminal' ? terminal.attemptId : null, persisted[0].attemptId)
+  } finally {
+    releasePush.resolve()
+    await coordinator.close()
+    await fixture.cleanup()
+  }
+})
+
+test('same-OID delete and rebuild stays inside the accepted ref identity boundary', async () => {
+  const fixture = await repositoryFixture('same-oid')
+  const coordinator = createRemoteGitCoordinator()
+  const destinationRef = 'refs/heads/cleanup'
+  const candidateOid = await commit(fixture.repo, 'candidate')
+  await seedRemoteObject(fixture.repo, candidateOid)
+  await updateRemote(fixture.remote, destinationRef, candidateOid)
+  const enteredPush = deferred()
+  const releasePush = deferred()
+  const settled: RemoteGitWriteAttempt[] = []
+  try {
+    const deletion = coordinator.deleteRemoteBranchIfPresent({
+      scope: { repoKey: 'o/same', remote: 'origin' },
+      validate: async () => ({ destinationRef, expectedRemoteOid: candidateOid }),
+      preRead: () => remoteOid(fixture.repo, destinationRef),
+      persistAttempt: async () => undefined,
+      execute: async (attempt) => {
+        enteredPush.resolve()
+        await releasePush.promise
+        return deleteWithLease(fixture.repo, attempt)
+      },
+      invalidate: () => undefined,
+      readback: (attempt) => remoteOid(fixture.repo, attempt.destinationRef),
+      settleAttempt: async (attempt) => {
+        settled.push(attempt)
+      },
+    })
+
+    await enteredPush.promise
+    await updateRemote(fixture.remote, destinationRef, null)
+    await updateRemote(fixture.remote, destinationRef, candidateOid)
+    releasePush.resolve()
+    const outcome = await deletion
+
+    assert.equal(outcome.outcome, 'confirmed')
+    assert.equal(await remoteOid(fixture.repo, destinationRef), null)
+    assert.equal(settled[0].status, 'confirmed')
+  } finally {
+    releasePush.resolve()
+    await coordinator.close()
+    await fixture.cleanup()
+  }
+})
+
+test('prepared cleanup delete recovers by readback without a second receive', async () => {
+  const fixture = await repositoryFixture('recovery')
+  const firstOwner = createRemoteGitCoordinator()
+  const destinationRef = 'refs/heads/cleanup'
+  const candidateOid = await commit(fixture.repo, 'candidate')
+  await seedRemoteObject(fixture.repo, candidateOid)
+  await updateRemote(fixture.remote, destinationRef, candidateOid)
+  const counterPath = join(fixture.remote, 'delete-receives')
+  const hookPath = join(fixture.remote, 'hooks', 'pre-receive')
+  await writeFile(hookPath, `#!/bin/sh\nprintf 'delete\\n' >> '${counterPath}'\n`)
+  await chmod(hookPath, 0o755)
+  const attempt: RemoteGitWriteAttempt = {
+    attemptId: 'cleanup-recovery',
+    scope: { repoKey: 'o/recovery-delete', remote: 'origin' },
+    operationKind: 'delete',
+    destinationRef,
+    expectedOid: null,
+    expectedRemoteOid: candidateOid,
+    status: 'prepared',
+    preparedAt: new Date().toISOString(),
+  }
+  try {
+    await deleteWithLease(fixture.repo, attempt)
+    assert.equal((await readFile(counterPath, 'utf8')).trim().split('\n').length, 1)
+    await firstOwner.close()
+
+    const restarted = createRemoteGitCoordinator()
+    let settled: RemoteGitWriteAttempt | null = null
+    const outcome = await restarted.recoverPush({
+      attempt,
+      readback: (plan) => remoteOid(fixture.repo, plan.destinationRef),
+      settleAttempt: async (value) => {
+        settled = value
+      },
+    })
+    assert.equal(outcome.outcome, 'confirmed')
+    assert.equal(settled?.status, 'confirmed')
+    assert.equal((await readFile(counterPath, 'utf8')).trim().split('\n').length, 1)
+    assert.equal(
+      restarted.lifecycleEvents().filter((event) => event.kind === 'subprocess-settled' && event.phase === 'push')
+        .length,
+      0,
+    )
+    await restarted.close()
+  } finally {
+    await firstOwner.close()
+    await fixture.cleanup()
+  }
+})
+
+test('delete boundary failures remain zero-write or conservatively unknown', async (t) => {
+  const oid = 'c'.repeat(40)
+  const destinationRef = 'refs/heads/cleanup'
+  const baseInput = () => ({
+    scope: { repoKey: 'o/delete-failures', remote: 'origin' },
+    validate: async () => ({ destinationRef, expectedRemoteOid: oid }),
+    preRead: async () => oid,
+    persistAttempt: async () => undefined,
+    execute: async () => 'deleted',
+    invalidate: () => undefined,
+    readback: async () => null,
+    settleAttempt: async () => undefined,
+  })
+
+  await t.test('validation failure dispatches no subprocess', async () => {
+    const coordinator = createRemoteGitCoordinator()
+    try {
+      const outcome = await coordinator.deleteRemoteBranchIfPresent({
+        ...baseInput(),
+        validate: async () => {
+          throw new Error('stale cleanup credential')
+        },
+      })
+      assert.equal(outcome.outcome, 'failed')
+      assert.match(outcome.error ?? '', /stale cleanup credential/)
+      assert.equal(
+        coordinator.lifecycleEvents().some((event) => event.kind === 'subprocess-settled'),
+        false,
+      )
+    } finally {
+      await coordinator.close()
+    }
+  })
+
+  await t.test('pre-read failure is unknown with no marker or write', async () => {
+    const coordinator = createRemoteGitCoordinator()
+    let markers = 0
+    try {
+      const outcome = await coordinator.deleteRemoteBranchIfPresent({
+        ...baseInput(),
+        preRead: async () => {
+          throw new Error('remote unavailable')
+        },
+        persistAttempt: async () => {
+          markers += 1
+        },
+      })
+      assert.equal(outcome.outcome, 'unknown')
+      assert.equal(markers, 0)
+    } finally {
+      await coordinator.close()
+    }
+  })
+
+  await t.test('pre-read OID mismatch is a failed zero-write decision', async () => {
+    const coordinator = createRemoteGitCoordinator()
+    let writes = 0
+    try {
+      const outcome = await coordinator.deleteRemoteBranchIfPresent({
+        ...baseInput(),
+        preRead: async () => 'd'.repeat(40),
+        execute: async () => {
+          writes += 1
+          return ''
+        },
+      })
+      assert.equal(outcome.outcome, 'failed')
+      assert.match(outcome.error ?? '', /远端 ref 已变化/)
+      assert.equal(writes, 0)
+    } finally {
+      await coordinator.close()
+    }
+  })
+
+  await t.test('marker persistence failure dispatches no write', async () => {
+    const coordinator = createRemoteGitCoordinator()
+    let writes = 0
+    try {
+      const outcome = await coordinator.deleteRemoteBranchIfPresent({
+        ...baseInput(),
+        persistAttempt: async () => {
+          throw new Error('marker disk failure')
+        },
+        execute: async () => {
+          writes += 1
+          return ''
+        },
+      })
+      assert.equal(outcome.outcome, 'failed')
+      assert.match(outcome.error ?? '', /marker disk failure/)
+      assert.equal(writes, 0)
+    } finally {
+      await coordinator.close()
+    }
+  })
+
+  await t.test('readback failure settles unknown', async () => {
+    const coordinator = createRemoteGitCoordinator()
+    let settled: RemoteGitWriteAttempt | null = null
+    try {
+      const outcome = await coordinator.deleteRemoteBranchIfPresent({
+        ...baseInput(),
+        readback: async () => {
+          throw new Error('readback unavailable')
+        },
+        settleAttempt: async (attempt) => {
+          settled = attempt
+        },
+      })
+      assert.equal(outcome.outcome, 'unknown')
+      assert.equal(settled?.status, 'unknown')
+      assert.match(settled?.diagnosticRef ?? '', /readback unavailable/)
+    } finally {
+      await coordinator.close()
+    }
+  })
+
+  await t.test('settlement persistence failure remains unknown', async () => {
+    const coordinator = createRemoteGitCoordinator()
+    try {
+      const outcome = await coordinator.deleteRemoteBranchIfPresent({
+        ...baseInput(),
+        settleAttempt: async () => {
+          throw new Error('settlement disk failure')
+        },
+      })
+      assert.equal(outcome.outcome, 'unknown')
+      assert.match(outcome.error ?? '', /settlement disk failure/)
+      assert.ok(outcome.attemptId)
+    } finally {
+      await coordinator.close()
+    }
+  })
+
+  await t.test('queue timeout is converted to a terminal unknown', async () => {
+    const coordinator = createRemoteGitCoordinator({ queueTimeoutMs: 5 })
+    const entered = deferred()
+    const release = deferred()
+    const blocker = coordinator.fetch({
+      scope: { repoKey: 'o/delete-failures', remote: 'origin' },
+      prune: true,
+      execute: async () => {
+        entered.resolve()
+        await release.promise
+        return ''
+      },
+      invalidate: () => undefined,
+      readback: async () => '',
+    })
+    try {
+      await entered.promise
+      const outcome = await coordinator.deleteRemoteBranchIfPresent(baseInput())
+      assert.equal(outcome.outcome, 'unknown')
+      assert.match(outcome.error ?? '', /排队超过/)
+    } finally {
+      release.resolve()
+      await blocker
+      await coordinator.close()
+    }
+  })
+})

--- a/tests/remote-git.test.ts
+++ b/tests/remote-git.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import type { Context } from '@deepseek-ai/cordis'
-import { remoteFetch, remotePush } from '../src/infra/remote-git.ts'
+import { remoteDeleteBranchIfPresent, remoteFetch, remotePush } from '../src/infra/remote-git.ts'
 
 function recordingShell(exitCode = 0, outputFor: (command: string) => string = () => 'out\n') {
   const commands: Array<{ command: string; workdir?: string; timeoutMs?: number }> = []
@@ -87,6 +87,56 @@ test('remotePush freezes an exact oid and performs one authoritative readback', 
     `git push --force-with-lease='refs/heads/main:${leaseOid}' origin '${forceOid}:refs/heads/main'`,
   )
   assert.equal(force.commands[1].command, "git ls-remote --heads origin 'refs/heads/main'")
+})
+
+test('remote delete performs a dedicated pre-read and only creates a marker when the ref exists', async () => {
+  const oid = 'd'.repeat(40)
+  let reads = 0
+  const present = recordingShell(0, (command) => {
+    if (!command.startsWith('git ls-remote')) return 'deleted\n'
+    reads += 1
+    return reads === 1 ? `${oid}\trefs/heads/feature\n` : ''
+  })
+  const states: string[] = []
+  await remoteDeleteBranchIfPresent(present.ctx, {
+    repoKey: 'ai-daming/clickvibe',
+    workdir: '/wt',
+    prepare: async () => ({ destinationRef: 'refs/heads/feature', expectedRemoteOid: oid }),
+    persistAttempt: async (attempt) => {
+      states.push(attempt.status)
+    },
+    settleAttempt: async (attempt) => {
+      states.push(attempt.status)
+    },
+  })
+  assert.deepEqual(
+    present.commands.map((command) => command.command),
+    [
+      "git ls-remote --heads origin 'refs/heads/feature'",
+      `git push --force-with-lease='refs/heads/feature:${oid}' origin ':refs/heads/feature'`,
+      "git ls-remote --heads origin 'refs/heads/feature'",
+    ],
+  )
+  assert.deepEqual(states, ['prepared', 'confirmed'])
+
+  const absent = recordingShell(0, () => '')
+  let markers = 0
+  await remoteDeleteBranchIfPresent(absent.ctx, {
+    repoKey: 'ai-daming/clickvibe',
+    workdir: '/wt',
+    prepare: async () => ({ destinationRef: 'refs/heads/missing', expectedRemoteOid: oid }),
+    persistAttempt: async () => {
+      markers += 1
+    },
+    settleAttempt: async () => {
+      markers += 1
+    },
+  })
+  assert.deepEqual(
+    absent.commands.map((command) => command.command),
+    ["git ls-remote --heads origin 'refs/heads/missing'"],
+  )
+  assert.equal(markers, 0)
 })
 
 test('non-zero exits reject through the shared runCommand semantics', async () => {

--- a/tests/review-dense-access.test.ts
+++ b/tests/review-dense-access.test.ts
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import test from 'node:test'
+import { createGithubGatewayOwner } from '../src/github/gateway-owner.ts'
+import { deriveGatewayMetrics } from '../src/github/gateway-lifecycle.ts'
+import { GithubRestReader } from '../src/github/rest.ts'
+import { createRemoteGitCoordinator, deriveRemoteGitMetrics } from '../src/infra/remote-git-coordinator.ts'
+
+const execFileAsync = promisify(execFile)
+
+function deferred(): { promise: Promise<void>; resolve(): void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+test('#133 review-dense keeps Remote Git at 1+2 joins, GitHub at most 9 and total upstream at most 10', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'clickvibe-review-dense-'))
+  const remote = join(root, 'remote.git')
+  const repo = join(root, 'repo')
+  const remoteOwner = createRemoteGitCoordinator()
+  const githubOwner = createGithubGatewayOwner()
+  const fetchEntered = deferred()
+  const releaseFetch = deferred()
+  const githubCommands: string[] = []
+  try {
+    await execFileAsync('git', ['init', '--bare', remote])
+    await execFileAsync('git', ['clone', remote, repo])
+    await execFileAsync('git', ['-C', repo, 'config', 'user.name', 'clickvibe-test'])
+    await execFileAsync('git', ['-C', repo, 'config', 'user.email', 'clickvibe-test@example.invalid'])
+    await execFileAsync('git', ['-C', repo, 'commit', '--allow-empty', '-m', 'base'])
+    await execFileAsync('git', ['-C', repo, 'branch', '-M', 'main'])
+    await execFileAsync('git', ['-C', repo, 'push', '-u', 'origin', 'main'])
+
+    const ctx = {
+      shell: {
+        resolve(spec: unknown) {
+          return spec
+        },
+        async run(spec: { command: string }) {
+          githubCommands.push(spec.command)
+          const body = spec.command.includes('/reviews')
+            ? []
+            : [
+                {
+                  number: githubCommands.length,
+                  state: 'open',
+                  merged_at: null,
+                  updated_at: '2026-09-02T00:00:00Z',
+                  head: { ref: 'review', sha: 'a'.repeat(40) },
+                  base: { ref: 'main', sha: 'b'.repeat(40) },
+                },
+              ]
+          return {
+            exitCode: 0,
+            stdout: {
+              text: [
+                'HTTP/1.1 200 OK',
+                'x-ratelimit-resource: core',
+                'x-ratelimit-limit: 5000',
+                'x-ratelimit-remaining: 4999',
+                'x-ratelimit-used: 1',
+                'x-ratelimit-reset: 4102444800',
+                '',
+                JSON.stringify(body),
+              ].join('\n'),
+            },
+            stderr: { text: '' },
+          }
+        },
+      },
+    }
+    const github = new GithubRestReader(ctx as never, { owner: githubOwner, minimumIntervalMs: 0 })
+    let physicalFetches = 0
+    const githubPrFact = async (workItem: number) => {
+      const [pr] = await github.json<Array<{ number: number }>>(
+        `repos/o/review-dense/pulls?state=all&head=o%3Areview-${workItem}&per_page=1`,
+      )
+      await github.json(`repos/o/review-dense/pulls/${pr.number}/reviews`)
+    }
+    const reviewPreflight = (workItem: number) =>
+      Promise.all([
+        remoteOwner.fetch({
+          scope: { repoKey: 'o/review-dense', remote: 'origin' },
+          prune: true,
+          execute: async () => {
+            physicalFetches += 1
+            fetchEntered.resolve()
+            await releaseFetch.promise
+            return (await execFileAsync('git', ['-C', repo, 'fetch', 'origin', '--prune'])).stdout
+          },
+          invalidate: () => undefined,
+          readback: async () =>
+            (
+              await execFileAsync('git', [
+                '-C',
+                repo,
+                'for-each-ref',
+                '--format=%(refname) %(objectname)',
+                'refs/remotes/origin',
+              ])
+            ).stdout,
+        }),
+        githubPrFact(workItem),
+      ])
+
+    const reviews = [reviewPreflight(1), reviewPreflight(2), reviewPreflight(3)]
+    await fetchEntered.promise
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    releaseFetch.resolve()
+    await Promise.all(reviews)
+
+    const remoteMetrics = deriveRemoteGitMetrics(remoteOwner.lifecycleEvents())
+    const githubMetrics = deriveGatewayMetrics(githubOwner.lifecycleEvents())
+    assert.equal(physicalFetches, 1)
+    assert.equal(remoteMetrics.upstreamRequests, 1)
+    assert.equal(remoteMetrics.singleflightJoins, 2)
+    assert.equal(githubMetrics.logicalRequests, 6)
+    assert.equal(githubMetrics.executions, 6)
+    assert.equal(githubMetrics.failures, 0)
+    assert.equal(githubMetrics.upstreamRequests, githubCommands.length)
+    assert.equal(githubMetrics.upstreamRequests, 6)
+    assert.ok(githubMetrics.upstreamRequests <= 9, `GitHub upstream=${githubMetrics.upstreamRequests}`)
+    assert.ok(
+      remoteMetrics.upstreamRequests + githubMetrics.upstreamRequests <= 10,
+      `total upstream=${remoteMetrics.upstreamRequests + githubMetrics.upstreamRequests}`,
+    )
+  } finally {
+    releaseFetch.resolve()
+    await remoteOwner.close()
+    await githubOwner.close({ drainMs: 50 })
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -7,25 +7,28 @@ beforeEach(() => {
   resetGithubGatewayOwnerForTests()
   resetRemoteGitCoordinatorForTests()
 })
-import { commitWorkflowFixture } from './workflow-fixture.ts'
+
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
-import { createServer, request, type RequestListener } from 'node:http'
+import { createServer, type RequestListener, request } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test, { after } from 'node:test'
+import { waitForTaskPersistence } from '../src/agent/task-supervisor.ts'
 import { apply, fetchRepositoryIssues } from '../src/index.ts'
 import { decodeLiveLogLine, encodeLiveLogEvent } from '../src/infra/live-output.ts'
+import { liveTasks } from '../src/infra/runtime.ts'
 import {
   appendLog,
   appendTaskLog,
+  type IssueWorkflow,
   issueBodyHash,
   loadAllArchivedWorkflows,
   loadWorkflow,
   readLogHistory,
   startTaskLog,
-  type IssueWorkflow,
 } from '../src/infra/state.ts'
 import { createFakeJobs } from './fake-jobs.ts'
+import { commitWorkflowFixture } from './workflow-fixture.ts'
 
 // Route tests exercise /state background reconciliation; never let that controller
 // discover or mutate the developer's real ~/.clickvibe workflow files.
@@ -2269,7 +2272,12 @@ async function waitForTask(listener: RequestListener, taskId: string): Promise<{
   for (let attempt = 0; attempt < 400; attempt++) {
     const polled = await post(listener, '/clickvibe/api/develop/poll', { taskId, cursor: 0 })
     const body = polled.body as { ok: boolean; done?: boolean; delta?: string[] }
-    if (body.done) return { delta: body.delta ?? [] }
+    if (body.done) {
+      const task = liveTasks.get(taskId)
+      assert.ok(task, `completed task ${taskId} disappeared before persistence quiesced`)
+      await waitForTaskPersistence(task)
+      return { delta: body.delta ?? [] }
+    }
     await new Promise((resolve) => setTimeout(resolve, 10))
   }
   throw new Error(`task ${taskId} did not finish`)

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { beforeEach } from 'node:test'
 import { resetGithubGatewayOwnerForTests } from '../src/github/gateway-owner.ts'
-import { resetRemoteGitCoordinatorForTests } from '../src/infra/remote-git.ts'
+import { closeRemoteGitCoordinator, resetRemoteGitCoordinatorForTests } from '../src/infra/remote-git.ts'
 
 beforeEach(() => {
   resetGithubGatewayOwnerForTests()
@@ -1061,7 +1061,7 @@ test('/merge requires one-use authorization, exact reviewed HEAD, merge commit, 
           number: 29,
           state: merged ? 'closed' : 'open',
           merged_at: merged ? '2026-08-22T01:00:00Z' : null,
-          head: { ref: workflow.branch, sha: 'abcdef1234567890' },
+          head: { ref: workflow.branch, sha: 'abcdef1234567890abcdef1234567890abcdef12' },
           base: { ref: 'main', sha: '1111111111111111' },
           html_url: 'https://github.com/o/r/pull/29',
         },
@@ -1083,7 +1083,7 @@ test('/merge requires one-use authorization, exact reviewed HEAD, merge commit, 
       if (spec.command === 'git worktree list --porcelain')
         return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
       if (spec.command.startsWith('if git show-ref')) return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
-      if (spec.command.startsWith('if git ls-remote'))
+      if (spec.command.startsWith('git ls-remote --heads'))
         return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
 
       throw new Error(`unexpected command: ${spec.command}`)
@@ -1111,7 +1111,7 @@ test('/merge requires one-use authorization, exact reviewed HEAD, merge commit, 
     assert.deepEqual(authorized.body.preview, {
       prNumber: '29',
       branch: workflow.branch,
-      head: 'abcdef1234567890',
+      head: 'abcdef1234567890abcdef1234567890abcdef12',
       baseRef: 'main',
       baseSha: '1111111111111111',
       mergeFlag: '--merge',
@@ -1163,7 +1163,11 @@ test('/merge requires one-use authorization, exact reviewed HEAD, merge commit, 
     assert.match(mergeCommand, /repos\/o\/r\/pulls\/29\/merge/)
     const mergeBody = JSON.parse(writeBodies[0] ?? '{}') as Record<string, unknown>
     assert.equal(mergeBody.merge_method, 'merge', 'merge commit strategy, not squash/rebase')
-    assert.equal(mergeBody.sha, 'abcdef1234567890', 'the head CAS pins the exact reviewed commit')
+    assert.equal(
+      mergeBody.sha,
+      'abcdef1234567890abcdef1234567890abcdef12',
+      'the head CAS pins the exact reviewed commit',
+    )
     assert.equal(mergeBody.commit_message, 'Closes #23')
     // The closing comment is its own confirmed write transaction: exactly one
     // POST with the exact body, proven by the comments readback.
@@ -1199,6 +1203,7 @@ test('/merge requires one-use authorization, exact reviewed HEAD, merge commit, 
     )
     assert.equal(replay.status, 403)
   } finally {
+    await closeRemoteGitCoordinator()
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1240,7 +1245,7 @@ test('/merge rejects a stale review hash before invoking the merge write', async
           number: 29,
           state: 'open',
           merged_at: null,
-          head: { ref: workflow.branch, sha: '2222222222222222' },
+          head: { ref: workflow.branch, sha: '2222222222222222222222222222222222222222' },
           base: { ref: 'main', sha: '1111111111111111' },
           html_url: 'https://github.com/o/r/pull/29',
         },
@@ -1304,7 +1309,7 @@ test('/merge authorization rejects a changed acceptance contract with the same P
           number: 29,
           state: 'open',
           merged_at: null,
-          head: { ref: workflow.branch, sha: 'abcdef1234567890' },
+          head: { ref: workflow.branch, sha: 'abcdef1234567890abcdef1234567890abcdef12' },
           base: { ref: 'main', sha: '1111111111111111' },
           html_url: 'https://github.com/o/r/pull/29',
         },
@@ -1388,7 +1393,7 @@ test('/merge gate rejection offers manual override that merges once and audits t
           number: 29,
           state: merged ? 'closed' : 'open',
           merged_at: merged ? '2026-08-22T01:00:00Z' : null,
-          head: { ref: workflow.branch, sha: '2222222222222222' },
+          head: { ref: workflow.branch, sha: '2222222222222222222222222222222222222222' },
           base: { ref: 'main', sha: '1111111111111111' },
           html_url: 'https://github.com/o/r/pull/29',
         },
@@ -1410,7 +1415,7 @@ test('/merge gate rejection offers manual override that merges once and audits t
       if (spec.command === 'git worktree list --porcelain')
         return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
       if (spec.command.startsWith('if git show-ref')) return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
-      if (spec.command.startsWith('if git ls-remote'))
+      if (spec.command.startsWith('git ls-remote --heads'))
         return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
 
       throw new Error(`unexpected command: ${spec.command}`)
@@ -1488,7 +1493,7 @@ test('/merge gate rejection offers manual override that merges once and audits t
     assert.match(mergeCommand, /repos\/o\/r\/pulls\/29\/merge/)
     assert.equal(
       (JSON.parse(writeBodies[0] ?? '{}') as { sha?: string }).sha,
-      '2222222222222222',
+      '2222222222222222222222222222222222222222',
       'the head CAS pins the exact reviewed commit',
     )
     assert.equal(await loadWorkflow(workflow.key), null)
@@ -1517,6 +1522,7 @@ test('/merge gate rejection offers manual override that merges once and audits t
     )
     assert.equal(replay.status, 403)
   } finally {
+    await closeRemoteGitCoordinator()
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1577,7 +1583,7 @@ test('/merge manual override refuses gate failures not covered by the confirmati
           number: 29,
           state: 'open',
           merged_at: null,
-          head: { ref: workflow.branch, sha: 'abcdef1234567890' },
+          head: { ref: workflow.branch, sha: 'abcdef1234567890abcdef1234567890abcdef12' },
           base: { ref: 'main', sha: '1111111111111111' },
           html_url: 'https://github.com/o/r/pull/29',
         },
@@ -1687,7 +1693,7 @@ test('cleanup failure keeps merged terminal state and retries without merging ag
           number: 29,
           state: merged ? 'closed' : 'open',
           merged_at: merged ? '2026-08-22T01:00:00Z' : null,
-          head: { ref: workflow.branch, sha: 'abcdef1234567890' },
+          head: { ref: workflow.branch, sha: 'abcdef1234567890abcdef1234567890abcdef12' },
           base: { ref: 'main', sha: '1111111111111111' },
           html_url: 'https://github.com/o/r/pull/29',
         },
@@ -1714,7 +1720,7 @@ test('cleanup failure keeps merged terminal state and retries without merging ag
         removeAttempts++
         return { exitCode: 1, stdout: { text: '' }, stderr: { text: 'worktree contains changes' } }
       }
-      if (spec.command.startsWith('if git show-ref') || spec.command.startsWith('if git ls-remote')) {
+      if (spec.command.startsWith('if git show-ref') || spec.command.startsWith('git ls-remote --heads')) {
         return { exitCode: 0, stdout: { text: '' }, stderr: { text: '' } }
       }
       throw new Error(`unexpected command: ${spec.command}`)
@@ -1764,6 +1770,7 @@ test('cleanup failure keeps merged terminal state and retries without merging ag
     assert.equal(commands.filter((command) => command.includes('/merge') && command.includes('--method PUT')).length, 1)
     assert.equal((await loadAllArchivedWorkflows())[0]?.delivery?.status, 'archived')
   } finally {
+    await closeRemoteGitCoordinator()
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await rm(tempHome, { recursive: true, force: true })
@@ -1789,7 +1796,7 @@ test('/state uses the live GitHub issue state instead of the stored issueState',
           number: 29,
           state: 'open',
           merged_at: null,
-          head: { ref: workflow.branch, sha: 'abcdef1234567890' },
+          head: { ref: workflow.branch, sha: 'abcdef1234567890abcdef1234567890abcdef12' },
           base: { ref: 'main', sha: '1111111111111111' },
           html_url: 'https://github.com/o/r/pull/29',
         },


### PR DESCRIPTION
## Summary

- migrate merge remote-branch cleanup into one Coordinator-owned delete operation
- use lock-internal pre-read, exact force-with-lease, invalidation and authoritative absent-ref readback
- persist cleanup-owned attempts and recover prepared deletes by readback only
- add permanent Review-dense two-plane count evidence without changing #133 frozen assets
- remove stale Slice C registration comments

## Correctness evidence

- initially absent ref: confirmed no-op, zero marker/push/invalidation
- different-OID rebuild: delete rejected and competitor ref preserved
- same-OID rebuild: accepted OID identity boundary explicitly tested
- prepared delete recovery: zero second push, proven by bare-remote hook
- merge-gate fetch remains upstream-confirmed and Coordinator-serialized

## #133 thresholds

- Remote Git upstream: 1
- Remote Git joins: 2
- GitHub upstream: 6 ≤ 9
- total upstream: 7 ≤ 10
- controlled key-write P95: 82.96ms ≤ 93ms

## Verification

- 786 tests passed
- coverage: lines 92.73%, branches 86.02%, functions 89.62%
- new core modules: 100% lines/branches/functions
- typecheck, build, lint, format, size, layers, state-write, local-git-write and GitHub-access gates passed

## Concept budget

- specific delete operation: consumed by merge cleanup
- cleanup attempt marker: consumed by readback-only recovery
- lifecycle attempt correlation: consumed by diagnostics and threshold derivation
- no new counter, queue, generation, configuration or persistence schema

Refs #135