### PR TITLE
feat(upgrade): offline cutover runner with fingerprint-echo authorization (#137)

### DIFF
--- a/scripts/upgrade-v0.2.mjs
+++ b/scripts/upgrade-v0.2.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+/**
+ * Offline v0.1 -> v0.2 upgrade runner (ADR-0013 §5, v02-upgrade-protocol §12).
+ *
+ * Thin composition only: every machine check (plan fingerprint, upgrade lock,
+ * generation fence, durable journal, recovery matrix) stays inside the
+ * library. The operator flow is:
+ *
+ *   node scripts/upgrade-v0.2.mjs preview [--home DIR] [--primary o/r=origin] \
+ *       [--exclude o/r=reason] > plan.json
+ *   node scripts/upgrade-v0.2.mjs apply --plan plan.json --fingerprint <echo>
+ *   node scripts/upgrade-v0.2.mjs recovery [--home DIR]
+ *   node scripts/upgrade-v0.2.mjs resume|rollback --plan plan.json --fingerprint <echo>
+ *
+ * `preview` is zero-write and prints the plan JSON between markers; the
+ * operator keeps that file. `apply`/`resume`/`rollback` require the operator
+ * to echo the preview fingerprint verbatim; the echo is recorded in the
+ * append-only authorization log before execution. Exit codes: 0 success,
+ * 1 usage/error, 2 blocked or facts changed, 3 failed upgrade.
+ */
+
+import { execFile } from 'node:child_process'
+import { appendFile, mkdir, readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+import {
+  createOfflineV02GenerationFence,
+  enumerateLegacyClickVibeProcesses,
+  V02_OFFLINE_HOST_DECLARATION,
+} from '../src/infra/v02-generation-fence.ts'
+import { applyV02Upgrade } from '../src/infra/v02-upgrade-execution.ts'
+import { previewV02UpgradeRecovery, resumeV02Upgrade, rollbackV02Upgrade } from '../src/infra/v02-upgrade-recovery.ts'
+import { previewV02Upgrade, v02UpgradePlanFingerprint } from '../src/infra/v02-upgrade.ts'
+
+const execFileAsync = promisify(execFile)
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const ENTRY = 'offline-runner-1'
+
+function fail(message, code = 1) {
+  console.error(String(message))
+  process.exit(code)
+}
+
+async function baselineSha() {
+  try {
+    return (await execFileAsync('git', ['-C', REPO_ROOT, 'rev-parse', 'HEAD'], { encoding: 'utf8' })).stdout.trim()
+  } catch {
+    fail('cannot determine the baseline SHA: `git rev-parse HEAD` failed inside the repository')
+  }
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv
+  const flags = new Map()
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index]
+    if (!token.startsWith('--')) fail(`unexpected argument: ${token}`)
+    const inline = token.indexOf('=')
+    if (inline > 0) {
+      flags.set(token.slice(2, inline), token.slice(inline + 1))
+    } else {
+      const value = rest[index + 1]
+      if (value === undefined) fail(`missing value for ${token}`)
+      flags.set(token.slice(2), value)
+      index += 1
+    }
+  }
+  return { command, flags }
+}
+
+function repeatable(flags, name) {
+  const values = []
+  for (const [key, value] of flags) if (key === name) values.push(value)
+  return values
+}
+
+function parsePairAssignments(values, label) {
+  const result = {}
+  for (const value of values) {
+    const split = value.indexOf('=')
+    if (split <= 0) fail(`--${label} expects ${label === 'primary' ? 'owner/repo=remote' : 'owner/repo=reason'}`)
+    result[value.slice(0, split)] = value.slice(split + 1)
+  }
+  return result
+}
+
+async function recordAuthorization(home, command, fingerprint) {
+  const root = join(resolve(home), '.clickvibe')
+  await mkdir(root, { recursive: true })
+  await appendFile(
+    join(root, 'upgrade-v0.2-authorization.log'),
+    `${JSON.stringify({ at: new Date().toISOString(), entry: ENTRY, command, fingerprint })}\n`,
+    'utf8',
+  )
+}
+
+function offlineFence() {
+  return createOfflineV02GenerationFence({ declaration: V02_OFFLINE_HOST_DECLARATION })
+}
+
+async function loadPlan(flags, command) {
+  const planPath = flags.get('plan')
+  if (!planPath) fail(`${command} requires --plan <plan.json saved from preview/recovery output>`)
+  const fingerprint = flags.get('fingerprint')
+  if (!fingerprint || !/^[0-9a-f]{64}$/.test(fingerprint)) {
+    fail(`${command} requires --fingerprint <the fingerprint you read in the preview output, echoed verbatim>`)
+  }
+  let plan
+  try {
+    plan = JSON.parse(await readFile(planPath, 'utf8'))
+  } catch (reason) {
+    fail(`cannot read the plan file: ${reason instanceof Error ? reason.message : String(reason)}`)
+  }
+  return { plan, fingerprint }
+}
+
+function printPreview(plan, fingerprint) {
+  console.log(`fingerprint: ${fingerprint}`)
+  console.log(`baselineSha: ${plan.baselineSha}`)
+  console.log(`activeConfig: ${plan.paths.activeConfig}`)
+  console.log(`configBackup: ${plan.paths.configBackup}`)
+  console.log(`activeState: ${plan.paths.activeState}`)
+  console.log(`stateBackup: ${plan.paths.stateBackup}`)
+  console.log(`stagedState: ${plan.paths.stagedState}`)
+  console.log(`journal: ${plan.paths.journal}`)
+  console.log(
+    `legacyState: ${plan.legacyState.status} (${plan.legacyState.fileCount} files, ${plan.legacyState.byteCount} bytes)`,
+  )
+  console.log(`hostActivity: oldPluginProcesses=${plan.hostActivity.oldPluginProcesses.length}`)
+  for (const exclusion of plan.exclusions) console.log(`excluded: ${exclusion.repoKey} (${exclusion.reason})`)
+  for (const binding of plan.bindings) {
+    console.log(
+      `binding: ${binding.container.id} -> ${binding.repository.localPath} (common-dir ${binding.realCommonDir}, repositoryId ${binding.repository.repositoryId}${binding.repositoryIdExisted ? '' : ' [new]'}, remote ${binding.repository.primaryRemote})`,
+    )
+  }
+  for (const worktree of plan.worktrees) {
+    const lines = worktree.porcelain.split('\n').filter((line) => line.startsWith('worktree ')).length
+    console.log(`worktrees: ${worktree.repoKey} observes ${lines} registered worktree(s)`)
+  }
+  console.log('PLAN-JSON-BEGIN')
+  console.log(JSON.stringify(plan, null, 2))
+  console.log('PLAN-JSON-END')
+  console.log(
+    'Preview was zero-write. Save the plan JSON, then run apply with --fingerprint echoing the fingerprint above.',
+  )
+}
+
+const { command, flags } = parseArgs(process.argv.slice(2))
+const home = flags.get('home') ?? homedir()
+
+try {
+  if (command === 'preview') {
+    const oldPluginProcesses = await enumerateLegacyClickVibeProcesses()
+    const preview = await previewV02Upgrade({
+      home,
+      baselineSha: await baselineSha(),
+      choices: { primaryRemotes: parsePairAssignments(repeatable(flags, 'primary'), 'primary'), exclusions: {} },
+      hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses },
+    })
+    if (preview.status === 'previewed') {
+      printPreview(preview.plan, preview.fingerprint)
+    } else if (preview.status === 'blocked') {
+      for (const item of preview.blocked) console.error(`blocked [${item.scope}] ${item.key}: ${item.error}`)
+      console.error('Fix the facts or pass --exclude owner/repo=reason, then run preview again.')
+      process.exit(2)
+    } else {
+      console.error('An unfinished upgrade journal exists; run the recovery command first.')
+      process.exit(2)
+    }
+  } else if (command === 'recovery') {
+    const recovery = await previewV02UpgradeRecovery({ home })
+    if (recovery.status === 'recovery-previewed') {
+      console.log(`fingerprint: ${recovery.fingerprint}`)
+      console.log(`journal: ${recovery.plan.journal.path} (phase ${recovery.plan.journal.value.phase})`)
+      for (const asset of recovery.plan.assets) console.log(`asset: ${asset.path} (${asset.kind})`)
+      console.log('PLAN-JSON-BEGIN')
+      console.log(JSON.stringify(recovery.plan, null, 2))
+      console.log('PLAN-JSON-END')
+      console.log('Save the plan JSON, then run resume or rollback with --fingerprint echoing the fingerprint above.')
+    } else {
+      console.error(`recovery unavailable (${recovery.status}): ${recovery.error}`)
+      process.exit(2)
+    }
+  } else if (command === 'apply') {
+    const { plan, fingerprint } = await loadPlan(flags, command)
+    if (v02UpgradePlanFingerprint(plan) !== fingerprint) {
+      fail('the echoed fingerprint does not match the supplied plan; authorization refused and nothing was written')
+    }
+    const planHome = dirname(plan.paths.root)
+    await recordAuthorization(planHome, command, fingerprint)
+    const result = await applyV02Upgrade({ plan, fingerprint, fence: offlineFence() })
+    if (result.status === 'verified') {
+      console.log(`verified: journal ${plan.paths.journal}`)
+    } else if (result.status === 'facts-changed') {
+      console.error('facts changed after authorization; the echo is void. Re-run preview and authorize again.')
+      process.exit(2)
+    } else {
+      console.error(`upgrade failed: ${result.error} (journal ${plan.paths.journal}); run the recovery command`)
+      process.exit(3)
+    }
+  } else if (command === 'resume' || command === 'rollback') {
+    const { plan, fingerprint } = await loadPlan(flags, command)
+    const planHome = dirname(plan.paths.root)
+    await recordAuthorization(planHome, command, fingerprint)
+    const options = { plan, fingerprint, fence: offlineFence() }
+    const result = command === 'resume' ? await resumeV02Upgrade(options) : await rollbackV02Upgrade(options)
+    if (result.status === 'verified' || result.status === 'rolled-back') {
+      console.log(`${result.status}: journal ${plan.journal.path}`)
+    } else {
+      console.error(`${command} did not complete (${JSON.stringify(result)}); re-run the recovery command`)
+      process.exit(3)
+    }
+  } else {
+    fail(`unknown command: ${command ?? '(none)'}; expected preview | apply | recovery | resume | rollback`)
+  }
+} catch (reason) {
+  fail(reason instanceof Error ? reason.message : String(reason))
+}

--- a/tests/upgrade-runner.test.ts
+++ b/tests/upgrade-runner.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Offline upgrade runner tests (ADR-0013 §5, protocol §12, issue #137 AC2/AC3).
+ *
+ * The runner is spawned exactly like an operator runs it against a real git
+ * fixture home: preview is zero-write and prints the plan JSON for the
+ * operator to keep; apply/resume/rollback require the operator to echo the
+ * preview fingerprint, record the confirmation in the append-only
+ * authorization log, and delegate every machine check to the library.
+ */
+import assert from 'node:assert/strict'
+import { execFile, spawnSync } from 'node:child_process'
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { promisify } from 'node:util'
+import test from 'node:test'
+
+const execFileAsync = promisify(execFile)
+
+const RUNNER = join('scripts', 'upgrade-v0.2.mjs')
+
+function run(args) {
+  return spawnSync(process.execPath, [RUNNER, ...args], { encoding: 'utf8', cwd: process.cwd() })
+}
+
+function planJsonFrom(output) {
+  const begin = output.indexOf('PLAN-JSON-BEGIN\n')
+  const end = output.indexOf('PLAN-JSON-END')
+  assert.ok(begin >= 0 && end > begin, `plan json markers missing:\n${output}`)
+  return JSON.parse(output.slice(begin + 'PLAN-JSON-BEGIN\n'.length, end))
+}
+
+function fingerprintFrom(output) {
+  const match = output.match(/^fingerprint: ([0-9a-f]{64})$/m)
+  assert.ok(match, `fingerprint line missing:\n${output}`)
+  return match[1]
+}
+
+async function git(cwd, ...args) {
+  return (await execFileAsync('git', ['-C', cwd, ...args], { encoding: 'utf8' })).stdout.trim()
+}
+
+async function fixture(name) {
+  const home = await mkdtemp(join(tmpdir(), `clickvibe-upgrade-runner-${name}-`))
+  const repository = join(home, 'repo')
+  const root = join(home, '.clickvibe')
+  await git(dirname(repository), 'init', repository)
+  await git(repository, 'config', 'user.name', 'clickvibe-test')
+  await git(repository, 'config', 'user.email', 'clickvibe-test@example.invalid')
+  await git(repository, 'commit', '--allow-empty', '-m', 'base')
+  await git(repository, 'remote', 'add', 'origin', 'https://github.com/o/r.git')
+  await mkdir(root, { recursive: true })
+  await writeFile(join(root, 'config.yaml'), `repos:\n  o/r: ${repository}\nfetchTtlSeconds: 45\n`, { mode: 0o600 })
+  await mkdir(join(root, 'state', 'o', 'r', 'issue-9'), { recursive: true })
+  await writeFile(join(root, 'state', 'o', 'r', 'issue-9', 'workflow.json'), '{"legacy":true}\n')
+  return { home, repository, root }
+}
+
+async function clickvibeEntries(root) {
+  try {
+    return (await readdir(root)).sort()
+  } catch {
+    return []
+  }
+}
+
+test('preview prints the plan and fingerprint and writes nothing', async (t) => {
+  const item = await fixture('preview')
+  t.after(() => rm(item.home, { recursive: true, force: true }))
+  const before = await clickvibeEntries(item.root)
+
+  const result = run(['preview', '--home', item.home])
+  assert.equal(result.status, 0, `stderr:\n${result.stderr}`)
+  const fingerprint = fingerprintFrom(result.stdout)
+  const plan = planJsonFrom(result.stdout)
+  assert.equal(plan.paths.root, item.root)
+  assert.match(result.stdout, /state-v0\.1-backup-/)
+  assert.match(result.stdout, /o\/r/)
+
+  assert.deepEqual(await clickvibeEntries(item.root), before, 'preview must be zero-write')
+})
+
+test('apply with a mismatched fingerprint echo is rejected before any write', async (t) => {
+  const item = await fixture('wrong-echo')
+  t.after(() => rm(item.home, { recursive: true, force: true }))
+  const preview = run(['preview', '--home', item.home])
+  assert.equal(preview.status, 0, preview.stderr)
+  const planFile = join(item.home, 'plan.json')
+  await writeFile(planFile, JSON.stringify(planJsonFrom(preview.stdout)))
+
+  const result = run(['apply', '--plan', planFile, '--fingerprint', '0'.repeat(64), '--home', item.home])
+  assert.notEqual(result.status, 0)
+  assert.match(result.stderr, /fingerprint/)
+
+  const entries = await clickvibeEntries(item.root)
+  assert.equal(entries.includes('upgrade-v0.2.json'), false, 'no journal may exist')
+  assert.equal(entries.includes('upgrade-v0.2-authorization.log'), false, 'no authorization record for a rejected echo')
+  assert.equal(entries.includes('upgrade-v0.2.lock'), false, 'no lock may exist')
+})
+
+test('apply with the echoed fingerprint records authorization and reaches verified', async (t) => {
+  const item = await fixture('verified')
+  t.after(() => rm(item.home, { recursive: true, force: true }))
+  const preview = run(['preview', '--home', item.home])
+  assert.equal(preview.status, 0, preview.stderr)
+  const fingerprint = fingerprintFrom(preview.stdout)
+  const planFile = join(item.home, 'plan.json')
+  await writeFile(planFile, JSON.stringify(planJsonFrom(preview.stdout)))
+
+  const result = run(['apply', '--plan', planFile, '--fingerprint', fingerprint, '--home', item.home])
+  assert.equal(result.status, 0, `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`)
+
+  const journal = JSON.parse(await readFile(join(item.root, 'upgrade-v0.2.json'), 'utf8'))
+  assert.equal(journal.phase, 'verified')
+  assert.equal(journal.planFingerprint, fingerprint)
+
+  const authorization = (await readFile(join(item.root, 'upgrade-v0.2-authorization.log'), 'utf8')).trim().split('\n')
+  assert.equal(authorization.length, 1)
+  const record = JSON.parse(authorization[0])
+  assert.equal(record.entry, 'offline-runner-1')
+  assert.equal(record.command, 'apply')
+  assert.equal(record.fingerprint, fingerprint)
+
+  const entries = await clickvibeEntries(item.root)
+  const backupName = entries.find((name) => name.startsWith('state-v0.1-backup-'))
+  assert.ok(backupName, `cold backup missing: ${entries.join(', ')}`)
+  const backupMarker = await readFile(join(item.root, backupName, 'o', 'r', 'issue-9', 'workflow.json'), 'utf8')
+  assert.equal(backupMarker, '{"legacy":true}\n')
+  const activeConfig = await readFile(join(item.root, 'config.yaml'), 'utf8')
+  assert.match(activeConfig, /schemaVersion: 1/)
+})
+
+test('a facts-changed apply still records the attempted authorization and writes no journal', async (t) => {
+  const item = await fixture('facts-changed')
+  t.after(() => rm(item.home, { recursive: true, force: true }))
+  const preview = run(['preview', '--home', item.home])
+  assert.equal(preview.status, 0, preview.stderr)
+  const fingerprint = fingerprintFrom(preview.stdout)
+  const planFile = join(item.home, 'plan.json')
+  await writeFile(planFile, JSON.stringify(planJsonFrom(preview.stdout)))
+
+  await writeFile(join(item.root, 'state', 'o', 'r', 'issue-9', 'workflow.json'), '{"legacy":false}\n')
+  const result = run(['apply', '--plan', planFile, '--fingerprint', fingerprint, '--home', item.home])
+  assert.notEqual(result.status, 0)
+  assert.match(result.stderr + result.stdout, /facts/i)
+
+  const record = JSON.parse(await readFile(join(item.root, 'upgrade-v0.2-authorization.log'), 'utf8'))
+  assert.equal(record.fingerprint, fingerprint)
+  assert.equal(await clickvibeEntries(item.root).then((e) => e.includes('upgrade-v0.2.json')), false)
+})
+
+test('recovery without an unfinished journal refuses and points back to preview', async (t) => {
+  const item = await fixture('recovery')
+  t.after(() => rm(item.home, { recursive: true, force: true }))
+  const preview = run(['preview', '--home', item.home])
+  assert.equal(preview.status, 0, preview.stderr)
+  const planFile = join(item.home, 'plan.json')
+  await writeFile(planFile, JSON.stringify(planJsonFrom(preview.stdout)))
+  // An authorized apply is not run here, so no journal exists yet.
+
+  const recovery = run(['recovery', '--home', item.home])
+  assert.equal(recovery.status, 2, `stdout:\n${recovery.stdout}\nstderr:\n${recovery.stderr}`)
+  assert.match(recovery.stderr, /recovery unavailable/)
+  assert.equal(recovery.stdout.includes('PLAN-JSON-BEGIN'), false)
+})


### PR DESCRIPTION
## 目的

#137 AC2/AC3 执行侧 / ADR-0013 §5 + 协议 §12：离线切换的操作者入口。

## 变更（TDD：5 条测试先红后绿，真实 git fixture、真实子进程 spawn）

- 新增 `scripts/upgrade-v0.2.mjs`：
  - `preview [--home] [--primary o/r=origin]`：零写入；打印 fingerprint、全部将写入路径、逐 Binding 盘点（common-dir/repositoryId/remote）、worktree 现场计数；plan JSON 以 `PLAN-JSON-BEGIN/END` 标记输出，由操作者自行保存（preview 不写任何文件）。
  - `apply --plan <file> --fingerprint <echo>`：回显必须与 `v02UpgradePlanFingerprint(plan)` 逐字一致，否则拒绝且零写入；通过后先向 append-only 的 `~/.clickvibe/upgrade-v0.2-authorization.log` 追加 `{at, entry:'offline-runner-1', command, fingerprint}`，再以离线 fence（固定声明串）执行 `applyV02Upgrade`。
  - `recovery` / `resume` / `rollback` 同构；fingerprint 校验在库内完成。
  - 退出码：0 成功 / 1 用法错误 / 2 blocked 或 facts-changed / 3 升级失败。
- 薄组装层：不复制任何 fence/lock/journal/fingerprint 逻辑，全部委托库；机器权威仍是 journal 内 `planFingerprint`。

## 测试

- preview 零写入断言（目录清单前后一致）。
- 错误回显 → 拒绝 + 无 journal/锁/授权日志。
- 正确回显 → verified：journal 配对、授权日志行、冷备份内容、schema-1 config 逐项断言。
- facts-changed（预览后改动 legacy state）→ 非零退出 + 授权尝试已记录 + 无 journal。
- 无 journal 时 recovery 拒绝并指回 preview。

## 概念预算

新增 1 个概念：`upgrade-v0.2-authorization.log` 行（append-only）。消费者：#137/#132 证据回填（AC2「显式授权」的审计证明）；ADR-0013 §5 已定义其字段与 journal 权威关系。

## 验证

typecheck / lint / format / check 全链 / test（826/826，+5）全绿。
