### PR TITLE
docs: v0.3 design baseline — autonomous delivery control & causal chain (#168 S0)

### DIFF
--- a/docs/architecture/decisions/0014-autonomous-delivery-control-and-trust.md
+++ b/docs/architecture/decisions/0014-autonomous-delivery-control-and-trust.md
@@ -1,0 +1,141 @@
+# ADR-0014：自主交付控制与信任模型——一条流水线、两种授权来源与确定性停机
+
+> Status: Accepted | Date: 2026-09-04 | Issue: #168（v0.3.0） | 落实: [ADR-0004](0004-policy-controlled-autonomous-delivery.md)、[ADR-0008](0008-deterministic-loop-guard-and-optional-runtime-observer.md) | 地基: [ADR-0012](0012-work-item-contract-canonicalization-and-evidence.md) 契约指纹 | Related: [ADR-0015](0015-event-envelope-causal-chain.md)
+
+## Context
+
+v0.2 终局后单 Work Item 仍需逐步人工授权；`/auto` 循环已存在且动作全部与手动共用后端 handler，但授权、策略、停机三件事是隐式的：`AutoRunConfig` 散落在启动载荷里、机器没有可持有的权限凭证、空转/振荡靠循环内参数兜底。本 ADR 把既有事实显式化为四个命名概念并补齐缺口，使「交付一个 Issue 后可以离开」成为可验证行为。
+
+## Decision
+
+### 0. 宪法条款：一条流水线、两种授权来源
+
+动作层（`startDevelop` / `createPullRequest` / `startReview` / `resumeDevelop` / `syncWorktree` / `mergeAndCleanup`）不接受「自动专用路径」。每个动作入口只接受两种凭证之一：
+
+- **人工一次性授权**（现有机制，原样保留）：人点按钮/命令，一次性、短时效；
+- **CapabilityLease**（本 ADR 新增）：机器持有的限时凭证。
+
+两者过**同一套门禁**（review 绑定、基线等价、CI、契约指纹、合并门禁），产生**同一格式的证据**（见 ADR-0015，每条记录授权来源）。禁止出现第二条「自动专用流水线」；发现即返工。
+
+### 1. 最小 Policy（v1）
+
+`DeliveryPolicy` 是版本化工件而非散落参数：
+
+```
+{ schemaVersion: 1, policyId, policyFingerprint,
+  autoMerge, devAgent, reviewAgent, maxRounds, budgetHours,
+  createdAt, authorizedBy: 'human-grant:<id>' }
+```
+
+- v1 存储位置：随启动授权快照进 workflow 记录（现状位置，命名为工件并加指纹）；项目级默认与完整版本化治理属 v0.7。
+- 默认手动：`autoMerge=false` 且不启动 lease 即纯手动（`decideAutoRun` 缺省 `manual` 的现状语义不变）。
+- 消费者：lease 校验（动作白名单由 policy 推导）、Loop Guard（轮次/预算）、面板展示。
+- `policyFingerprint` 进入 DeliveryBasis；policy 变更 = 基变更 = lease 作废。
+
+### 2. DeliveryBasis（命名凭证）
+
+收口既有三要素为一个显式凭证并定义失效规则：
+
+```
+{ basisFingerprint,
+  contractFingerprint (wic1_…, ADR-0012),
+  policyFingerprint,
+  frozenBaseline (baseRef @ sha),
+  reviewBinding?: { reviewedSha, reviewFingerprint } }
+```
+
+失效规则（任一命中 → lease 作废，自动推进停止）：
+
+| 变化 | 后果 |
+|---|---|
+| 契约指纹变化 | **永远要求新的人工授权**——绝不自动续跑（`startAutoRun` 现有的启动期校验推广到每次 lease 消耗前） |
+| policy / 基线变化 | lease 作废，进入 `human-required`，可由人基于新基快速重开 |
+| review 绑定失效 | 按既有 review 失效规则，禁止带旧结论合并（现状不变，纳入凭证） |
+
+校验点：每次 reconcile 在派发动作**之前**重导当前基指纹，不匹配即作废——不靠启动时一次性检查。
+
+### 3. WorkflowControlState（控制视角状态机）
+
+从 `AutoRunState`（status/pausedReason/step/rounds/unresolved）演进为控制视角的显式状态机：
+
+```
+manual ──人工授权──▶ leased(issuing) ──▶ leased(idle|acting|waiting)
+   ▲                    │ guard stop / 失效 / 预算尽 / 失败×2
+   │                    ▼
+   └──人工重新授权── paused(human-required) 
+leased(*) ──合并完成/issue 关闭──▶ completed
+```
+
+- `paused(human-required)` 最小暂停出口（roadmap v0.3 边界）：**持久化**暂停原因 + **最低完整证据**（基快照、最后决策、触发规则的原始失败文本、命中的 guard 规则）+ **明确下一步**（人需要做什么）。现状 `pauseAutoRun` 已持久化 reason 与部分证据，缺口是结构化「命中规则 + 下一步」。
+- 恢复 = 人重新授权 = 基于当前观察发放新 lease（对 `controller-error` 的重挂机制保留，作为暂停态内部的自愈通道）。
+
+### 4. CapabilityLease
+
+```
+{ leaseId, basisFingerprint,
+  actions: 白名单（7 种 NextAction 按 policy 过滤；autoMerge=false 则不含 merge/cleanup）,
+  issuedAt, deadline(=budget), roundsUsed/roundsMax,
+  status: active | consumed | void | expired,
+  issuedBy: 'human-grant:<id>' }
+```
+
+- **发放**：唯一入口是人工授权绑基（`startAutoRun` 即发放仪式——它已校验契约指纹并保存 contract，本 ADR 将其扩展为绑定完整 basis）。
+- **消耗**：每个自动动作 = 一次消耗，记录 `{leaseId, action, at, result}` 为 workflow 事件（授权来源可追溯——双模一致性的证据面）。
+- **吊销/过期**：用户 stop、基失效、guard 停机、deadline（现有 deadline 武装机制保留）。
+- **实现边界**：不引入新锁机制——并发安全沿用 workflow 持久层 revision/CAS 与现有 reconcile 串行化。
+
+### 5. 纯规则 Loop Guard
+
+独立纯函数 `evaluateLoopGuard(input) → proceed | backoff(ms) | stop(rule, humanRequired)`，在**每次 reconcile 派发动作之前**求值，求值结果本身入因果链（ADR-0015）。v0.3 冻结规则集：
+
+| 规则 | 输入 | 结论 |
+|---|---|---|
+| R1 预算/轮次耗尽 | deadline、roundsUsed/maxRounds | stop（现状形式化） |
+| R2 同类失败连续 2 次 | 连续两次同 PausedReason 分类的自动可重试失败（conflict/controller-error 类） | stop，human-required（新增红线） |
+| R3 review 振荡 | 同一未解决 issue 文本连续 ≥2 轮复现 | stop，human-required（新增） |
+| R4 契约漂移 | 消耗前基校验失败 | lease 作废 + stop，human-required（新增，永不自动重启） |
+| R5 瞬时可重试 | rate-limit（经 Gateway 断路器）、sync 冲突（现场已保留） | backoff 有界重试（现状形式化：conflict 自动转交 agent 的路径保留） |
+| R6 issue 关闭 | issueState | complete（现状） |
+
+Guard **只约束自动来源**：人工动作永不被 R1–R4 拦截（同样过门禁、留证据）。规则从 `decideAutoRun` 的内嵌检查中提取为独立模块（`auto-run-policy.ts` 同层纯函数），纯逻辑测试无沙箱依赖。
+
+## Algorithm ↔ Data Structure Cross-check
+
+| 算法/迁移 | 读 | 写 | owner/串行点 | 失败结果 |
+|---|---|---|---|---|
+| lease 发放（人工授权） | 当前契约观察 + policy | lease 记录（workflow 元数据） | 人工授权 + workflow CAS | 基不匹配 → 拒绝启动 |
+| 消耗前基校验 | 契约指纹、基线、review 绑定 | 无（只读判定） | reconcile 串行点 | 不匹配 → lease 作废 + human-required |
+| guard 求值 | rounds、失败序列、振荡、预算 | 判定记录（事件） | reconcile 串行点 | stop → paused(human-required) |
+| 动作派发（双来源） | lease 或人工授权 | 动作结果 + 消耗记录（事件） | 动作层（现有） | 失败按 R2/R5 分类 |
+
+| 概念 | 生产者 | 生产消费者 | 生命周期 |
+|---|---|---|---|
+| DeliveryPolicy | 人工授权时的快照 | lease 校验、guard、面板 | 随 lease 存续，指纹入基 |
+| DeliveryBasis | 发放时组装 + 消耗前重导 | lease 校验、guard R4 | 随 lease 存续 |
+| CapabilityLease | 人工授权仪式 | reconcile 派发、面板来源展示 | issue→consumed/void/expired |
+| ControlState | reconcile/pause/complete | derive、面板、恢复入口 | workflow 生命周期 |
+
+## Required Verification
+
+- lease：无授权不发；基漂移后任一动作被拒且 lease=void；autoMerge=false 时 merge/cleanup 不在白名单。
+- guard：R1–R6 各一测（纯函数）；R2 用连续两次同因失败构造；人工路径不被 R1–R4 拦截的反向测试。
+- 双模一致性：同一动作分别以人工授权与 lease 触发，门禁与证据格式一致、来源字段不同。
+- 暂停出口：paused 记录含原因+证据+下一步三元组，进程重启后仍完整。
+- 交错/崩溃：消耗记录与动作副作用的写入顺序（先副作用后记账 vs 反之）在 checkpoint 注入下可恢复。
+
+## Consequences
+
+- 正：机器获得有凭证、可吊销、可追溯的自主权；「走不开」的根因（逐次人点）被 lease 替代；停机红线确定性化。
+- 负：每次消耗前基校验增加每轮观察成本（复用 v0.2 平面缓存，实测约束在验收）；四个新概念各有消费者，评审按 #144 概念预算纪律把关。
+- 中性：项目级 policy、授权快照审计推 v0.7。
+
+## Alternatives Considered
+
+- 自动专用流水线：拒绝——门禁分叉即绕过面。
+- lease 绑定时钟 TTL 而非预算 deadline：拒绝——deadline 已存在且可持久化恢复。
+- guard 内嵌在 decideAutoRun：拒绝——停机规则必须独立可枚举、可测试、可在面板解释。
+
+## References
+
+- roadmap v0.3.0 与「v0.3 最小暂停出口」；#111/#107 现场教训（controller-error 重挂、sync 冲突自动转交）
+- 现状实现：`src/workflow/auto-run.ts`（reconcile 串行、startAutoRun 契约校验）、`auto-run-policy.ts`、`auto-run-recovery.ts`

--- a/docs/architecture/decisions/0015-event-envelope-causal-chain.md
+++ b/docs/architecture/decisions/0015-event-envelope-causal-chain.md
@@ -1,0 +1,81 @@
+# ADR-0015：EventEnvelope 判别式因果链——Decision→Action→Re-observe 随真实生产者落地
+
+> Status: Accepted | Date: 2026-09-04 | Issue: #168（v0.3.0） | 落实: [ADR-0006](0006-canonical-domain-model-and-contracts.md) 判别式事件契约的 v0.3 首切片 | 依赖: [ADR-0014](0014-autonomous-delivery-control-and-trust.md)（lease/guard 是首批真实生产者） | 地基: [ADR-0012](0012-work-item-contract-canonicalization-and-evidence.md) 诊断关联模式
+
+## Context
+
+roadmap 明确：v0.2 不建完整自主决策事件总包，「判别式 EventEnvelope 及首条 Decision→Action→Re-observe 因果链在 v0.3 随真实生产者落地」。现状证据分三处：workflow `WorkflowEvent`（appendEvent，面板时间线）、两条平面 lifecycle 流 + DiagnosticRecord（ADR-0010/0011/0012）。v0.3 的停机出口要求「最低完整证据」——缺的是把一次 reconcile 内的 观察→守门→决策→动作→再观察 串成可追溯因果链的信封，而不是新总线。
+
+## Decision
+
+### 1. 信封是记录形状，不是新通道
+
+`EventEnvelope` 是**判别式记录形状**，通过**既有 `appendEvent` 通道**追加进 workflow 事件流；失败与平面细节仍由 DiagnosticRecord / lifecycle 流承载，信封以 `correlationId` 关联（复用 ADR-0012 的 `source + correlationId` 模式）。禁止第四条持久化证据总线。
+
+```
+{ schemaVersion: 1, envelope: 'decision' | 'action' | 're-observe' | 'guard',
+  causalId,            // 指向前一条信封（链头 = lease 发放）
+  leaseId?: string,    // 自动来源时的 lease；人工动作为 null + grantId
+  grantId?: string,    // 人工一次性授权 id（双模来源可分辨）
+  at,
+  // 判别式载荷：
+  observed?: { factsRef },          // 观察：紧凑事实引用（派生键/契约指纹/基指纹），不复制大对象
+  guard?: { rule, verdict },        // 守门：命中的规则与结论
+  decided?: { action | 'wait' | 'pause' | 'complete' },
+  acted?: { action, result: 'ok' | 'failed', detailRef },  // detailRef 指向动作结果/诊断
+  verified?: { basisFingerprint } } // 再观察：消耗前基校验结论
+```
+
+### 2. 因果链单元与真实生产者
+
+一次 reconcile tick 产生：`verified(基校验) → guard(规则判定) → decided(决策) → acted(若有动作) → 下一 tick 的 re-observe`。v0.3 的真实生产者恰是 ADR-0014 的新机器：
+
+| 生产者 | 信封 |
+|---|---|
+| lease 发放（人工授权仪式） | 链头：`decision(lease-issued)`，绑 basisFingerprint |
+| 消耗前基校验 | `re-observe(verified)` 或失败 → `guard(R4)` |
+| Loop Guard 求值 | `guard(verdict)`——R1–R6 每次求值留痕，含 proceed（空转审计需要「为什么不停」与「为什么停」同样可查） |
+| 动作派发（lease 来源） | `action(acted)`，consumption 记录并入 |
+| 停机/暂停 | `decision(pause)` + 触发规则 + 下一步提示 |
+| 人工动作（手动模式） | `action`（grantId 来源）——双模一致性要求人工路径同样入链 |
+
+### 3. v0.3 范围：最小因果链，不做 v0.4
+
+- **做**：单 lease 生命周期内的线性链；暂停出口的最低完整证据（ADR-0014 §3）由链尾片段构成；面板暂停视图按链解释「为什么停」。
+- **不做**：跨任务协议审计、完整 Decision→Action→Re-observe 恢复重放（v0.4）、模型化 Runtime Observer（v0.6）。信封不承担恢复执行语义，只承担可追溯性。
+
+### 4. 消费者（概念预算）
+
+| 字段/概念 | 消费者 |
+|---|---|
+| causalId 链 | 面板暂停视图（按链解释）、guard R2/R3（读自身既往判定构造连续性）、事后审计 |
+| guard.verdict（含 proceed） | 空转审计、面板「为什么没停」 |
+| leaseId/grantId 来源字段 | 双模一致性验证、面板来源展示 |
+| observed.factsRef（引用不复制） | 链解释时定位事实快照；大对象留在原处（平面/契约存储） |
+
+无消费者的字段不得进入 schemaVersion 1。
+
+## Required Verification
+
+- 链完整性：一次自动轮次产生的信封序列可从链头走到链尾，causalId 无断链；进程重启后链仍完整（持久化即 workflow 事件）。
+- 双模：同一动作在人工/lease 两来源下信封形状一致、仅来源字段不同。
+- guard proceed 留痕：R1–R6 每次求值（含放行）都有记录。
+- 基漂移场景：verified 失败 → guard(R4) → pause 的链尾即暂停出口证据。
+- 概念预算测试：信封不复制平面/诊断大对象（factsRef 引用制）。
+
+## Consequences
+
+- 正：暂停证据从「散落注释」升级为可追溯因果链；空转可审计（含放行理由）；双模来源机器可分辨。
+- 负：每轮 reconcile 追加 2–4 条事件记录，workflow.json 增长加快（轮次有上限 + 事件已随 workflow 持久化，接受）。
+- 中性：完整重放/恢复、跨任务审计明确推 v0.4+。
+
+## Alternatives Considered
+
+- 新建独立事件总线持久化信封：拒绝——第四总线违反概念预算与 ADR-0012 关联模式。
+- 信封复制完整事实快照：拒绝——引用制（factsRef）；复制即状态双写。
+- 仅在停机时补写因果链：拒绝——proceed 也留痕是空转审计的前置条件，事后补写不可信。
+
+## References
+
+- roadmap：v0.3 行、「v0.2 不迁移 WorkflowEvent，不建完整自主决策事件总包」
+- 现状通道：`src/infra/state.ts` appendEvent / WorkflowEvent、`src/infra/diagnostic-record.ts`、gateway/remote-git lifecycle

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -30,3 +30,5 @@ ADR 记录长期有效的架构取舍，不记录普通实现步骤。每个 ADR
 | [0011](0011-remote-git-coordinator-admission-and-recovery.md) | Accepted | Remote Git Coordinator 的 fetch 单飞、串行化、写凭证与崩溃恢复 |
 | [0012](0012-work-item-contract-canonicalization-and-evidence.md) | Accepted | Work Item 契约规范化、原子 capture 发布、失效接线与诊断证据 |
 | [0013](0013-v02-exit-verification-single-writer-and-cutover-execution.md) | Accepted | v0.2 退出验收：状态类单一写入守卫、三平面终局汇总、provider-neutral 审计、资产处置与离线切换入口 |
+| [0014](0014-autonomous-delivery-control-and-trust.md) | Accepted | v0.3 自主交付控制与信任模型：最小 Policy、DeliveryBasis、WorkflowControlState、CapabilityLease 与纯规则 Loop Guard |
+| [0015](0015-event-envelope-causal-chain.md) | Accepted | v0.3 EventEnvelope 判别式因果链：随 lease/guard 真实生产者落地，包裹既有事件流 |


### PR DESCRIPTION
## 目的

#168（v0.3.0）切片 S0：design-only 基线。落实已 Accepted 的 ADR-0004/0008 与 roadmap「v0.3 最小暂停出口」，把 v0.2 已有的隐式事实显式化。

## 变更

- **ADR-0014 自主交付控制与信任模型**：
  - 宪法条款：一条动作流水线、两种授权来源（人工一次性授权保留 / CapabilityLease 新增），同门禁同证据，禁止自动专用流水线；
  - 最小 Policy v1（AutoRunConfig → 版本化工件，指纹入基）；DeliveryBasis（契约指纹+policy+冻结基线+review 绑定收口，契约漂移永远要求新人工授权）；WorkflowControlState（含 human-required 最小暂停出口三元组：原因+证据+下一步）；CapabilityLease（人工授权仪式发放、消耗记账、复用 workflow CAS 不新增锁）；纯规则 Loop Guard R1–R6（同类失败×2、review 振荡必停等人；瞬时类有界退避；只约束自动不拦手动）。
  - 含算法↔数据结构两向 trace 与验证要求。
- **ADR-0015 EventEnvelope 判别式因果链**：信封是记录形状而非新总线（走既有 appendEvent + ADR-0012 correlationId 关联三流）；链单元 = verified→guard→decided→acted→re-observe；真实生产者 = lease 发放/消耗、guard 求值（含放行留痕）、双模动作；v0.3 只做最小链，完整重放推 v0.4。
- ADR 索引登记。

## 与讨论收敛点对应

默认手动+显式开启自动 ✓；停机红线（失败×2/振荡/漂移必停）✓；lease 绑契约指纹复用 ADR-0012 ✓；双模一致性入验收 ✓；整合现有 auto-run 机器（startAutoRun 契约校验推广为消耗前基校验、conflict 自动转交保留）✓。

## 概念预算

4 个新概念（Policy 工件/Basis/Lease/ControlState）+ 信封形状，每个均列生产消费者；实现 PR 按此把关。

## 验证

纯 docs；typecheck/lint/format/size 全绿。CI verify 走完整链。

## 后续

合入后对 #168 各实现切片（S1 guard → S2 lease+policy → S3 control state → S4 basis → S5 envelope → S6 端到端）逐个 impl-gate。
