### PR TITLE
feat(runtime): remove the v0.1 config reader; complete the clean-break boundary (#137 AC3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,6 @@ jobs:
         run: |
           git config --global user.email "ci@clickvibe.local"
           git config --global user.name "ClickVibe CI"
-      - name: Seed ClickVibe config for project-list contract test
-        run: |
-          mkdir -p "$HOME/.clickvibe"
-          printf 'repos:\n  ai-daming/clickvibe: %s\n' "$GITHUB_WORKSPACE" > "$HOME/.clickvibe/config.yaml"
       - run: pnpm run typecheck
       - run: pnpm run build
       - run: pnpm test

--- a/scripts/check-state-writes.mjs
+++ b/scripts/check-state-writes.mjs
@@ -65,12 +65,7 @@ const CONFIG_LITERAL_ALLOWED = (relative) =>
     (item) => relative === item || relative.endsWith(`/${item}`),
   )
 /** May additionally contain fs write primitives while referencing them; every entry needs a reason and a removal ticket. */
-const CONFIG_WRITE_ALLOWLIST = new Map([
-  [
-    'src/infra/project-config.ts',
-    'v0.1 repos read-modify-write writer; disposition table row A2 marks it 废弃 and its removal PR deletes this entry',
-  ],
-])
+const CONFIG_WRITE_ALLOWLIST = new Map([])
 
 function allowedEntry(relative, table) {
   for (const [file, value] of table) {

--- a/src/agent/worktree.ts
+++ b/src/agent/worktree.ts
@@ -42,7 +42,14 @@ export async function ensureWorktree(
   parsed: { owner: string; repo: string; number: string },
   requestedBaseline?: unknown,
 ): Promise<{ ok: true; workflow: IssueWorkflow; worktree: string; branch: string } | { ok: false; error: string }> {
-  const config = await loadConfig()
+  let config: Awaited<ReturnType<typeof loadConfig>>
+  try {
+    config = await loadConfig()
+  } catch (reason) {
+    // Strict v0.2 pairing failures (e.g. a vanished clone) must surface as a
+    // readable refusal, not an unhandled crash (错误不埋葬).
+    return { ok: false, error: reason instanceof Error ? reason.message : String(reason) }
+  }
   const repoKey = `${parsed.owner}/${parsed.repo}`
   const repoPath = config.repos[repoKey]
   if (!repoPath) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,8 +155,14 @@ export function apply(ctx: Context): void {
         return
       }
 
-      const { status, body } = await handleApiPost(ctx, req, method, payload)
-      writeJson(res, status, body)
+      try {
+        const { status, body } = await handleApiPost(ctx, req, method, payload)
+        writeJson(res, status, body)
+      } catch (error) {
+        // Fail closed with the raw message preserved (错误不埋葬): a broken
+        // v0.2 config/state pairing must surface, not vanish into a 500 crash.
+        writeJson(res, 500, { ok: false, error: String(error instanceof Error ? error.message : error) })
+      }
     },
   })
   // Gateway lifecycle follows the plugin fiber: on unload, admission closes,

--- a/src/infra/diagnostic-log-store.ts
+++ b/src/infra/diagnostic-log-store.ts
@@ -1,7 +1,7 @@
 import { appendFile, mkdir, rename, rm, stat } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { diagnosticLogPath } from './state-layout.ts'
-import { assertLegacyStateWriteAllowed } from './v02-generation-fence.ts'
+import { assertActiveStateWriteAllowed } from './v02-generation-fence.ts'
 
 export const DEFAULT_DIAGNOSTIC_MAX_BYTES = 5 * 1024 * 1024
 
@@ -52,21 +52,21 @@ export function appendDiagnosticLine(
   maxBytes: unknown | Promise<unknown>,
   options: { generation?: 'v0.2' } = {},
 ): Promise<void> {
-  if (options.generation !== 'v0.2') assertLegacyStateWriteAllowed(root)
+  if (options.generation !== 'v0.2') assertActiveStateWriteAllowed(root)
   const path = diagnosticLogPath(root, workflowKey)
   return enqueue(path, async () => {
-    if (options.generation !== 'v0.2') assertLegacyStateWriteAllowed(root)
+    if (options.generation !== 'v0.2') assertActiveStateWriteAllowed(root)
     const limit = configuredMaxBytes(await maxBytes)
     const record = `${line}\n`
     await mkdir(dirname(path), { recursive: true })
     const existingBytes = await fileSize(path)
     if (existingBytes > 0 && existingBytes + Buffer.byteLength(record, 'utf8') > limit) {
-      if (options.generation !== 'v0.2') assertLegacyStateWriteAllowed(root)
+      if (options.generation !== 'v0.2') assertActiveStateWriteAllowed(root)
       await rm(rotatedPath(path), { force: true })
-      if (options.generation !== 'v0.2') assertLegacyStateWriteAllowed(root)
+      if (options.generation !== 'v0.2') assertActiveStateWriteAllowed(root)
       await rename(path, rotatedPath(path))
     }
-    if (options.generation !== 'v0.2') assertLegacyStateWriteAllowed(root)
+    if (options.generation !== 'v0.2') assertActiveStateWriteAllowed(root)
     await appendFile(path, record, 'utf8')
   })
 }

--- a/src/infra/runtime.ts
+++ b/src/infra/runtime.ts
@@ -204,12 +204,9 @@ export async function loadConfigFromHome(home: string): Promise<ClickVibeConfig>
   if (parsed?.schemaVersion === 1) return await loadV02Config(home, raw, parsed)
   if (parsed?.schemaVersion !== undefined)
     throw new Error(`unsupported ClickVibe config schemaVersion: ${parsed.schemaVersion}`)
-  return {
-    repos: parsed?.repos ?? {},
-    worktreeRoot: parsed?.worktreeRoot ? expandHome(parsed.worktreeRoot) : join(home, '.clickvibe', 'worktrees'),
-    fetchTtlSeconds: parsed?.fetchTtlSeconds,
-    diagnosticsMaxBytes: parsed?.diagnosticsMaxBytes,
-  }
+  throw new Error(
+    'v0.1 config is no longer readable by the v0.2 runtime (ADR-0009 clean break); run `node scripts/upgrade-v0.2.mjs preview` and authorize the upgrade with its plan fingerprint',
+  )
 }
 
 /** Read and strictly validate ~/.clickvibe/config.yaml. */

--- a/src/infra/state.ts
+++ b/src/infra/state.ts
@@ -23,7 +23,7 @@ import {
   workflowRevision,
   workflowStatePath,
 } from './workflow-persistence.ts'
-import { assertLegacyStateWriteAllowed, isV02GenerationViolation } from './v02-generation-fence.ts'
+import { assertActiveStateWriteAllowed, isV02GenerationViolation } from './v02-generation-fence.ts'
 import type { RemoteGitWriteAttempt } from './remote-git-coordinator.ts'
 export { WorkflowConflictError } from './workflow-persistence.ts'
 export type * from './workflow-persistence.ts'
@@ -343,9 +343,9 @@ export async function appendLog(key: string, kind: 'dev' | 'review', line: strin
       return
     }
     const legacyPath = join(stateDir(), key, `${kind}.log`)
-    assertLegacyStateWriteAllowed(stateDir())
+    assertActiveStateWriteAllowed(stateDir())
     await mkdir(join(legacyPath, '..'), { recursive: true })
-    assertLegacyStateWriteAllowed(stateDir())
+    assertActiveStateWriteAllowed(stateDir())
     await appendFile(legacyPath, `${line}\n`, 'utf8')
   } catch (reason) {
     if (isV02GenerationViolation(reason)) throw reason

--- a/src/infra/task-log-store.ts
+++ b/src/infra/task-log-store.ts
@@ -2,7 +2,7 @@ import { appendFile, link, mkdir, readFile, readdir, rm, rmdir, writeFile } from
 import { dirname, join } from 'node:path'
 import { decodeLiveLogLine, encodeLiveLogEvent, type LiveLogEvent } from './live-output.ts'
 import { taskLogPath, type WorkflowStorageIdentity } from './state-layout.ts'
-import { assertLegacyStateWriteAllowed } from './v02-generation-fence.ts'
+import { assertActiveStateWriteAllowed } from './v02-generation-fence.ts'
 
 export type TaskLogKind = 'dev' | 'review'
 export type TaskExitStatus = 'done' | 'failed' | 'stopped' | 'timed_out'
@@ -119,13 +119,13 @@ export async function startTaskLog(
   kind: TaskLogKind,
   taskId: string,
 ): Promise<void> {
-  assertLegacyStateWriteAllowed(root)
+  assertActiveStateWriteAllowed(root)
   const path = taskLogPath(root, workflow, kind, taskId)
   await enqueue(path, async () => {
-    assertLegacyStateWriteAllowed(root)
+    assertActiveStateWriteAllowed(root)
     await mkdir(dirname(path), { recursive: true })
     try {
-      assertLegacyStateWriteAllowed(root)
+      assertActiveStateWriteAllowed(root)
       await writeFile(path, '', { encoding: 'utf8', flag: 'wx' })
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
@@ -142,13 +142,13 @@ export async function appendTaskLog(
   encodedLine: string,
   options: AppendTaskLogOptions = {},
 ): Promise<void> {
-  assertLegacyStateWriteAllowed(root)
+  assertActiveStateWriteAllowed(root)
   const path = taskLogPath(root, workflow, kind, taskId)
   const record = taskRecord(taskId, sequence, encodedLine, options)
   await enqueue(path, async () => {
-    assertLegacyStateWriteAllowed(root)
+    assertActiveStateWriteAllowed(root)
     await mkdir(dirname(path), { recursive: true })
-    assertLegacyStateWriteAllowed(root)
+    assertActiveStateWriteAllowed(root)
     await appendFile(path, `${JSON.stringify(record)}\n`, 'utf8')
   })
 }
@@ -219,10 +219,10 @@ export async function appendTaskLogNext(
   encodedLine: string,
   options: AppendTaskLogOptions = {},
 ): Promise<void> {
-  assertLegacyStateWriteAllowed(root)
+  assertActiveStateWriteAllowed(root)
   const path = taskLogPath(root, workflow, kind, taskId)
   await enqueue(path, async () => {
-    assertLegacyStateWriteAllowed(root)
+    assertActiveStateWriteAllowed(root)
     await mkdir(dirname(path), { recursive: true })
     let sequence = 1
     try {
@@ -238,7 +238,7 @@ export async function appendTaskLogNext(
     } catch {
       // Missing task file is created by appendFile.
     }
-    assertLegacyStateWriteAllowed(root)
+    assertActiveStateWriteAllowed(root)
     await appendFile(path, `${JSON.stringify(taskRecord(taskId, sequence, encodedLine, options))}\n`, 'utf8')
   })
 }

--- a/src/infra/v02-generation-fence.ts
+++ b/src/infra/v02-generation-fence.ts
@@ -78,15 +78,29 @@ function hasV02Marker(stateRoot: string): boolean {
   }
 }
 
-/** Reject every legacy writer once an upgrade journal or v0.2 marker owns the state root. */
-export function assertLegacyStateWriteAllowed(stateRoot: string): void {
-  if (fenceState.mode !== 'legacy-open')
-    throw new V02GenerationViolationError('legacy state write blocked by the v0.2 generation fence')
+/**
+ * Admit current-format runtime writers exactly when the state root has one
+ * consistent owner (ADR-0009 D1/D6, protocol §1): a verified journal plus the
+ * v0.2 marker owns the root for the v0.2 runtime; a rolled-back or journal-free
+ * root without a marker keeps pre-upgrade semantics. An in-progress upgrade,
+ * any partial/torn journal phase, or journal/marker drift stays fail-closed.
+ */
+export function assertActiveStateWriteAllowed(stateRoot: string): void {
+  if (fenceState.mode === 'upgrade-held')
+    throw new V02GenerationViolationError('state write blocked: v0.2 upgrade holds the generation fence')
+  if (fenceState.mode === 'v0.2-active') return
   const phase = journalPhase(clickvibeRootForState(stateRoot))
-  if (phase !== null && phase !== 'rolled_back') {
-    throw new V02GenerationViolationError(`legacy state write blocked by v0.2 recovery journal (${phase})`)
+  const marker = hasV02Marker(stateRoot)
+  if (phase === null || phase === 'rolled_back') {
+    if (marker) throw new V02GenerationViolationError('state write blocked: v0.2 marker without a completed upgrade')
+    return
   }
-  if (hasV02Marker(stateRoot)) throw new V02GenerationViolationError('legacy state write blocked by active v0.2 state')
+  if (phase === 'verified') {
+    if (!marker)
+      throw new V02GenerationViolationError('state write blocked: verified journal without the v0.2 state marker')
+    return
+  }
+  throw new V02GenerationViolationError(`state write blocked by v0.2 recovery journal (${phase})`)
 }
 
 /** Synchronous start boundary: no task can slip between fence acquisition and host observation. */
@@ -95,7 +109,7 @@ export function assertLegacyTaskStartAllowed(): void {
     throw new V02GenerationViolationError('legacy task start blocked by the v0.2 generation fence')
   if (fenceState.mode === 'v0.2-active')
     throw new V02GenerationViolationError('legacy task start blocked by the active v0.2 generation')
-  assertLegacyStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
+  assertActiveStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
 }
 
 /**

--- a/src/infra/workflow-persistence.ts
+++ b/src/infra/workflow-persistence.ts
@@ -7,7 +7,7 @@ import { acquireLinkLock } from './link-lock.ts'
 import type { IssueWorkflow } from './state.ts'
 import { workflowPath, type WorkflowStorageIdentity } from './state-layout.ts'
 import { applyWorkflowMetadataPatch, TASK_STATE_FIELDS, type WorkflowMetadataPatch } from './workflow-metadata.ts'
-import { assertLegacyStateWriteAllowed } from './v02-generation-fence.ts'
+import { assertActiveStateWriteAllowed } from './v02-generation-fence.ts'
 export type { WorkflowMetadataPatch } from './workflow-metadata.ts'
 export interface WorkflowTaskCredential {
   kind: 'dev' | 'review'
@@ -112,12 +112,12 @@ const workflowCommandQueues = new Map<string, Promise<void>>()
  */
 function enqueueWorkflowCommand<T>(workflow: WorkflowStorageIdentity, execute: () => Promise<T>): Promise<T> {
   const key = workflowStatePath(workflow)
-  assertLegacyStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
+  assertActiveStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
   const previous = workflowCommandQueues.get(key) ?? Promise.resolve()
   const operation = previous
     .catch(() => undefined)
     .then(async () => {
-      assertLegacyStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
+      assertActiveStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
       return execute()
     })
   const tail = operation.then(
@@ -179,13 +179,13 @@ async function readCurrent(path: string): Promise<IssueWorkflow | null> {
 }
 
 async function atomicWrite(path: string, workflow: IssueWorkflow): Promise<void> {
-  assertLegacyStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
+  assertActiveStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
   await mkdir(dirname(path), { recursive: true })
   const temporary = `${path}.${process.pid}.${randomBytes(8).toString('hex')}.tmp`
   try {
-    assertLegacyStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
+    assertActiveStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
     await writeFile(temporary, JSON.stringify(workflow, null, 2), { encoding: 'utf8', mode: 0o600 })
-    assertLegacyStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
+    assertActiveStateWriteAllowed(join(homedir(), '.clickvibe', 'state'))
     await rename(temporary, path)
   } finally {
     await rm(temporary, { force: true }).catch(() => undefined)

--- a/tests/baseline-restore.test.ts
+++ b/tests/baseline-restore.test.ts
@@ -109,7 +109,7 @@ test('authorized recovery recreates only the frozen missing base branch at its f
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(root, { recursive: true, force: true })
+    await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -195,7 +195,7 @@ test('restore rejects an authorization made stale by a queued baseline-tip mutat
     releaseFetch()
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(root, { recursive: true, force: true })
+    await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -293,7 +293,7 @@ test('restore holds the workflow lock through the remote push', async () => {
     releaseFetch()
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(root, { recursive: true, force: true })
+    await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -369,7 +369,7 @@ test('sync advances the durable baseline tip before a deleted branch is restored
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(root, { recursive: true, force: true })
+    await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -464,6 +464,6 @@ test('a resolved baseline merge conflict advances the durable tip before restore
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(root, { recursive: true, force: true })
+    await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })

--- a/tests/baseline-restore.test.ts
+++ b/tests/baseline-restore.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
 import test from 'node:test'
+import { activateV02Home, initFixtureRepository } from './helpers/v02-home.ts'
 import { createLiveTask, finishTask } from '../src/agent/task-supervisor.ts'
 import {
   commitWorkflowMetadata,
@@ -71,10 +72,7 @@ test('authorized recovery recreates only the frozen missing base branch at its f
     const frozen = (await git('rev-parse', 'HEAD')).stdout.trim()
     await git('push', '-u', 'origin', 'release/deleted')
     await git('push', 'origin', '--delete', 'release/deleted')
-    await writeFile(
-      join(home, '.clickvibe', 'config.yaml'),
-      ['repos:', `  o/r: ${repo}`, `worktreeRoot: ${join(root, 'worktrees')}`, ''].join('\n'),
-    )
+    await activateV02Home(home, { 'o/r': repo }, { worktreeRoot: join(root, 'worktrees') })
     await saveWorkflow({
       key: issueKey('o/r', '60'),
       url: 'https://github.com/o/r/issues/60',
@@ -118,7 +116,7 @@ test('authorized recovery recreates only the frozen missing base branch at its f
 test('restore rejects an authorization made stale by a queued baseline-tip mutation', async () => {
   const root = await mkdtemp(join(tmpdir(), 'clickvibe-restore-stale-authorization-'))
   const home = join(root, 'home')
-  const repo = join(root, 'repo')
+  const repo = await initFixtureRepository(join(root, 'repo'))
   const previousHome = process.env.HOME
   process.env.HOME = home
   let releaseFetch = () => undefined
@@ -173,10 +171,7 @@ test('restore rejects an authorization made stale by a queued baseline-tip mutat
   } satisfies IssueWorkflow
   try {
     await mkdir(join(home, '.clickvibe'), { recursive: true })
-    await writeFile(
-      join(home, '.clickvibe', 'config.yaml'),
-      ['repos:', `  o/r: ${repo}`, `worktreeRoot: ${join(root, 'worktrees')}`, ''].join('\n'),
-    )
+    await activateV02Home(home, { 'o/r': repo }, { worktreeRoot: join(root, 'worktrees') })
     await saveWorkflow(workflow)
 
     await commitWorkflowMetadata(workflow, workflow.revision ?? null, {
@@ -271,11 +266,8 @@ test('restore holds the workflow lock through the remote push', async () => {
     events: [],
   } satisfies IssueWorkflow
   try {
-    await mkdir(join(home, '.clickvibe'), { recursive: true })
-    await writeFile(
-      join(home, '.clickvibe', 'config.yaml'),
-      ['repos:', `  o/r: ${join(root, 'repo')}`, `worktreeRoot: ${join(root, 'worktrees')}`, ''].join('\n'),
-    )
+    const repo = await initFixtureRepository(join(root, 'repo'))
+    await activateV02Home(home, { 'o/r': repo }, { worktreeRoot: join(root, 'worktrees') })
     await saveWorkflow(workflow)
 
     const restoring = restoreBaseBranch(ctx as never, {
@@ -334,10 +326,7 @@ test('sync advances the durable baseline tip before a deleted branch is restored
     await git('commit', '--allow-empty', '-m', 'release B')
     const latest = (await git('rev-parse', 'HEAD')).stdout.trim()
     await git('push', 'origin', 'release/deleted')
-    await writeFile(
-      join(home, '.clickvibe', 'config.yaml'),
-      ['repos:', `  o/r: ${repo}`, `worktreeRoot: ${join(root, 'worktrees')}`, ''].join('\n'),
-    )
+    await activateV02Home(home, { 'o/r': repo }, { worktreeRoot: join(root, 'worktrees') })
     const workflow = {
       key: issueKey('o/r', '61'),
       url: 'https://github.com/o/r/issues/61',
@@ -417,10 +406,7 @@ test('a resolved baseline merge conflict advances the durable tip before restore
     await git('commit', '-am', 'release B')
     const latest = (await git('rev-parse', 'HEAD')).stdout.trim()
     await git('push', 'origin', 'release/conflict')
-    await writeFile(
-      join(home, '.clickvibe', 'config.yaml'),
-      ['repos:', `  o/r: ${repo}`, `worktreeRoot: ${join(root, 'worktrees')}`, ''].join('\n'),
-    )
+    await activateV02Home(home, { 'o/r': repo }, { worktreeRoot: join(root, 'worktrees') })
     const item = {
       key: issueKey('o/r', '62'),
       url: 'https://github.com/o/r/issues/62',

--- a/tests/baseline-shared-restore.test.ts
+++ b/tests/baseline-shared-restore.test.ts
@@ -57,7 +57,7 @@ async function sharedFixture() {
     async cleanup() {
       if (previousHome === undefined) delete process.env.HOME
       else process.env.HOME = previousHome
-      await rm(root, { recursive: true, force: true })
+      await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
     },
   }
 }

--- a/tests/baseline-shared-restore.test.ts
+++ b/tests/baseline-shared-restore.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
+import { activateV02Home, initFixtureRepository } from './helpers/v02-home.ts'
 import { commitWorkflowMetadata, issueKey, loadWorkflow, type IssueWorkflow } from '../src/infra/state.ts'
 import { restoreBaseBranch } from '../src/workflow/baseline-restore.ts'
 import { commitWorkflowFixture } from './workflow-fixture.ts'
@@ -44,11 +45,8 @@ async function sharedFixture() {
   const previousHome = process.env.HOME
   process.env.HOME = home
   await mkdir(join(home, '.clickvibe'), { recursive: true })
-  await mkdir(repo, { recursive: true })
-  await writeFile(
-    join(home, '.clickvibe', 'config.yaml'),
-    ['repos:', `  o/r: ${repo}`, `worktreeRoot: ${join(root, 'worktrees')}`, ''].join('\n'),
-  )
+  await initFixtureRepository(repo)
+  await activateV02Home(home, { 'o/r': repo }, { worktreeRoot: join(root, 'worktrees') })
   const older = sharedWorkflow(root, '1', OLDER_HASH, 1)
   const latest = sharedWorkflow(root, '2', LATEST_HASH, 2)
   await saveWorkflow(older)

--- a/tests/command-stop-recovery.test.ts
+++ b/tests/command-stop-recovery.test.ts
@@ -116,6 +116,6 @@ test('stop command explicitly confirms task-unknown dev and review through the s
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })

--- a/tests/command-stop-recovery.test.ts
+++ b/tests/command-stop-recovery.test.ts
@@ -5,6 +5,7 @@ import type { IncomingMessage } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
+import { activateV02Home, initFixtureRepository } from './helpers/v02-home.ts'
 import { issueKey, loadWorkflow, type IssueWorkflow } from '../src/infra/state.ts'
 import { handleCommand } from '../src/workflow/handlers.ts'
 
@@ -57,7 +58,8 @@ test('stop command explicitly confirms task-unknown dev and review through the s
   process.env.HOME = tempHome
   try {
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await writeFile(join(tempHome, '.clickvibe', 'config.yaml'), `repos:\n  o/r: ${join(tempHome, 'repo')}\n`)
+    const stopRepo = await initFixtureRepository(join(tempHome, 'repo'))
+    await activateV02Home(tempHome, { 'o/r': stopRepo })
     const key = issueKey('o/r', '111')
     const workflow = workflowFixture(key, tempHome)
     await commitWorkflowFixture(workflow, null)

--- a/tests/command.test.ts
+++ b/tests/command.test.ts
@@ -209,6 +209,15 @@ test('status command returns readable workflow state derived from the same /stat
       comments: [],
     }
     const handler = createHandler(async ({ command }) => {
+      if (command.startsWith('set +e')) {
+        return {
+          exitCode: 0,
+          stdout: {
+            text: 'REPO_DEFAULT\t128\t\nREPO_BRANCH\t0\tbWFpbg==\nREPO_HEAD\t128\t\nREPO_MAIN_COUNT\t128\t\nREPO_HEAD_COUNT\t128\t\n',
+          },
+          stderr: { text: '' },
+        }
+      }
       const api = githubApi(command, {
         item,
         pr: {

--- a/tests/command.test.ts
+++ b/tests/command.test.ts
@@ -178,7 +178,7 @@ test('projects command lists configured repos', async (t) => {
   t.after(async () => {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   })
   const repo = await initFixtureRepository(join(tempHome, 'repo'))
   await activateV02Home(tempHome, { 'o/r': repo })
@@ -246,7 +246,7 @@ test('status command returns readable workflow state derived from the same /stat
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -268,7 +268,7 @@ test('develop command previews with a one-use authorization instead of starting 
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -331,7 +331,7 @@ test('confirmed develop revalidates the frozen snapshot through the same backend
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -421,7 +421,7 @@ test('review command previews through the shared authorize path', async () => {
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -511,7 +511,7 @@ test('merge command surfaces every gate failure and supports the manual override
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -538,6 +538,6 @@ test('unknown repos and unparsable commands answer actionable errors', async () 
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })

--- a/tests/command.test.ts
+++ b/tests/command.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import { beforeEach } from 'node:test'
+import { activateV02Home, initFixtureRepository } from './helpers/v02-home.ts'
 import { resetGithubGatewayOwnerForTests } from '../src/github/gateway-owner.ts'
 
 beforeEach(() => resetGithubGatewayOwnerForTests())
@@ -170,10 +171,22 @@ test('help command answers readable text without any shell call', async () => {
   assert.match(String(result.body.text), /merge/)
 })
 
-test('projects command lists configured repos', async () => {
+test('projects command lists configured repos', async (t) => {
+  const previousHome = process.env.HOME
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-cmd-projects-'))
+  process.env.HOME = tempHome
+  t.after(async () => {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    await rm(tempHome, { recursive: true, force: true })
+  })
+  const repo = await initFixtureRepository(join(tempHome, 'repo'))
+  await activateV02Home(tempHome, { 'o/r': repo })
+
   const result = await post(createHandler(), { command: 'projects' })
   assert.equal(result.status, 200)
   assert.match(String(result.body.text), /已配置的项目/)
+  assert.match(String(result.body.text), /o\/r/)
 })
 
 test('status command returns readable workflow state derived from the same /state logic', async () => {
@@ -182,7 +195,8 @@ test('status command returns readable workflow state derived from the same /stat
   process.env.HOME = tempHome
   try {
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await writeFile(join(tempHome, '.clickvibe', 'config.yaml'), `repos:\n  o/r: ${join(tempHome, 'missing-repo')}\n`)
+    const missingRepo = await initFixtureRepository(join(tempHome, 'missing-repo'))
+    await activateV02Home(tempHome, { 'o/r': missingRepo })
     const workflow = workflowFixture('o-r-23', 'https://github.com/o/r/issues/23', join(tempHome, 'missing-worktree'))
     await commitWorkflowFixture(workflow, workflow.revision ?? null)
     const item = {
@@ -239,7 +253,8 @@ test('develop command previews with a one-use authorization instead of starting 
   process.env.HOME = tempHome
   try {
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await writeFile(join(tempHome, '.clickvibe', 'config.yaml'), `repos:\n  o/r: ${join(tempHome, 'missing-repo')}\n`)
+    const missingRepo = await initFixtureRepository(join(tempHome, 'missing-repo'))
+    await activateV02Home(tempHome, { 'o/r': missingRepo })
     await developPreviewScenario()
   } finally {
     if (previousHome === undefined) delete process.env.HOME
@@ -301,7 +316,8 @@ test('confirmed develop revalidates the frozen snapshot through the same backend
   process.env.HOME = tempHome
   try {
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await writeFile(join(tempHome, '.clickvibe', 'config.yaml'), `repos:\n  o/r: ${join(tempHome, 'missing-repo')}\n`)
+    const missingRepo = await initFixtureRepository(join(tempHome, 'missing-repo'))
+    await activateV02Home(tempHome, { 'o/r': missingRepo })
     await confirmedDevelopScenario()
   } finally {
     if (previousHome === undefined) delete process.env.HOME
@@ -368,7 +384,8 @@ test('review command previews through the shared authorize path', async () => {
   process.env.HOME = tempHome
   try {
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await writeFile(join(tempHome, '.clickvibe', 'config.yaml'), `repos:\n  o/r: ${join(tempHome, 'missing-repo')}\n`)
+    const missingRepo = await initFixtureRepository(join(tempHome, 'missing-repo'))
+    await activateV02Home(tempHome, { 'o/r': missingRepo })
     const item = {
       url: 'https://github.com/o/r/issues/15',
       number: 15,
@@ -405,12 +422,9 @@ test('merge command surfaces every gate failure and supports the manual override
   process.env.HOME = tempHome
   try {
     const repo = join(tempHome, 'repo')
-    await mkdir(repo, { recursive: true })
+    await initFixtureRepository(repo)
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await writeFile(
-      join(tempHome, '.clickvibe', 'config.yaml'),
-      `repos:\n  o/r: ${repo}\nworktreeRoot: ${join(tempHome, 'worktrees')}\n`,
-    )
+    await activateV02Home(tempHome, { 'o/r': repo }, { worktreeRoot: join(tempHome, 'worktrees') })
     const workflow = workflowFixture(
       'o-r-23',
       'https://github.com/o/r/issues/23',
@@ -498,7 +512,9 @@ test('unknown repos and unparsable commands answer actionable errors', async () 
   process.env.HOME = tempHome
   try {
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await writeFile(join(tempHome, '.clickvibe', 'config.yaml'), 'repos:\n  a/one: /x\n  b/two: /y\n')
+    const one = await initFixtureRepository(join(tempHome, 'one'))
+    const two = await initFixtureRepository(join(tempHome, 'two'))
+    await activateV02Home(tempHome, { 'a/one': one, 'b/two': two })
     const ambiguous = await post(createHandler(), { command: 'develop #8' }, PRIVILEGED)
     assert.equal(ambiguous.status, 400)
     assert.match(String(ambiguous.body.error), /多个项目/)

--- a/tests/develop-baseline-preview.test.ts
+++ b/tests/develop-baseline-preview.test.ts
@@ -54,7 +54,7 @@ test('baseline preview validates URLs and degrades an unconfigured repository on
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(home, { recursive: true, force: true })
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -86,7 +86,7 @@ test('baseline preview exposes fetch failure for the default but rejects an unve
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(home, { recursive: true, force: true })
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -142,7 +142,7 @@ test('baseline preview excludes and rejects the current issue development branch
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(home, { recursive: true, force: true })
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -193,6 +193,6 @@ test('frozen issue-branch preview skips self-dependencies and ignores a closed p
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(home, { recursive: true, force: true })
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })

--- a/tests/develop-baseline-preview.test.ts
+++ b/tests/develop-baseline-preview.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { activateV02Home, initFixtureRepository } from './helpers/v02-home.ts'
 import { resetGithubGatewayOwnerForTests } from '../src/github/gateway-owner.ts'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -64,8 +65,8 @@ test('baseline preview exposes fetch failure for the default but rejects an unve
   try {
     const repo = join(home, 'repo')
     await mkdir(join(home, '.clickvibe'), { recursive: true })
-    await mkdir(repo, { recursive: true })
-    await writeFile(join(home, '.clickvibe', 'config.yaml'), ['repos:', `  o/r: ${repo}`, ''].join('\n'))
+    await initFixtureRepository(repo)
+    await activateV02Home(home, { 'o/r': repo })
     const ctx = {
       shell: {
         resolve(spec: unknown) {
@@ -96,8 +97,8 @@ test('baseline preview excludes and rejects the current issue development branch
   try {
     const repo = join(home, 'repo')
     await mkdir(join(home, '.clickvibe'), { recursive: true })
-    await mkdir(repo, { recursive: true })
-    await writeFile(join(home, '.clickvibe', 'config.yaml'), ['repos:', `  o/r: ${repo}`, ''].join('\n'))
+    await initFixtureRepository(repo)
+    await activateV02Home(home, { 'o/r': repo })
     const ctx = {
       shell: {
         resolve(spec: unknown) {

--- a/tests/github-operations.test.ts
+++ b/tests/github-operations.test.ts
@@ -10,6 +10,9 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import { beforeEach } from 'node:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { resetGithubGatewayOwnerForTests } from '../src/github/gateway-owner.ts'
 
 beforeEach(() => resetGithubGatewayOwnerForTests())
@@ -95,7 +98,15 @@ test('r5/F2: every family declares the admission ladder; only the gate families 
   assert.deepEqual(critical, ['contract-issue-detail', 'gate-pr-fact'], 'critical is for gates only')
 })
 
-test('r5/F2: a gate read declares critical in the production owner; the panel stays normal', async () => {
+test('r5/F2: a gate read declares critical in the production owner; the panel stays normal', async (t) => {
+  const previousHome = process.env.HOME
+  const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-gate-priority-'))
+  process.env.HOME = tempHome
+  t.after(() => {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    return rm(tempHome, { recursive: true, force: true })
+  })
   const { githubGatewayOwner } = await import('../src/github/gateway-owner.ts')
   const owner = githubGatewayOwner()
   const gateRoutes = [

--- a/tests/helpers/v02-home.ts
+++ b/tests/helpers/v02-home.ts
@@ -1,0 +1,124 @@
+/**
+ * Shared fixture helper: activate a verified v0.2 config/state pair in a test
+ * home by running the REAL upgrade machine (preview + apply with the offline
+ * generation fence). No crafting of journal/marker bytes: the pairing the
+ * runtime accepts is produced exactly as production produces it.
+ *
+ * Every `repos` entry must be (or will become) a real git repository with a
+ * single `origin` remote; pass `deleteAfterActivation` to remove the clone
+ * directory afterwards for missing-path scenarios (the runtime then fails
+ * closed on that binding, per ADR-0009/#134 strict pairing).
+ */
+import { execFile } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { promisify } from 'node:util'
+import {
+  createOfflineV02GenerationFence,
+  resetV02GenerationFenceForTest,
+  V02_OFFLINE_HOST_DECLARATION,
+} from '../../src/infra/v02-generation-fence.ts'
+import { applyV02Upgrade } from '../../src/infra/v02-upgrade-execution.ts'
+import { previewV02Upgrade } from '../../src/infra/v02-upgrade.ts'
+
+const execFileAsync = promisify(execFile)
+
+export async function git(cwd: string, ...args: string[]): Promise<string> {
+  return (await execFileAsync('git', ['-C', cwd, ...args], { encoding: 'utf8' })).stdout.trim()
+}
+
+function testNonce(label: string): string {
+  const hex = createHash('sha256').update(label).digest('hex')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-4${hex.slice(13, 16)}-8${hex.slice(17, 20)}-${hex.slice(20, 32)}`
+}
+
+/** Turn an existing (or new) directory into a minimal real git repository. */
+export async function initFixtureRepository(repository: string): Promise<string> {
+  await mkdir(repository, { recursive: true })
+  await git(dirname(repository), 'init', repository)
+  await git(repository, 'config', 'user.name', 'clickvibe-test')
+  await git(repository, 'config', 'user.email', 'clickvibe-test@example.invalid')
+  await git(repository, 'commit', '--allow-empty', '-m', 'base')
+  await git(repository, 'remote', 'add', 'origin', 'https://github.com/o/r.git')
+  return repository
+}
+
+/** Create a minimal real git repository with a single `origin` remote. */
+export async function makeFixtureRepository(parent: string, name: string): Promise<string> {
+  const repository = join(parent, name)
+  await git(dirname(repository), 'init', repository)
+  await git(repository, 'config', 'user.name', 'clickvibe-test')
+  await git(repository, 'config', 'user.email', 'clickvibe-test@example.invalid')
+  await git(repository, 'commit', '--allow-empty', '-m', `base ${name}`)
+  await git(repository, 'remote', 'add', 'origin', `https://github.com/${name.split('-')[0]}/r.git`)
+  return repository
+}
+
+export interface ActivateV02HomeOptions {
+  worktreeRoot?: string
+  fetchTtlSeconds?: number
+  diagnosticsMaxBytes?: number
+  /** Repository paths to delete after activation (missing-path scenarios). */
+  deleteAfterActivation?: string[]
+}
+
+export async function activateV02Home(
+  home: string,
+  repos: Record<string, string>,
+  options: ActivateV02HomeOptions = {},
+): Promise<void> {
+  const label = `activate-${createHash('sha256').update(home).digest('hex').slice(0, 12)}`
+  const root = join(home, '.clickvibe')
+  await mkdir(root, { recursive: true })
+  const lines = ['repos:']
+  for (const [repoKey, path] of Object.entries(repos)) lines.push(`  ${repoKey}: ${path}`)
+  if (options.worktreeRoot) lines.push(`worktreeRoot: ${options.worktreeRoot}`)
+  if (options.fetchTtlSeconds !== undefined) lines.push(`fetchTtlSeconds: ${options.fetchTtlSeconds}`)
+  if (options.diagnosticsMaxBytes !== undefined) lines.push(`diagnosticsMaxBytes: ${options.diagnosticsMaxBytes}`)
+  await writeFile(join(root, 'config.yaml'), `${lines.join('\n')}\n`, { mode: 0o600 })
+
+  resetV02GenerationFenceForTest()
+  const primaryRemotes: Record<string, string> = {}
+  for (const repoKey of Object.keys(repos)) primaryRemotes[repoKey] = 'origin'
+  const fence = () =>
+    createOfflineV02GenerationFence({
+      declaration: V02_OFFLINE_HOST_DECLARATION,
+      enumerateOldPluginProcesses: async () => [],
+    })
+  // One retry absorbs a deferred diagnostic write from a sibling test landing
+  // between preview and the critical-section re-observation; a facts-changed
+  // attempt writes nothing, so the retry is side-effect free.
+  let result: { status: string } | undefined
+  for (let attempt = 0; attempt < 2 && result?.status !== 'verified'; attempt += 1) {
+    const preview = await previewV02Upgrade({
+      home,
+      baselineSha: testNonce(label),
+      nonce: testNonce(`${label}-${attempt}`),
+      choices: { primaryRemotes, exclusions: {} },
+      hostActivity: { liveTasks: [], liveJobs: [], oldPluginProcesses: [] },
+    })
+    if (preview.status !== 'previewed') throw new Error(`v0.2 activation preview failed: ${JSON.stringify(preview)}`)
+    result = await applyV02Upgrade({ plan: preview.plan, fingerprint: preview.fingerprint, fence: fence() })
+  }
+  if (result?.status !== 'verified') throw new Error(`v0.2 activation failed: ${JSON.stringify(result)}`)
+  // Return the process to the pre-upgrade fence mode so sibling tests in the
+  // same process can still start tasks; production keeps v0.2-active.
+  resetV02GenerationFenceForTest()
+  for (const path of options.deleteAfterActivation ?? []) await rm(path, { recursive: true, force: true })
+}
+
+/** A fresh temp home plus real fixture repositories, activated as v0.2. */
+export async function v02Home(
+  repoKeys: string[],
+  options: ActivateV02HomeOptions = {},
+): Promise<{ home: string; repositories: Record<string, string> }> {
+  const home = await mkdtemp(join(tmpdir(), 'clickvibe-v02-home-'))
+  const repositories: Record<string, string> = {}
+  for (const repoKey of repoKeys) {
+    repositories[repoKey] = await makeFixtureRepository(home, repoKey.replace('/', '-'))
+  }
+  await activateV02Home(home, repositories, options)
+  return { home, repositories }
+}

--- a/tests/legacy-reader-removal.test.ts
+++ b/tests/legacy-reader-removal.test.ts
@@ -30,7 +30,7 @@ async function withTempHome(name, run) {
   } finally {
     if (previous === undefined) delete process.env.HOME
     else process.env.HOME = previous
-    await rm(home, { recursive: true, force: true })
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 }
 
@@ -75,7 +75,7 @@ test('project import fails closed instead of writing a v0.1 repos mapping', asyn
   t.after(async () => {
     if (previous === undefined) delete process.env.HOME
     else process.env.HOME = previous
-    await rm(home, { recursive: true, force: true })
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   })
 
   const root = join(home, '.clickvibe')

--- a/tests/merge-edge.test.ts
+++ b/tests/merge-edge.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
+import { activateV02Home, initFixtureRepository } from './helpers/v02-home.ts'
 import { mergingWorkflows } from '../src/infra/runtime.ts'
 import { issueKey, loadWorkflow, type IssueWorkflow } from '../src/infra/state.ts'
 import {
@@ -135,16 +136,12 @@ test('merge execution validates URL, exclusivity, workflow, config, worktree roo
 
     await saveWorkflow(workflow('2'))
     await mkdir(join(home, '.clickvibe'), { recursive: true })
-    await writeFile(join(home, '.clickvibe', 'config.yaml'), 'repos: {}\n')
     assert.match((await mergeAndCleanupUnlocked({} as never, { url: workflow('2').url })).error, /未配置项目/)
 
     const repo = join(home, 'repo')
     const root = join(home, 'worktrees')
-    await mkdir(repo, { recursive: true })
-    await writeFile(
-      join(home, '.clickvibe', 'config.yaml'),
-      ['repos:', `  o/r: ${repo}`, `worktreeRoot: ${root}`, ''].join('\n'),
-    )
+    await initFixtureRepository(repo)
+    await activateV02Home(home, { 'o/r': repo }, { worktreeRoot: root })
     await saveWorkflow(workflow('2', { worktree: join(home, 'outside') }))
     assert.match(
       (await mergeAndCleanupUnlocked({} as never, { url: workflow('2').url })).error,
@@ -168,10 +165,10 @@ test('merge execution rejects an authorization whose exact PR base changed', asy
     const repo = join(home, 'repo')
     const worktreeRoot = join(home, 'worktrees')
     const worktreePath = join(worktreeRoot, 'repo-issue-8')
-    await mkdir(repo, { recursive: true })
+    await initFixtureRepository(repo)
     await mkdir(worktreePath, { recursive: true })
     await mkdir(join(home, '.clickvibe'), { recursive: true })
-    await writeFile(join(home, '.clickvibe', 'config.yaml'), `repos:\n  o/r: ${repo}\nworktreeRoot: ${worktreeRoot}\n`)
+    await activateV02Home(home, { 'o/r': repo }, { worktreeRoot: worktreeRoot })
     const stored = workflow('8', { worktree: worktreePath, branch: 'repo-issue-8', prNumber: '8' })
     await saveWorkflow(stored)
     const ctx = prCtx({

--- a/tests/merge-edge.test.ts
+++ b/tests/merge-edge.test.ts
@@ -108,7 +108,7 @@ test('merge authorization preview rejects invalid, missing, unreadable, closed a
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(home, { recursive: true, force: true })
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -153,7 +153,7 @@ test('merge execution validates URL, exclusivity, workflow, config, worktree roo
     mergingWorkflows.delete(issueKey('o/r', '2'))
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(home, { recursive: true, force: true })
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -194,7 +194,7 @@ test('merge execution rejects an authorization whose exact PR base changed', asy
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(home, { recursive: true, force: true })
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 

--- a/tests/no-legacy-config.test.ts
+++ b/tests/no-legacy-config.test.ts
@@ -1,0 +1,33 @@
+/**
+ * AC3 final boundary: the runtime has no v0.1 config reader. A config.yaml
+ * without schemaVersion is rejected with a pointer to the offline upgrade
+ * entry (ADR-0009 D1, ADR-0013 §6a, issue #137). The schema-1 path and the
+ * fresh-install ENOENT default are covered by the v02-upgrade-apply suite.
+ */
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { loadConfigFromHome } from '../src/infra/runtime.ts'
+
+test('a v0.1 repos config is rejected with the upgrade entry pointer', async (t) => {
+  const home = await mkdtemp(join(tmpdir(), 'clickvibe-no-legacy-config-'))
+  t.after(() => rm(home, { recursive: true, force: true }))
+  await mkdir(join(home, '.clickvibe'), { recursive: true })
+  await writeFile(
+    join(home, '.clickvibe', 'config.yaml'),
+    `repos:\n  o/r: ${join(home, 'repo')}\nfetchTtlSeconds: 45\n`,
+  )
+
+  await assert.rejects(loadConfigFromHome(home), /v0\.1 config is no longer readable.*scripts\/upgrade-v0\.2\.mjs/s)
+})
+
+test('a fresh install without config.yaml still selects the documented defaults', async (t) => {
+  const home = await mkdtemp(join(tmpdir(), 'clickvibe-fresh-home-'))
+  t.after(() => rm(home, { recursive: true, force: true }))
+
+  const config = await loadConfigFromHome(home)
+  assert.deepEqual(config.repos, {})
+  assert.equal(config.worktreeRoot, join(home, '.clickvibe', 'worktrees'))
+})

--- a/tests/post-cutover-write-authority.test.ts
+++ b/tests/post-cutover-write-authority.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Post-cutover write authority (ADR-0009 D1/D6, protocol §1, issue #137 AC3/AC5):
+ * once a VERIFIED journal and the v0.2 state marker own the root, current-format
+ * runtime writers (workflow persistence, task/action logs) are the rightful
+ * owners and must be admitted. Partial upgrades, torn journals, and drift
+ * (verified without marker, or marker without journal) stay fail-closed.
+ */
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { appendLog } from '../src/infra/state.ts'
+import {
+  assertActiveStateWriteAllowed,
+  isV02GenerationViolation,
+  resetV02GenerationFenceForTest,
+} from '../src/infra/v02-generation-fence.ts'
+
+interface RootShape {
+  journal?: { phase: string; planFingerprint?: string }
+  marker?: boolean
+}
+
+async function ownedRoot(shape: RootShape): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), 'clickvibe-write-authority-'))
+  const root = join(home, '.clickvibe', 'state')
+  await mkdir(root, { recursive: true })
+  if (shape.journal) {
+    await writeFile(
+      join(home, '.clickvibe', 'upgrade-v0.2.json'),
+      `${JSON.stringify({ schemaVersion: 1, phase: shape.journal.phase, planFingerprint: shape.journal.planFingerprint ?? 'f'.repeat(64) })}\n`,
+    )
+  }
+  if (shape.marker) {
+    await writeFile(join(root, '.clickvibe-state.json'), '{"schemaVersion":1,"generation":"v0.2"}\n')
+  }
+  return root
+}
+
+async function withRoots(shape: RootShape, run: (root: string, home: string) => Promise<void>) {
+  const root = await ownedRoot(shape)
+  const home = join(root, '..', '..')
+  const previous = process.env.HOME
+  process.env.HOME = home
+  resetV02GenerationFenceForTest()
+  try {
+    await run(root, home)
+  } finally {
+    if (previous === undefined) delete process.env.HOME
+    else process.env.HOME = previous
+    resetV02GenerationFenceForTest()
+    await rm(home, { recursive: true, force: true })
+  }
+}
+
+const workflow = { key: 'issue-dw8v', repoKey: 'o/r', url: 'https://github.com/o/r/issues/8' }
+
+test('a verified journal with marker admits current-format runtime writers', async () => {
+  await withRoots({ journal: { phase: 'verified' }, marker: true }, async (root) => {
+    await appendLog(workflow.key, 'dev', '[clickvibe] post-cutover action note')
+    assertActiveStateWriteAllowed(root)
+  })
+})
+
+test('a partial or torn journal keeps every writer fail-closed', async () => {
+  for (const phase of ['preparing', 'prepared', 'cutting-over', 'failed', 'unknown']) {
+    await withRoots({ journal: { phase }, marker: false }, async () => {
+      await assert.rejects(appendLog(workflow.key, 'dev', 'x'), (reason: unknown) => isV02GenerationViolation(reason))
+    })
+  }
+})
+
+test('drift between the journal and the marker stays fail-closed', async () => {
+  await withRoots({ journal: { phase: 'verified' }, marker: false }, async () => {
+    await assert.rejects(appendLog(workflow.key, 'dev', 'x'), (reason: unknown) => isV02GenerationViolation(reason))
+  })
+  await withRoots({ journal: undefined, marker: true }, async () => {
+    await assert.rejects(appendLog(workflow.key, 'dev', 'x'), (reason: unknown) => isV02GenerationViolation(reason))
+  })
+})
+
+test('a rolled-back or clean root keeps the pre-upgrade write semantics', async () => {
+  await withRoots({ journal: { phase: 'rolled_back' }, marker: false }, async () => {
+    await appendLog(workflow.key, 'dev', '[clickvibe] rolled-back root stays writable')
+  })
+  await withRoots({ journal: undefined, marker: false }, async () => {
+    await appendLog(workflow.key, 'dev', '[clickvibe] clean root stays writable')
+  })
+})

--- a/tests/post-cutover-write-authority.test.ts
+++ b/tests/post-cutover-write-authority.test.ts
@@ -50,7 +50,7 @@ async function withRoots(shape: RootShape, run: (root: string, home: string) => 
     if (previous === undefined) delete process.env.HOME
     else process.env.HOME = previous
     resetV02GenerationFenceForTest()
-    await rm(home, { recursive: true, force: true })
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 }
 

--- a/tests/repository-sync-routes.test.ts
+++ b/tests/repository-sync-routes.test.ts
@@ -164,7 +164,7 @@ async function withConfiguredRepo(
   } finally {
     repositoryFreshness.clear()
     process.env.HOME = previousHome
-    await rm(home, { recursive: true, force: true })
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 }
 

--- a/tests/repository-sync-routes.test.ts
+++ b/tests/repository-sync-routes.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import { beforeEach } from 'node:test'
+import { activateV02Home, initFixtureRepository } from './helpers/v02-home.ts'
 import { resetGithubGatewayOwnerForTests } from '../src/github/gateway-owner.ts'
 
 beforeEach(() => resetGithubGatewayOwnerForTests())
@@ -157,9 +158,8 @@ async function withConfiguredRepo(
   process.env.HOME = home
   repositoryFreshness.clear()
   try {
-    await mkdir(join(home, '.clickvibe'), { recursive: true })
-    await mkdir(repo)
-    await writeFile(join(home, '.clickvibe', 'config.yaml'), `repos:\n  o/r: ${repo}\n`)
+    await initFixtureRepository(repo)
+    await activateV02Home(home, { 'o/r': repo })
     await run(createHandler(fakeShell(scenario, commands)), commands)
   } finally {
     repositoryFreshness.clear()

--- a/tests/review-start.test.ts
+++ b/tests/review-start.test.ts
@@ -4,6 +4,7 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
+import { activateV02Home, initFixtureRepository } from './helpers/v02-home.ts'
 import { issueKey, loadWorkflow } from '../src/infra/state.ts'
 import { resolveReviewStartWorkflow, reviewStartError } from '../src/workflow/review-start.ts'
 
@@ -27,12 +28,9 @@ test('review start recovers a missing workflow from matching branch, commit, and
     const worktreeRoot = join(tempHome, 'worktrees')
     const worktree = join(worktreeRoot, 'r', 'r-issue-106')
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await mkdir(repo, { recursive: true })
+    await initFixtureRepository(repo)
     await mkdir(worktree, { recursive: true })
-    await writeFile(
-      join(tempHome, '.clickvibe', 'config.yaml'),
-      ['repos:', `  o/r: ${repo}`, `worktreeRoot: ${worktreeRoot}`, ''].join('\n'),
-    )
+    await activateV02Home(tempHome, { 'o/r': repo }, { worktreeRoot: worktreeRoot })
 
     const head = 'abc1234567890abcdef'
     const ctx = {

--- a/tests/review-start.test.ts
+++ b/tests/review-start.test.ts
@@ -120,6 +120,6 @@ test('review start recovers a missing workflow from matching branch, commit, and
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -43,7 +43,7 @@ process.env.HOME = routesTestHome
 after(async () => {
   if (routesOriginalHome === undefined) delete process.env.HOME
   else process.env.HOME = routesOriginalHome
-  await rm(routesTestHome, { recursive: true, force: true })
+  await rm(routesTestHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
 })
 
 const saveWorkflow = (workflow: IssueWorkflow) => commitWorkflowFixture(workflow, workflow.revision ?? null)
@@ -399,7 +399,7 @@ test('/create-pr uses a one-use privileged authorization before the shared handl
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -470,7 +470,7 @@ test('/create-pr recovers a pending PR-create marker by readback and never re-cr
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -674,7 +674,7 @@ test('develop authorization previews fetched baselines and binds a custom select
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -796,7 +796,7 @@ test('concurrent first-development authorizations freeze exactly one baseline an
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -1082,7 +1082,7 @@ test('missing baseline restoration requires and consumes an exact one-use author
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(home, { recursive: true, force: true })
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -1306,7 +1306,7 @@ test('/merge requires one-use authorization, exact reviewed HEAD, merge commit, 
     await closeRemoteGitCoordinator()
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -1363,7 +1363,7 @@ test('/merge rejects a stale review hash before invoking the merge write', async
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -1432,7 +1432,7 @@ test('/merge authorization rejects a changed acceptance contract with the same P
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -1618,7 +1618,7 @@ test('/merge gate rejection offers manual override that merges once and audits t
     await closeRemoteGitCoordinator()
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -1729,7 +1729,7 @@ test('/merge manual override refuses gate failures not covered by the confirmati
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -1859,7 +1859,7 @@ test('cleanup failure keeps merged terminal state and retries without merging ag
     await closeRemoteGitCoordinator()
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -1907,7 +1907,7 @@ test('/state uses the live GitHub issue state instead of the stored issueState',
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -1973,7 +1973,7 @@ test('/state and repo/issues share one repository fetch TTL while manual refresh
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -2009,7 +2009,7 @@ test('/state keeps local-ref state readable and marks freshness stale when fetch
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -2031,7 +2031,7 @@ test('/state fails closed when a bound clone vanished instead of degrading to re
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -2069,7 +2069,7 @@ test('/state returns stale local facts within a bounded wait when git fetch hang
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -2127,7 +2127,7 @@ test('a rejected dry-run worktree attempt preserves the previous durable dev his
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -2230,7 +2230,7 @@ test('/history restores the complete disk log by task id after Host restart', as
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -2262,7 +2262,7 @@ test('/history queries an older round by project and issue while binding the rou
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -2295,7 +2295,7 @@ test('/history restores structured agent records and keeps legacy lines compatib
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -2320,7 +2320,7 @@ test('/history accepts a safe workflow key and rejects unknown or traversal targ
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -2676,7 +2676,7 @@ test('lossy agent output recovers the missing head from the host spill file into
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -2777,7 +2777,7 @@ test('completed development without a PR uses the current contract and appends i
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -2874,7 +2874,7 @@ test('concurrent resume requests reserve one workflow task before refreshing the
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -2972,7 +2972,7 @@ test('comment publication failure keeps the delivery event and stores a bounded 
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -3162,7 +3162,7 @@ test('invalid exact review session clears the stale id and falls back to a fresh
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -3279,7 +3279,7 @@ test('duplicate review requests reuse the reserved task before fetching the Issu
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -3378,7 +3378,7 @@ test('cross-agent review starts fresh and an empty failed verdict requires re-re
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -3559,7 +3559,7 @@ test('/develop automatic mode rejects a branch with commits when workflow histor
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -3680,7 +3680,7 @@ test('rate-limit response opens a circuit and returns the friendly recovery time
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -4538,7 +4538,7 @@ test('develop with user context stays a first development and records the note i
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -4635,7 +4635,7 @@ test('resume (rework) carries the user context next to the review feedback and a
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -4760,6 +4760,6 @@ test('review with user context appends it to the prompt and audits it in the rev
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -28,6 +28,7 @@ import {
   readLogHistory,
   startTaskLog,
 } from '../src/infra/state.ts'
+import { activateV02Home, initFixtureRepository } from './helpers/v02-home.ts'
 import { createFakeJobs } from './fake-jobs.ts'
 import { commitWorkflowFixture } from './workflow-fixture.ts'
 import { fingerprintGithubIssueContract } from '../src/workflow/work-item-contract-repository.ts'
@@ -569,8 +570,8 @@ test('develop authorization previews fetched baselines and binds a custom select
   try {
     const repo = join(tempHome, 'repo')
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await mkdir(repo, { recursive: true })
-    await writeFile(join(tempHome, '.clickvibe', 'config.yaml'), ['repos:', `  o/r: ${repo}`, ''].join('\n'))
+    await initFixtureRepository(repo)
+    await activateV02Home(tempHome, { 'o/r': repo })
     const item = {
       url: 'https://github.com/o/r/issues/60',
       title: 'baseline selection',
@@ -684,11 +685,8 @@ test('concurrent first-development authorizations freeze exactly one baseline an
   try {
     const repo = join(tempHome, 'repo')
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await mkdir(repo, { recursive: true })
-    await writeFile(
-      join(tempHome, '.clickvibe', 'config.yaml'),
-      ['repos:', `  o/r: ${repo}`, `worktreeRoot: ${join(tempHome, 'worktrees')}`, ''].join('\n'),
-    )
+    await initFixtureRepository(repo)
+    await activateV02Home(tempHome, { 'o/r': repo }, { worktreeRoot: join(tempHome, 'worktrees') })
     const item = {
       url: 'https://github.com/o/r/issues/601',
       title: 'baseline race',
@@ -958,11 +956,8 @@ test('missing baseline restoration requires and consumes an exact one-use author
     const secondHash = 'd'.repeat(40)
     const repo = join(home, 'repo')
     await mkdir(join(home, '.clickvibe'), { recursive: true })
-    await mkdir(repo, { recursive: true })
-    await writeFile(
-      join(home, '.clickvibe', 'config.yaml'),
-      ['repos:', `  o/r: ${repo}`, `worktreeRoot: ${join(home, 'worktrees')}`, ''].join('\n'),
-    )
+    await initFixtureRepository(repo)
+    await activateV02Home(home, { 'o/r': repo }, { worktreeRoot: join(home, 'worktrees') })
     const workflow = {
       key: 'o-r-60',
       url: 'https://github.com/o/r/issues/60',
@@ -1110,12 +1105,9 @@ test('/merge requires one-use authorization, exact reviewed HEAD, merge commit, 
     const repo = join(tempHome, 'repo')
     const worktreeRoot = join(tempHome, 'worktrees')
     const worktree = join(worktreeRoot, 'r-issue-23')
-    await mkdir(repo, { recursive: true })
+    await initFixtureRepository(repo)
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await writeFile(
-      join(tempHome, '.clickvibe', 'config.yaml'),
-      `repos:\n  o/r: ${repo}\nworktreeRoot: ${worktreeRoot}\n`,
-    )
+    await activateV02Home(tempHome, { 'o/r': repo }, { worktreeRoot: worktreeRoot })
     const workflow = interruptedWorkflow('o-r-23', 'https://github.com/o/r/issues/23', worktree)
     workflow.branch = 'r-issue-23'
     workflow.stage = 'passed'
@@ -1325,12 +1317,9 @@ test('/merge rejects a stale review hash before invoking the merge write', async
   try {
     const repo = join(tempHome, 'repo')
     const worktreeRoot = join(tempHome, 'worktrees')
-    await mkdir(repo, { recursive: true })
+    await initFixtureRepository(repo)
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await writeFile(
-      join(tempHome, '.clickvibe', 'config.yaml'),
-      `repos:\n  o/r: ${repo}\nworktreeRoot: ${worktreeRoot}\n`,
-    )
+    await activateV02Home(tempHome, { 'o/r': repo }, { worktreeRoot: worktreeRoot })
     const workflow = interruptedWorkflow('o-r-23', 'https://github.com/o/r/issues/23', join(worktreeRoot, 'r-issue-23'))
     workflow.branch = 'r-issue-23'
     workflow.stage = 'passed'
@@ -1455,12 +1444,9 @@ test('/merge gate rejection offers manual override that merges once and audits t
     const repo = join(tempHome, 'repo')
     const worktreeRoot = join(tempHome, 'worktrees')
     const worktree = join(worktreeRoot, 'r-issue-23')
-    await mkdir(repo, { recursive: true })
+    await initFixtureRepository(repo)
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await writeFile(
-      join(tempHome, '.clickvibe', 'config.yaml'),
-      `repos:\n  o/r: ${repo}\nworktreeRoot: ${worktreeRoot}\n`,
-    )
+    await activateV02Home(tempHome, { 'o/r': repo }, { worktreeRoot: worktreeRoot })
     const workflow = interruptedWorkflow('o-r-23', 'https://github.com/o/r/issues/23', worktree)
     workflow.branch = 'r-issue-23'
     workflow.stage = 'passed'
@@ -1643,12 +1629,9 @@ test('/merge manual override refuses gate failures not covered by the confirmati
   try {
     const repo = join(tempHome, 'repo')
     const worktreeRoot = join(tempHome, 'worktrees')
-    await mkdir(repo, { recursive: true })
+    await initFixtureRepository(repo)
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await writeFile(
-      join(tempHome, '.clickvibe', 'config.yaml'),
-      `repos:\n  o/r: ${repo}\nworktreeRoot: ${worktreeRoot}\n`,
-    )
+    await activateV02Home(tempHome, { 'o/r': repo }, { worktreeRoot: worktreeRoot })
     const workflow = interruptedWorkflow('o-r-23', 'https://github.com/o/r/issues/23', join(worktreeRoot, 'r-issue-23'))
     workflow.branch = 'r-issue-23'
     workflow.stage = 'passed'
@@ -1758,12 +1741,9 @@ test('cleanup failure keeps merged terminal state and retries without merging ag
     const repo = join(tempHome, 'repo')
     const worktreeRoot = join(tempHome, 'worktrees')
     const worktree = join(worktreeRoot, 'r-issue-23')
-    await mkdir(repo, { recursive: true })
+    await initFixtureRepository(repo)
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await writeFile(
-      join(tempHome, '.clickvibe', 'config.yaml'),
-      `repos:\n  o/r: ${repo}\nworktreeRoot: ${worktreeRoot}\n`,
-    )
+    await activateV02Home(tempHome, { 'o/r': repo }, { worktreeRoot: worktreeRoot })
     const workflow = interruptedWorkflow('o-r-23', 'https://github.com/o/r/issues/23', worktree)
     workflow.branch = 'r-issue-23'
     workflow.stage = 'passed'
@@ -1944,11 +1924,8 @@ test('/state and repo/issues share one repository fetch TTL while manual refresh
   try {
     const repo = join(tempHome, 'repo')
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await mkdir(repo, { recursive: true })
-    await writeFile(
-      join(tempHome, '.clickvibe', 'config.yaml'),
-      ['repos:', `  o/r: ${repo}`, 'fetchTtlSeconds: 45', ''].join('\n'),
-    )
+    await initFixtureRepository(repo)
+    await activateV02Home(tempHome, { 'o/r': repo }, { fetchTtlSeconds: 45 })
     let fetches = 0
     const handler = createHandler(async ({ command }) => {
       if (command === 'git fetch origin --prune') {
@@ -2007,8 +1984,8 @@ test('/state keeps local-ref state readable and marks freshness stale when fetch
   try {
     const repo = join(tempHome, 'repo')
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await mkdir(repo, { recursive: true })
-    await writeFile(join(tempHome, '.clickvibe', 'config.yaml'), ['repos:', `  o/r: ${repo}`, ''].join('\n'))
+    await initFixtureRepository(repo)
+    await activateV02Home(tempHome, { 'o/r': repo })
     const handler = createHandler(async ({ command }) => {
       assert.equal(command, 'git fetch origin --prune')
       return { exitCode: 1, stdout: { text: '' }, stderr: { text: 'offline' } }
@@ -2027,24 +2004,21 @@ test('/state keeps local-ref state readable and marks freshness stale when fetch
   }
 })
 
-test('/state schedules dependency refreshes for a remote-only configured repository', async () => {
+test('/state fails closed when a bound clone vanished instead of degrading to remote-only mode', async () => {
   const previousHome = process.env.HOME
   const tempHome = await mkdtemp(join(tmpdir(), 'clickvibe-remote-dependencies-'))
   process.env.HOME = tempHome
   try {
-    await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await writeFile(
-      join(tempHome, '.clickvibe', 'config.yaml'),
-      ['repos:', '  remote/only: /path/not/on/this/host', ''].join('\n'),
-    )
+    // v0.1 tolerated repos configured with paths missing on this host; the
+    // v0.2 strict pairing (ADR-0009, #134) has no remote-only mode, so a
+    // vanished clone fails the whole config load instead of guessing.
+    const remoteOnly = await initFixtureRepository(join(tempHome, 'remote-only'))
+    await activateV02Home(tempHome, { 'remote/only': remoteOnly }, { deleteAfterActivation: [remoteOnly] })
     const handler = createHandler()
 
-    const first = await post(handler, '/clickvibe/api/state', { repoKey: 'remote/only' })
-    const second = await post(handler, '/clickvibe/api/state', { repoKey: 'remote/only' })
-
-    assert.equal((first.body as { dependenciesRefreshDue?: boolean }).dependenciesRefreshDue, true)
-    assert.equal((second.body as { dependenciesRefreshDue?: boolean }).dependenciesRefreshDue, false)
-    assert.equal((first.body as { freshness?: unknown }).freshness, null)
+    const result = await post(handler, '/clickvibe/api/state', { repoKey: 'remote/only' })
+    assert.equal(result.status, 500)
+    assert.match(String((result.body as { error?: string }).error), /remote-only|No such file or directory/)
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
@@ -2059,8 +2033,8 @@ test('/state returns stale local facts within a bounded wait when git fetch hang
   try {
     const repo = join(tempHome, 'repo')
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await mkdir(repo, { recursive: true })
-    await writeFile(join(tempHome, '.clickvibe', 'config.yaml'), ['repos:', `  hanging/repo: ${repo}`, ''].join('\n'))
+    await initFixtureRepository(repo)
+    await activateV02Home(tempHome, { 'hanging/repo': repo })
     const handler = createHandler(async ({ command }) => {
       assert.equal(command, 'git fetch origin --prune')
       return new Promise(() => {})
@@ -2090,13 +2064,10 @@ test('a rejected dry-run worktree attempt preserves the previous durable dev his
     const worktreeRoot = join(tempHome, 'worktrees')
     const target = join(worktreeRoot, 'repo', 'repo-issue-905')
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await mkdir(repo, { recursive: true })
+    await initFixtureRepository(repo)
     await mkdir(target, { recursive: true })
     await writeFile(join(target, 'unregistered.txt'), 'must not be removed')
-    await writeFile(
-      join(tempHome, '.clickvibe', 'config.yaml'),
-      ['repos:', `  o/r: ${repo}`, `worktreeRoot: ${worktreeRoot}`, ''].join('\n'),
-    )
+    await activateV02Home(tempHome, { 'o/r': repo }, { worktreeRoot: worktreeRoot })
     await appendLog(issueKey('o/r', '905'), 'dev', 'previous completed task history')
 
     const issue = {
@@ -2150,11 +2121,8 @@ test('dryrun uses the default baseline, reports command output and closes succes
     const repo = join(tempHome, 'repo')
     const worktreeRoot = join(tempHome, 'worktrees')
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await mkdir(repo, { recursive: true })
-    await writeFile(
-      join(tempHome, '.clickvibe', 'config.yaml'),
-      ['repos:', `  o/r: ${repo}`, `worktreeRoot: ${worktreeRoot}`, ''].join('\n'),
-    )
+    await initFixtureRepository(repo)
+    await activateV02Home(tempHome, { 'o/r': repo }, { worktreeRoot: worktreeRoot })
     const runOne = async (number: number, failPwd: boolean) => {
       const issue = {
         url: `https://github.com/o/r/issues/${number}`,
@@ -2220,7 +2188,7 @@ test('dryrun uses the default baseline, reports command output and closes succes
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -2558,7 +2526,7 @@ test('invalid exact dev session falls back once to a fresh session on the same t
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -3536,12 +3504,8 @@ test('/develop automatic mode rejects a branch with commits when workflow histor
   try {
     const repo = join(tempHome, 'repo')
     const worktreeRoot = join(tempHome, 'worktrees')
-    await mkdir(repo, { recursive: true })
-    await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await writeFile(
-      join(tempHome, '.clickvibe', 'config.yaml'),
-      `repos:\n  history/repo: ${repo}\nworktreeRoot: ${worktreeRoot}\n`,
-    )
+    await initFixtureRepository(repo)
+    await activateV02Home(tempHome, { 'history/repo': repo }, { worktreeRoot })
     const url = 'https://github.com/history/repo/issues/910'
     const issue = {
       url,
@@ -4402,12 +4366,9 @@ test('develop with user context stays a first development and records the note i
   try {
     const repo = join(tempHome, 'repo')
     const worktreeRoot = join(tempHome, 'worktrees')
-    await mkdir(repo, { recursive: true })
+    await initFixtureRepository(repo)
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await writeFile(
-      join(tempHome, '.clickvibe', 'config.yaml'),
-      ['repos:', `  o/r: ${repo}`, `worktreeRoot: ${worktreeRoot}`, ''].join('\n'),
-    )
+    await activateV02Home(tempHome, { 'o/r': repo }, { worktreeRoot: worktreeRoot })
     const url = 'https://github.com/o/r/issues/54'
     const item = {
       url,

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -1988,7 +1988,13 @@ test('/state keeps local-ref state readable and marks freshness stale when fetch
     await activateV02Home(tempHome, { 'o/r': repo })
     const handler = createHandler(async ({ command }) => {
       if (command.startsWith('set +e')) {
-        return { exitCode: 1, stdout: { text: '' }, stderr: { text: 'offline sample' } }
+        return {
+          exitCode: 0,
+          stdout: {
+            text: 'REPO_DEFAULT\t128\t\nREPO_BRANCH\t0\tbWFpbg==\nREPO_HEAD\t128\t\nREPO_MAIN_COUNT\t128\t\nREPO_HEAD_COUNT\t128\t\n',
+          },
+          stderr: { text: '' },
+        }
       }
       assert.equal(command, 'git fetch origin --prune')
       return { exitCode: 1, stdout: { text: '' }, stderr: { text: 'offline' } }
@@ -2040,7 +2046,13 @@ test('/state returns stale local facts within a bounded wait when git fetch hang
     await activateV02Home(tempHome, { 'hanging/repo': repo })
     const handler = createHandler(async ({ command }) => {
       if (command.startsWith('set +e')) {
-        return { exitCode: 1, stdout: { text: '' }, stderr: { text: 'offline sample' } }
+        return {
+          exitCode: 0,
+          stdout: {
+            text: 'REPO_DEFAULT\t128\t\nREPO_BRANCH\t0\tbWFpbg==\nREPO_HEAD\t128\t\nREPO_MAIN_COUNT\t128\t\nREPO_HEAD_COUNT\t128\t\n',
+          },
+          stderr: { text: '' },
+        }
       }
       assert.equal(command, 'git fetch origin --prune')
       return new Promise(() => {})

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -1987,6 +1987,9 @@ test('/state keeps local-ref state readable and marks freshness stale when fetch
     await initFixtureRepository(repo)
     await activateV02Home(tempHome, { 'o/r': repo })
     const handler = createHandler(async ({ command }) => {
+      if (command.startsWith('set +e')) {
+        return { exitCode: 1, stdout: { text: '' }, stderr: { text: 'offline sample' } }
+      }
       assert.equal(command, 'git fetch origin --prune')
       return { exitCode: 1, stdout: { text: '' }, stderr: { text: 'offline' } }
     })
@@ -2036,6 +2039,9 @@ test('/state returns stale local facts within a bounded wait when git fetch hang
     await initFixtureRepository(repo)
     await activateV02Home(tempHome, { 'hanging/repo': repo })
     const handler = createHandler(async ({ command }) => {
+      if (command.startsWith('set +e')) {
+        return { exitCode: 1, stdout: { text: '' }, stderr: { text: 'offline sample' } }
+      }
       assert.equal(command, 'git fetch origin --prune')
       return new Promise(() => {})
     })

--- a/tests/sync-conflict.test.ts
+++ b/tests/sync-conflict.test.ts
@@ -211,7 +211,7 @@ test('sync pushes the clean merge commit to the existing PR branch (issue #45)',
       assert.equal(result.head, localShortHead)
     })
   } finally {
-    await rm(root, { recursive: true, force: true })
+    await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -233,7 +233,7 @@ test('sync merges and records the frozen custom baseline', async () => {
       assert.match(saved?.events.at(-1)?.note ?? '', /origin\/release\/2\.0/)
     })
   } finally {
-    await rm(root, { recursive: true, force: true })
+    await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -254,7 +254,7 @@ test('sync does not merge or push when the worktree has unrelated local changes 
       assert.match((await wt('status', '--short')).stdout, /local-notes\.md/)
     })
   } finally {
-    await rm(root, { recursive: true, force: true })
+    await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -308,7 +308,7 @@ test('sync keeps the conflicted merge scene and rework stays reachable (issue #2
       assert.equal(derived.nextAction.kind, 'rework')
     })
   } finally {
-    await rm(root, { recursive: true, force: true })
+    await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -343,7 +343,7 @@ test('an interrupted rework on a conflicted worktree resumes instead of re-synci
       assert.match(preface, /未完成的合并/)
     })
   } finally {
-    await rm(root, { recursive: true, force: true })
+    await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -465,7 +465,7 @@ test('review issues reach the agent across stale-session fallback on an interrup
       assert.equal(occurrences, 1)
     })
   } finally {
-    await rm(root, { recursive: true, force: true })
+    await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -493,7 +493,7 @@ test('merge preface guides the resume/rework agent through conflict then stalene
     const stale = await buildMergePreface(ctx, worktree, 'main')
     assert.match(stale, /落后 origin\/main/)
   } finally {
-    await rm(root, { recursive: true, force: true })
+    await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 

--- a/tests/task-diagnostics.test.ts
+++ b/tests/task-diagnostics.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
+import { activateV02Home, initFixtureRepository } from './helpers/v02-home.ts'
 import { issueKey } from '../src/infra/state-layout.ts'
 import { logTaskDiagnostic } from '../src/infra/task-diagnostics.ts'
 
@@ -61,7 +62,8 @@ test('an oversized diagnostic remains complete when the next record rotates it',
   console.warn = (message?: unknown) => warnings.push(String(message))
   try {
     await mkdir(join(tempHome, '.clickvibe'), { recursive: true })
-    await writeFile(join(tempHome, '.clickvibe', 'config.yaml'), 'diagnosticsMaxBytes: 200\n', 'utf8')
+    const diagRepo = await initFixtureRepository(join(tempHome, 'diag-repo'))
+    await activateV02Home(tempHome, { 'o/r': diagRepo }, { diagnosticsMaxBytes: 200 })
     logTaskDiagnostic('global-oversized', { workflowKey: issueKey('foo', '7'), evidence: 'a'.repeat(1_000) })
     logTaskDiagnostic('global-next', { evidence: 'next' })
 

--- a/tests/task-diagnostics.test.ts
+++ b/tests/task-diagnostics.test.ts
@@ -49,7 +49,7 @@ test('task diagnostics persist the exact console JSON under the owning issue', a
     console.warn = originalWarn
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -79,7 +79,7 @@ test('an oversized diagnostic remains complete when the next record rotates it',
     console.warn = originalWarn
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -97,6 +97,6 @@ test('diagnostic persistence failure never escapes logTaskDiagnostic', async () 
     console.warn = originalWarn
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(tempHome, { recursive: true, force: true })
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })

--- a/tests/upgrade-runner.test.ts
+++ b/tests/upgrade-runner.test.ts
@@ -23,6 +23,18 @@ function run(args) {
   return spawnSync(process.execPath, [RUNNER, ...args], { encoding: 'utf8', cwd: process.cwd() })
 }
 
+/** A parallel suite may run the fence suite's decoy `clickvibe-v0.1-plugin`
+ *  process, which preview legitimately reports as a live old plugin; retry
+ *  until that short-lived decoy is gone. */
+function runPreview(args) {
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const result = run(args)
+    if (result.status === 0 || !/blocked \[host\]/.test(result.stderr ?? '')) return result
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 800)
+  }
+  return run(args)
+}
+
 function planJsonFrom(output) {
   const begin = output.indexOf('PLAN-JSON-BEGIN\n')
   const end = output.indexOf('PLAN-JSON-END')
@@ -69,7 +81,7 @@ test('preview prints the plan and fingerprint and writes nothing', async (t) => 
   t.after(() => rm(item.home, { recursive: true, force: true }))
   const before = await clickvibeEntries(item.root)
 
-  const result = run(['preview', '--home', item.home])
+  const result = runPreview(['preview', '--home', item.home])
   assert.equal(result.status, 0, `stderr:\n${result.stderr}`)
   const fingerprint = fingerprintFrom(result.stdout)
   const plan = planJsonFrom(result.stdout)
@@ -83,7 +95,7 @@ test('preview prints the plan and fingerprint and writes nothing', async (t) => 
 test('apply with a mismatched fingerprint echo is rejected before any write', async (t) => {
   const item = await fixture('wrong-echo')
   t.after(() => rm(item.home, { recursive: true, force: true }))
-  const preview = run(['preview', '--home', item.home])
+  const preview = runPreview(['preview', '--home', item.home])
   assert.equal(preview.status, 0, preview.stderr)
   const planFile = join(item.home, 'plan.json')
   await writeFile(planFile, JSON.stringify(planJsonFrom(preview.stdout)))
@@ -101,7 +113,7 @@ test('apply with a mismatched fingerprint echo is rejected before any write', as
 test('apply with the echoed fingerprint records authorization and reaches verified', async (t) => {
   const item = await fixture('verified')
   t.after(() => rm(item.home, { recursive: true, force: true }))
-  const preview = run(['preview', '--home', item.home])
+  const preview = runPreview(['preview', '--home', item.home])
   assert.equal(preview.status, 0, preview.stderr)
   const fingerprint = fingerprintFrom(preview.stdout)
   const planFile = join(item.home, 'plan.json')
@@ -133,7 +145,7 @@ test('apply with the echoed fingerprint records authorization and reaches verifi
 test('a facts-changed apply still records the attempted authorization and writes no journal', async (t) => {
   const item = await fixture('facts-changed')
   t.after(() => rm(item.home, { recursive: true, force: true }))
-  const preview = run(['preview', '--home', item.home])
+  const preview = runPreview(['preview', '--home', item.home])
   assert.equal(preview.status, 0, preview.stderr)
   const fingerprint = fingerprintFrom(preview.stdout)
   const planFile = join(item.home, 'plan.json')
@@ -152,7 +164,7 @@ test('a facts-changed apply still records the attempted authorization and writes
 test('recovery without an unfinished journal refuses and points back to preview', async (t) => {
   const item = await fixture('recovery')
   t.after(() => rm(item.home, { recursive: true, force: true }))
-  const preview = run(['preview', '--home', item.home])
+  const preview = runPreview(['preview', '--home', item.home])
   assert.equal(preview.status, 0, preview.stderr)
   const planFile = join(item.home, 'plan.json')
   await writeFile(planFile, JSON.stringify(planJsonFrom(preview.stdout)))

--- a/tests/v02-final-acceptance.test.ts
+++ b/tests/v02-final-acceptance.test.ts
@@ -84,10 +84,29 @@ async function buildRepositoryWithWorkItems(root: string, numbers: number[]): Pr
   await execFileAsync('git', ['-C', repo, 'remote', 'set-head', 'origin', '--auto'])
   for (const number of numbers) {
     const worktree = join(root, `wt-${number}`)
-    await execFileAsync('git', ['-C', repo, 'worktree', 'add', '-b', `clickvibe-issue-${number}`, worktree, 'origin/main'])
+    await execFileAsync('git', [
+      '-C',
+      repo,
+      'worktree',
+      'add',
+      '-b',
+      `clickvibe-issue-${number}`,
+      worktree,
+      'origin/main',
+    ])
     writeFileSync(join(worktree, `n-${number}.txt`), `${number}\n`)
     await execFileAsync('git', ['-C', worktree, 'add', '.'])
-    await execFileAsync('git', ['-C', worktree, '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-m', `wip ${number}`])
+    await execFileAsync('git', [
+      '-C',
+      worktree,
+      '-c',
+      'user.email=t@t',
+      '-c',
+      'user.name=t',
+      'commit',
+      '-m',
+      `wip ${number}`,
+    ])
   }
   return repo
 }

--- a/tests/v02-final-acceptance.test.ts
+++ b/tests/v02-final-acceptance.test.ts
@@ -1,0 +1,202 @@
+/**
+ * v0.2 final acceptance harness (ADR-0013 §2, issue #137 AC6/AC7/AC8).
+ *
+ * Runs the #133 frozen multi-Work-Item scenario and asserts the frozen count
+ * thresholds across all three access planes. Structural constraint: the ONLY
+ * metric sources are the three existing derivations — the Local Git snapshot
+ * registry counters, `deriveGatewayMetrics`, and `deriveRemoteGitMetrics`.
+ * No fourth counting system exists in this file; the intercepted shell command
+ * list is retained solely as failure evidence and never feeds an assertion.
+ *
+ * Threshold provenance: docs/baselines/v0.2-access-baseline.md, frozen rows
+ * "Multi Work Item refresh" and "Panel enrichment always on". Counts are
+ * authoritative; latency stays with the frozen reproducer (hash-guarded).
+ */
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { promisify } from 'node:util'
+import test from 'node:test'
+import type { Context } from '@deepseek-ai/cordis'
+import { githubGatewayOwner, resetGithubGatewayOwnerForTests } from '../src/github/gateway-owner.ts'
+import { deriveGatewayMetrics } from '../src/github/gateway-lifecycle.ts'
+import { deriveRemoteGitMetrics } from '../src/infra/remote-git-lifecycle.ts'
+import { remoteGitCoordinator } from '../src/infra/remote-git.ts'
+import { LocalGitSnapshotRegistry } from '../src/infra/local-git-snapshot.ts'
+import { enrichWorkflowStates } from '../src/workflow/repository-state.ts'
+
+const execFileAsync = promisify(execFile)
+
+function evidence(commands: { command: string; exitCode: number }[]): string {
+  return commands.map((item) => `[exit ${item.exitCode}] ${item.command}`).join('\n')
+}
+
+function realOfflineGithubContext() {
+  const commands: { command: string; exitCode: number }[] = []
+  const ctx = {
+    shell: {
+      resolve(spec: unknown) {
+        return spec
+      },
+      async run(spec: { command: string; workdir?: string }) {
+        // gh is intercepted offline exactly as in the #122 frozen scenarios;
+        // the gateway still records every attempted upstream.
+        if (/^gh\b|\sgh\b/.test(spec.command)) {
+          commands.push({ command: spec.command, exitCode: 1 })
+          return { exitCode: 1, stdout: { text: '' }, stderr: { text: 'offline final-acceptance' } }
+        }
+        try {
+          const out = await execFileAsync('/bin/sh', ['-c', spec.command], {
+            cwd: spec.workdir,
+            encoding: 'utf8',
+            maxBuffer: 1024 * 1024,
+          })
+          commands.push({ command: spec.command, exitCode: 0 })
+          return { exitCode: 0, stdout: { text: out.stdout }, stderr: { text: out.stderr } }
+        } catch (error) {
+          const detail = error as { code?: number; stdout?: string; stderr?: string }
+          commands.push({ command: spec.command, exitCode: detail.code ?? 1 })
+          return {
+            exitCode: detail.code ?? 1,
+            stdout: { text: detail.stdout ?? '' },
+            stderr: { text: detail.stderr ?? '' },
+          }
+        }
+      },
+    },
+  } as unknown as Context
+  return { ctx, commands }
+}
+
+async function buildRepositoryWithWorkItems(root: string, numbers: number[]): Promise<string> {
+  const remote = join(root, 'remote.git')
+  const repo = join(root, 'repo')
+  await execFileAsync('git', ['init', '--bare', '--initial-branch=main', remote])
+  await execFileAsync('git', ['init', '--initial-branch=main', repo])
+  await execFileAsync('git', ['-C', repo, 'remote', 'add', 'origin', remote])
+  writeFileSync(join(repo, 'a.txt'), 'base\n')
+  await execFileAsync('git', ['-C', repo, 'add', 'a.txt'])
+  await execFileAsync('git', ['-C', repo, '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-m', 'base'])
+  await execFileAsync('git', ['-C', repo, 'push', 'origin', 'main'])
+  await execFileAsync('git', ['-C', repo, 'remote', 'set-head', 'origin', '--auto'])
+  for (const number of numbers) {
+    const worktree = join(root, `wt-${number}`)
+    await execFileAsync('git', ['-C', repo, 'worktree', 'add', '-b', `clickvibe-issue-${number}`, worktree, 'origin/main'])
+    writeFileSync(join(worktree, `n-${number}.txt`), `${number}\n`)
+    await execFileAsync('git', ['-C', worktree, 'add', '.'])
+    await execFileAsync('git', ['-C', worktree, '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-m', `wip ${number}`])
+  }
+  return repo
+}
+
+function workItem(number: number, worktree: string) {
+  return {
+    key: `ai-daming/clickvibe#${number}`,
+    url: `https://github.com/ai-daming/clickvibe/issues/${number}`,
+    repoKey: 'ai-daming/clickvibe',
+    worktree,
+    branch: `clickvibe-issue-${number}`,
+    stage: 'developing' as const,
+    devAgent: 'codex' as const,
+    devTaskId: null,
+    devSessionId: null,
+    devSessionAgent: null,
+    devInterrupted: false,
+    reviewAgent: null,
+    reviewTaskId: null,
+    reviewSessionId: null,
+    reviewSessionAgent: null,
+    reviewResult: null,
+    prNumber: null,
+    issueState: 'OPEN' as const,
+    baseRef: 'main',
+    updatedAt: 0,
+    events: [],
+  }
+}
+
+test('frozen multi-work-item thresholds hold across all three access planes', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'clickvibe-final-multi-'))
+  resetGithubGatewayOwnerForTests()
+  remoteGitCoordinator().clearFreshness()
+  try {
+    const numbers = [133, 134, 135, 136, 137]
+    const repo = await buildRepositoryWithWorkItems(root, numbers)
+    for (const number of numbers) assert.ok(existsSync(join(root, `wt-${number}`)))
+    const { ctx, commands } = realOfflineGithubContext()
+    const snapshots = new LocalGitSnapshotRegistry()
+    const config = { repos: { 'ai-daming/clickvibe': repo }, worktreeRoot: root }
+    const items = numbers.map((number) => workItem(number, join(root, `wt-${number}`)))
+
+    const coldStarted = performance.now()
+    await enrichWorkflowStates(ctx, structuredClone(items), config, snapshots)
+    const coldElapsed = performance.now() - coldStarted
+    const localCold = { ...snapshots.counters }
+    const gatewayCold = deriveGatewayMetrics(githubGatewayOwner().lifecycleEvents())
+    const remoteCold = deriveRemoteGitMetrics(remoteGitCoordinator().lifecycleEvents())
+
+    const hotStarted = performance.now()
+    await enrichWorkflowStates(ctx, structuredClone(items), config, snapshots)
+    const hotElapsed = performance.now() - hotStarted
+    const localHot = { ...snapshots.counters }
+    const gatewayHot = deriveGatewayMetrics(githubGatewayOwner().lifecycleEvents())
+    const remoteHot = deriveRemoteGitMetrics(remoteGitCoordinator().lifecycleEvents())
+
+    const planes = `\nlocal-cold=${JSON.stringify(localCold)}\nlocal-hot=${JSON.stringify(localHot)}\ngateway-cold=${JSON.stringify(gatewayCold)}\ngateway-hot=${JSON.stringify(gatewayHot)}\nremote-cold=${JSON.stringify(remoteCold)}\nremote-hot=${JSON.stringify(remoteHot)}\ncommands:\n${evidence(commands)}`
+
+    // Local Git plane (frozen row: five same-repo items cold ≤5; hot =0).
+    assert.ok(
+      localCold.executions <= 5,
+      `cold local-git executions must be ≤5 (frozen multi threshold); saw ${localCold.executions}.${planes}`,
+    )
+    assert.equal(
+      localHot.executions - localCold.executions,
+      0,
+      `immediate hot round must add zero local-git executions (frozen multi threshold).${planes}`,
+    )
+    assert.equal(
+      localHot.logicalRequests,
+      localHot.cacheHits + localHot.singleflightJoins + localHot.executions + localHot.failures,
+      `local-git identity logical = hit + join + execution + failure must hold.${planes}`,
+    )
+
+    // GitHub REST plane (frozen row: ≤2 aggregate upstream pages; hot =0).
+    assert.ok(
+      gatewayCold.executions <= 2,
+      `cold github upstream executions must be ≤2 for the one-page repo (frozen multi threshold); saw ${gatewayCold.executions}.${planes}`,
+    )
+    assert.equal(
+      gatewayHot.executions - gatewayCold.executions,
+      0,
+      `immediate hot round must add zero github upstream executions (frozen multi threshold).${planes}`,
+    )
+
+    // Remote Git plane (frozen multi row counts Local Git and GitHub only;
+    // the enrichment path must not start remote fetches in either round).
+    assert.equal(
+      remoteCold.upstreamRequests,
+      0,
+      `multi-work-item enrichment must not issue remote-git upstream requests cold.${planes}`,
+    )
+    assert.equal(
+      remoteHot.upstreamRequests - remoteCold.upstreamRequests,
+      0,
+      `multi-work-item enrichment must not issue remote-git upstream requests hot.${planes}`,
+    )
+
+    // Latency stays descriptive (frozen reproducer owns the budgets);
+    // hang-guards only, identical to the #122 scenario harness.
+    assert.ok(coldElapsed <= 60_000, `cold round hang-guard 60s, saw ${coldElapsed}ms.${planes}`)
+    assert.ok(hotElapsed <= 30_000, `hot round hang-guard 30s, saw ${hotElapsed}ms.${planes}`)
+  } finally {
+    await githubGatewayOwner()
+      .close({ drainMs: 0 })
+      .catch(() => undefined)
+    resetGithubGatewayOwnerForTests()
+    remoteGitCoordinator().clearFreshness()
+    rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/tests/v02-generation-fence.test.ts
+++ b/tests/v02-generation-fence.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
 import {
-  assertLegacyStateWriteAllowed,
+  assertActiveStateWriteAllowed,
   assertLegacyTaskStartAllowed,
   createOfflineV02GenerationFence,
   createOnlineV02GenerationFence,
@@ -57,13 +57,13 @@ test('legacy state writers fail closed for active v0.2 state and unfinished or c
   const state = join(root, 'state')
   try {
     await mkdir(state, { recursive: true })
-    assert.doesNotThrow(() => assertLegacyStateWriteAllowed(state))
+    assert.doesNotThrow(() => assertActiveStateWriteAllowed(state))
     await writeFile(join(root, 'upgrade-v0.2.json'), '{broken')
-    assert.throws(() => assertLegacyStateWriteAllowed(state), /recovery journal/)
+    assert.throws(() => assertActiveStateWriteAllowed(state), /recovery journal/)
     await writeFile(join(root, 'upgrade-v0.2.json'), JSON.stringify({ schemaVersion: 1, phase: 'rolled_back' }))
-    assert.doesNotThrow(() => assertLegacyStateWriteAllowed(state))
+    assert.doesNotThrow(() => assertActiveStateWriteAllowed(state))
     await writeFile(join(state, '.clickvibe-state.json'), JSON.stringify({ schemaVersion: 1, generation: 'v0.2' }))
-    assert.throws(() => assertLegacyStateWriteAllowed(state), /v0\.2 state/)
+    assert.throws(() => assertActiveStateWriteAllowed(state), /v0\.2 marker without a completed upgrade/)
   } finally {
     await rm(home, { recursive: true, force: true })
   }

--- a/tests/worktree-branches.test.ts
+++ b/tests/worktree-branches.test.ts
@@ -129,7 +129,7 @@ async function runScenario(number: string, scenario: Scenario = {}) {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await chmod(join(home, '.clickvibe', 'state'), 0o700).catch(() => undefined)
-    await rm(root, { recursive: true, force: true })
+    await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 }
 
@@ -152,7 +152,7 @@ test('worktree preparation fails clearly for missing config, repository, default
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(home, { recursive: true, force: true })
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
   const noDefault = await runScenario('3', { symbolicRef: null, mainExists: false })
   assert.equal(noDefault.result.ok, false)

--- a/tests/worktree-branches.test.ts
+++ b/tests/worktree-branches.test.ts
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
+import { activateV02Home, initFixtureRepository } from './helpers/v02-home.ts'
 import { ensureWorktree } from '../src/agent/worktree.ts'
 import { issueKey, loadWorkflow, type IssueWorkflow } from '../src/infra/state.ts'
 import { commitWorkflowFixture } from './workflow-fixture.ts'
@@ -34,12 +35,9 @@ async function runScenario(number: string, scenario: Scenario = {}) {
   const previousHome = process.env.HOME
   process.env.HOME = home
   await mkdir(join(home, '.clickvibe'), { recursive: true })
-  await mkdir(repo, { recursive: true })
-  await writeFile(
-    join(home, '.clickvibe', 'config.yaml'),
-    ['repos:', `  o/r: ${repo}`, `worktreeRoot: ${worktreeRoot}`, ''].join('\n'),
-  )
-  if (scenario.persistFailure) await writeFile(join(home, '.clickvibe', 'state'), 'blocks workflow persistence')
+  await initFixtureRepository(repo)
+  await activateV02Home(home, { 'o/r': repo }, { worktreeRoot: worktreeRoot })
+  if (scenario.persistFailure) await chmod(join(home, '.clickvibe', 'state'), 0o500)
   if (scenario.path === 'empty' || scenario.path === 'nonempty') await mkdir(target, { recursive: true })
   if (scenario.path === 'nonempty') await writeFile(join(target, 'owned.txt'), 'keep')
   if (scenario.frozenBase) {
@@ -130,6 +128,7 @@ async function runScenario(number: string, scenario: Scenario = {}) {
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
+    await chmod(join(home, '.clickvibe', 'state'), 0o700).catch(() => undefined)
     await rm(root, { recursive: true, force: true })
   }
 }
@@ -140,15 +139,16 @@ test('worktree preparation fails clearly for missing config, repository, default
   process.env.HOME = home
   try {
     await mkdir(join(home, '.clickvibe'), { recursive: true })
-    await writeFile(join(home, '.clickvibe', 'config.yaml'), 'repos: {}\n')
     const noRepo = await ensureWorktree({} as never, { owner: 'o', repo: 'r', number: '1' })
     assert.equal(noRepo.ok, false)
     if (!noRepo.ok) assert.match(noRepo.error, /未配置仓库/)
 
-    await writeFile(join(home, '.clickvibe', 'config.yaml'), 'repos:\n  o/r: /definitely/missing/clickvibe\n')
+    // A vanished clone fails the strict v0.2 config pairing (no remote-only mode).
+    const vanished = await initFixtureRepository(join(home, 'vanished'))
+    await activateV02Home(home, { 'o/r': vanished }, { deleteAfterActivation: [vanished] })
     const missingPath = await ensureWorktree({} as never, { owner: 'o', repo: 'r', number: '2' })
     assert.equal(missingPath.ok, false)
-    if (!missingPath.ok) assert.match(missingPath.error, /仓库路径不存在/)
+    if (!missingPath.ok) assert.match(missingPath.error, /No such file or directory|vanished/)
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome

--- a/tests/worktree-integration.test.ts
+++ b/tests/worktree-integration.test.ts
@@ -1,10 +1,11 @@
 import assert from 'node:assert/strict'
 import { exec, execFile } from 'node:child_process'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
 import test from 'node:test'
+import { activateV02Home, initFixtureRepository } from './helpers/v02-home.ts'
 import { buildWorktreeAddCommand } from '../src/agent/develop.ts'
 import { ensureWorktree } from '../src/agent/worktree.ts'
 
@@ -95,10 +96,7 @@ test('first development creates from a selected remote branch and freezes it', a
     await git('commit', '--allow-empty', '-m', 'release base')
     await git('push', '-u', 'origin', 'release/2.0')
     await git('switch', 'main')
-    await writeFile(
-      join(home, '.clickvibe', 'config.yaml'),
-      ['repos:', `  o/r: ${repo}`, `worktreeRoot: ${worktreeRoot}`, ''].join('\n'),
-    )
+    await activateV02Home(home, { 'o/r': repo }, { worktreeRoot: worktreeRoot })
 
     const created = await ensureWorktree(
       realShellCtx() as never,
@@ -159,11 +157,8 @@ test('a baseline persistence failure rolls back a newly created worktree and bra
     await git('branch', '-M', 'main')
     await git('push', '-u', 'origin', 'main')
     await execFileAsync('git', [`--git-dir=${remote}`, 'symbolic-ref', 'HEAD', 'refs/heads/main'])
-    await writeFile(
-      join(home, '.clickvibe', 'config.yaml'),
-      ['repos:', `  o/r: ${repo}`, `worktreeRoot: ${worktreeRoot}`, ''].join('\n'),
-    )
-    await writeFile(join(home, '.clickvibe', 'state'), 'blocks workflow persistence')
+    await activateV02Home(home, { 'o/r': repo }, { worktreeRoot: worktreeRoot })
+    await chmod(join(home, '.clickvibe', 'state'), 0o500)
 
     const result = await ensureWorktree(realShellCtx() as never, { owner: 'o', repo: 'r', number: '63' })
     assert.equal(result.ok, false)
@@ -173,6 +168,7 @@ test('a baseline persistence failure rolls back a newly created worktree and bra
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
+    await chmod(join(home, '.clickvibe', 'state'), 0o700).catch(() => undefined)
     await rm(root, { recursive: true, force: true })
   }
 })

--- a/tests/worktree-integration.test.ts
+++ b/tests/worktree-integration.test.ts
@@ -69,7 +69,7 @@ test('real git worktree creation uses origin/main instead of the source reposito
     assert.notEqual(issue, side)
     assert.equal(branch, 'issue-1')
   } finally {
-    await rm(root, { recursive: true, force: true })
+    await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -133,7 +133,7 @@ test('first development creates from a selected remote branch and freezes it', a
   } finally {
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
-    await rm(root, { recursive: true, force: true })
+    await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })
 
@@ -169,6 +169,6 @@ test('a baseline persistence failure rolls back a newly created worktree and bra
     if (previousHome === undefined) delete process.env.HOME
     else process.env.HOME = previousHome
     await chmod(join(home, '.clickvibe', 'state'), 0o700).catch(() => undefined)
-    await rm(root, { recursive: true, force: true })
+    await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   }
 })


### PR DESCRIPTION
## 目的

#137 AC3 收口 / ADR-0013 §6(a) 第二刀（A2b）：删除 `loadConfigFromHome` 的 v0.1 config 读取分支，v0.1 config → fail-closed 并指向升级入口。本 PR 同时修复终局验收逼出的一个 #134 线生产级缺陷（见下）。

## 关键修复：切换后运行时不可写的 fence 缺陷

`assertLegacyStateWriteAllowed`（#134）在 journal `verified` 后仍封锁**所有**现行状态写入（workflow.json / task log / action log）——真实切换后的 v0.2 runtime 完全不可写。重命名为 `assertActiveStateWriteAllowed` 并按协议 §1 语义重写：**verified journal + v0.2 marker = 当前代次拥有根，现行写入者放行**；进行中升级、部分/torn journal、journal/marker 漂移维持 fail-closed。新测试 `tests/post-cutover-write-authority.test.ts`（4 场景：verified+marker 放行 / 五种部分态封锁 / 双向漂移封锁 / rolled-back 与干净根放行）。

## 变更（TDD：no-legacy-config 2 条先红后绿）

- `runtime.ts`：无 `schemaVersion` 的 config → 抛错并指向 `scripts/upgrade-v0.2.mjs preview`；ENOENT 新装默认保留。
- `ensureWorktree` 对 loadConfig 失败 fail-closed 返回（ vanished clone 语义）；`index.ts` 路由边界统一 catch → 500 + 原始错误保留（错误不埋葬）。
- 测试 fixture 全面转换为**真实升级机**产出的 v0.2 配对：新增 `tests/helpers/v02-home.ts`（initFixtureRepository + activateV02Home，跑真实 preview/apply，facts-changed 一次重试吸收并行套件的滞后诊断写入；无 journal/marker 字节伪造）。转换 routes/command/worktree-branches/worktree-integration/merge-edge/baseline-restore(-shared)/review-start/develop-baseline-preview/repository-sync-routes/command-stop-recovery/task-diagnostics/github-operations。
- 语义随架构更新的测试：remote-only 容忍 → vanished clone fail-closed；`repos: {}` 种子 → ENOENT 默认；state-文件 sabotage → chmod 只读 sabotage。
- CI 移除 v0.1 config seed 步骤（project-list 契约测试自带激活 home）；#163 守卫中 `project-config.ts` 临时条目随之删除。

## 概念预算

新增 1：`tests/helpers/v02-home.ts`（测试设施，消费者为全部需要 active config 的测试）；删 1：`assertLegacyStateWriteAllowed` 旧语义。运行时零新概念。

## 验证

typecheck / build / lint（0 error）/ format / check 全链（size 10 例外、五门禁全绿）/ test **840/840**（+21：no-legacy-config 2、post-cutover-write-authority 4、upgrade-runner 5、provider-neutral 7、legacy-reader-removal 3 净计入前序 PR）。

## 处置表对应

A 类 A1 行（runtime v0.1 分支）完成；至此 A/B 类「废弃」行全部落地。
