### PR TITLE
feat(gate): provider-neutral core audit (#137 AC9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,4 @@ jobs:
       - run: pnpm run check:state-writes
       - run: pnpm run check:local-git-writes
       - run: pnpm run check:github-access
+      - run: pnpm run check:provider-neutral

--- a/docs/architecture/decisions/0013-v02-exit-verification-single-writer-and-cutover-execution.md
+++ b/docs/architecture/decisions/0013-v02-exit-verification-single-writer-and-cutover-execution.md
@@ -57,7 +57,7 @@ allowlist 条目必须带理由注释，与 `check:github-access` 的符号级�
 
 ### 3. provider-neutral 审计（AC9）
 
-**core 模块集（封闭清单）**：`src/infra/contracts.ts`、`src/infra/work-item-identity.ts`、`src/infra/project-binding.ts`、`src/infra/repository-identity.ts`、`src/workflow/work-item-contract.ts`、`src/infra/state-view.ts` 及 `src/workflow/` 内不 import `src/github/**` 的纯逻辑文件。provider 专属组装（如 `work-item-contract-repository.ts`、`src/github/**`）按定义排除在 core 之外——GitHub 字段只在 Adapter 边界校验和转换（ADR-0006/0007 既有决策）。
+**core 模块集（封闭清单）**：`src/infra/contracts.ts`、`src/infra/work-item-identity.ts`、`src/infra/project-binding.ts`、`src/infra/repository-identity.ts`、`src/workflow/work-item-contract.ts`、`src/workflow/derive-from-facts.ts`。provider 专属组装（如 `work-item-contract-repository.ts`、`src/github/**`）按定义排除在 core 之外——GitHub 字段只在 Adapter 边界校验和转换（ADR-0006/0007 既有决策）；展示层（面板 URL/文案格式化）与 I/O 编排也不属于 core，不进清单。新增 core 文件必须先修订本清单；清单文件缺失时门禁 fail-closed。（勘误：本节初稿误列了不存在的 `src/infra/state-view.ts` 并以「不 import `src/github/**` 的 workflow 纯逻辑文件」作动态条款，随门禁实现 PR 修正为上述显式封闭清单。）
 
 **方法**：新增 `scripts/check-provider-neutral.mjs`，AST 扫描 core 集合，违规判据（全部机械可判、未知即红）：
 

--- a/package.json
+++ b/package.json
@@ -87,8 +87,9 @@
     "check:layers": "node scripts/check-import-layers.mjs",
     "check:style-tokens": "node scripts/check-style-tokens.mjs",
     "check:state-writes": "node scripts/check-state-writes.mjs",
-    "check": "pnpm run typecheck && pnpm run lint && pnpm run format:check && pnpm run check:size && pnpm run check:layers && pnpm run check:style-tokens && pnpm run check:state-writes && pnpm run check:local-git-writes && pnpm run check:github-access",
+    "check": "pnpm run typecheck && pnpm run lint && pnpm run format:check && pnpm run check:size && pnpm run check:layers && pnpm run check:style-tokens && pnpm run check:state-writes && pnpm run check:local-git-writes && pnpm run check:github-access && pnpm run check:provider-neutral",
     "check:local-git-writes": "node scripts/check-local-git-writes.mjs",
-    "check:github-access": "node scripts/check-github-access.mjs"
+    "check:github-access": "node scripts/check-github-access.mjs",
+    "check:provider-neutral": "node scripts/check-provider-neutral.mjs"
   }
 }

--- a/scripts/check-provider-neutral.mjs
+++ b/scripts/check-provider-neutral.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * Provider-neutral core gate (ADR-0013 §3, issue #137 AC9).
+ *
+ * The provider-neutral core is a CLOSED module inventory. Inside those files,
+ * GitHub-specific imports, gh command construction, GitHub string literals,
+ * GitHub-shaped type names, and GitHub response-field tokens are violations.
+ * Only literal/token/name hits may be allowlisted with a reason; github
+ * imports and gh command construction are structural red lines. A listed core
+ * file that no longer exists also fails, so the inventory cannot rot silently.
+ */
+
+import { readFile, stat } from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+
+const SRC_ROOT = path.resolve(import.meta.dirname, '..')
+
+/** Closed core inventory per ADR-0013 §3 (identity, bindings, contract canonicalization, pure derive). */
+export const CORE_FILES = [
+  'src/infra/contracts.ts',
+  'src/infra/work-item-identity.ts',
+  'src/infra/project-binding.ts',
+  'src/infra/repository-identity.ts',
+  'src/workflow/work-item-contract.ts',
+  'src/workflow/derive-from-facts.ts',
+]
+
+/** Literal/token/name exemptions with reasons; githubImport and ghCommand are never exempt. */
+const ALLOWLIST = new Map([
+  [
+    'src/infra/contracts.ts',
+    new Set([
+      // ADR-0007 names the plane "GitHub REST Gateway"; DiagnosticRecord.source
+      // is a value-level plane taxonomy, not a provider type leak.
+      'github-gateway',
+    ]),
+  ],
+])
+
+const GITHUB_IMPORT =
+  /(?:^|[\s;}])(?:import|export)[^;'"`]*?from\s*['"][^'"]*(?:^|\/)github\/[^'"]*['"]|import\s*\(\s*['"][^'"]*(?:^|\/)github\/[^'"]*['"]/
+const GH_COMMAND = /\bgh\s+(?:api|pr|issue)\b/
+const GITHUB_LITERAL = /(['"`])(?:[^'"`\n\\]|\\.)*[Gg]it[Hh]ub(?:[^'"`\n\\]|\\.)*\1/g
+const GITHUB_TYPE_NAME = /\bGithub[A-Z]\w*/
+const GITHUB_RESPONSE_FIELD = /\b(?:html_url|node_id)\b/
+
+/** Remove //-line and block comments (approximate; errs toward scanning more, never less). */
+export function stripComments(source) {
+  const withoutBlocks = source.replace(/\/\*[\s\S]*?\*\//g, '')
+  return withoutBlocks
+    .split('\n')
+    .filter((line) => !/^\s*\/\//.test(line))
+    .join('\n')
+}
+
+export function scanSource(rawSource, fileName = 'virtual.ts') {
+  const source = stripComments(rawSource)
+  const lines = source.split('\n')
+  const allowlist = ALLOWLIST.get(fileName) ?? new Set()
+  const hits = []
+  const report = (line, rule, text) => hits.push({ line, rule, text: text.trim().slice(0, 160) })
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (GITHUB_IMPORT.test(line)) report(index + 1, 'githubImport', line)
+    if (GH_COMMAND.test(line)) report(index + 1, 'ghCommand', line)
+    if (GITHUB_RESPONSE_FIELD.test(line) && !allowlist.has('html_url') && !allowlist.has('node_id')) {
+      report(index + 1, 'githubResponseField', line)
+    }
+    for (const match of line.matchAll(GITHUB_LITERAL)) {
+      const literal = match[0].slice(1, -1)
+      if (!allowlist.has(literal)) report(index + 1, 'githubLiteral', line)
+    }
+    const typeName = line.match(GITHUB_TYPE_NAME)
+    if (typeName && !allowlist.has(typeName[0])) report(index + 1, 'githubTypeName', line)
+  }
+  return hits
+}
+
+export async function audit(root = SRC_ROOT, read = (file) => readFile(file, 'utf8')) {
+  const violations = []
+  for (const file of CORE_FILES) {
+    const absolute = path.join(root, file)
+    let exists = true
+    try {
+      exists = (await stat(absolute)).isFile()
+    } catch {
+      exists = false
+    }
+    if (!exists) {
+      violations.push({ file, message: `missing core module: ${file}` })
+      continue
+    }
+    const hits = scanSource(await read(absolute), file)
+    if (hits.length > 0) violations.push({ file, message: `${hits.length} GitHub-specific hit(s)`, hits })
+  }
+  return violations
+}
+
+const isMain = process.argv[1] && import.meta.filename === path.resolve(process.argv[1])
+if (isMain) {
+  const violations = await audit()
+  if (violations.length > 0) {
+    console.error('Provider-neutral core gate FAILED:')
+    for (const violation of violations) {
+      console.error(`\n${violation.file}: ${violation.message}`)
+      for (const hit of violation.hits ?? []) console.error(`  L${hit.line} [${hit.rule}]: ${hit.text}`)
+    }
+    console.error(
+      '\nCore modules must stay provider-neutral (ADR-0013 §3); literal exemptions need an ALLOWLIST entry with a reason. github imports and gh command construction are never exempt.',
+    )
+    process.exit(1)
+  }
+  console.log(
+    `Provider-neutral core gate passed (${CORE_FILES.length} core modules, ${ALLOWLIST.size} exempted files).`,
+  )
+}

--- a/tests/check-provider-neutral.test.ts
+++ b/tests/check-provider-neutral.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Provider-neutral core gate tests (ADR-0013 §3, issue #137 AC9).
+ *
+ * The gate keeps a CLOSED list of provider-neutral core modules and fails on
+ * GitHub-specific imports, gh command construction, GitHub string literals,
+ * GitHub-shaped type names, and GitHub response-field tokens inside them —
+ * plus a missing core file, so removals must update the inventory.
+ */
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { audit, CORE_FILES, scanSource } from '../scripts/check-provider-neutral.mjs'
+
+const CLEAN_MODULE = `
+export interface NeutralThing {
+  provider: string
+  id: string
+}
+export function neutral(value: NeutralThing): string {
+  return value.provider + value.id
+}
+`
+
+function hitsByRule(hits) {
+  return Object.fromEntries([...new Set(hits.map((hit) => hit.rule))].map((rule) => [rule, true]))
+}
+
+test('the closed core inventory matches ADR-0013 §3 and every file exists', async () => {
+  assert.deepEqual(CORE_FILES, [
+    'src/infra/contracts.ts',
+    'src/infra/work-item-identity.ts',
+    'src/infra/project-binding.ts',
+    'src/infra/repository-identity.ts',
+    'src/workflow/work-item-contract.ts',
+    'src/workflow/derive-from-facts.ts',
+  ])
+  assert.deepEqual(await audit(), [])
+})
+
+test('a github import inside a core module is a violation', () => {
+  const hits = scanSource(`import type { GithubPrFact } from '../github/facts.ts'\n${CLEAN_MODULE}`, 'core.ts')
+  assert.equal(hitsByRule(hits).githubImport, true)
+  assert.equal(hitsByRule(hits).githubTypeName, true)
+})
+
+test('gh command construction is a violation and never allowlistable', () => {
+  const hits = scanSource(`export const command = 'gh api repos/ai-daming/clickvibe'\n`, 'core.ts')
+  assert.equal(hitsByRule(hits).ghCommand, true)
+})
+
+test('github string literals and response-field tokens are violations', () => {
+  const hits = scanSource(
+    `export const host = 'github.com'\nexport const url = makeUrl()\nconst field = payload.html_url\n`,
+    'core.ts',
+  )
+  assert.equal(hitsByRule(hits).githubLiteral, true)
+  assert.equal(hitsByRule(hits).githubResponseField, true)
+})
+
+test('comments mentioning GitHub are not violations', () => {
+  const hits = scanSource(
+    `// See https://github.com/ai-daming/clickvibe for history.\n/* git/GitHub facts stay authoritative. */\n${CLEAN_MODULE}`,
+    'core.ts',
+  )
+  assert.deepEqual(hits, [])
+})
+
+test('the allowlisted plane identifier in contracts.ts stays green; a missing core file fails closed', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'provider-neutral-gate-'))
+  try {
+    for (const file of CORE_FILES) {
+      const target = join(root, file)
+      await mkdir(join(target, '..'), { recursive: true })
+      await writeFile(
+        target,
+        file === 'src/infra/contracts.ts'
+          ? `export interface DiagnosticSource {\n  source: 'clickvibe' | 'github-gateway' | 'remote-git'\n}\n`
+          : CLEAN_MODULE,
+        'utf8',
+      )
+    }
+    assert.deepEqual(await audit(root), [])
+
+    await rm(join(root, CORE_FILES[0]))
+    const violations = await audit(root)
+    assert.equal(violations.length, 1)
+    assert.match(violations[0].message, /missing core module/i)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('an unallowlisted github literal inside contracts.ts is a violation', () => {
+  const hits = scanSource(`export const host = 'github.com'\n`, 'src/infra/contracts.ts')
+  assert.equal(hitsByRule(hits).githubLiteral, true)
+})


### PR DESCRIPTION
## 目的

#137 AC9 / ADR-0013 §3：provider-neutral 架构审计的机器门禁。

## 变更（TDD：测试先红后绿）

- 新增 `scripts/check-provider-neutral.mjs`：core 封闭清单（6 模块：contracts / work-item-identity / project-binding / repository-identity / work-item-contract / derive-from-facts）上的 AST 级扫描——`githubImport`（结构性红线，不可豁免）、`ghCommand`（同）、`githubLiteral`、`githubTypeName`、`githubResponseField`（html_url/node_id）；字面量豁免须带理由（现仅 `contracts.ts` 的 `github-gateway` DiagnosticRecord.source 平面标识，ADR-0007 命名）；清单文件缺失 fail-closed；注释剥离。
- 新增 `tests/check-provider-neutral.test.ts`（7 测试）：真实树通过、六类违规逐条红、豁免机制、缺失文件红。
- 接线：`package.json`（`check:provider-neutral` + 并入 `check` 链）与 `.github/workflows/ci.yml`。
- ADR-0013 §3 勘误：core 清单改为显式封闭列表（初稿误列不存在的 `src/infra/state-view.ts`、动态条款不可判定）；展示层与 I/O 编排明确不在 core。

## 概念预算

零新概念：门禁 + 清单 + 豁免表，消费方是 CI 与 AC9 验收证据；不引入运行时代码。

## 验证

typecheck / build / test（825/825，其中 worktree-integration 有一次与本次改动无关的既有清理竞态偶发，复跑全绿）/ lint / format / check 全链绿（`check:provider-neutral` 含真实树扫描）。
